### PR TITLE
feat(tempo): add fee_payer_url field and fix fee sponsorship docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@
 //!
 //! mpay re-exports alloy's signer types for convenience:
 //!
-//! ```no_run
+#![cfg_attr(feature = "evm", doc = "```no_run")]
+#![cfg_attr(not(feature = "evm"), doc = "```ignore")]
 //! use mpay::{Signer, PrivateKeySigner};
 //! # fn main() {}
 //! ```

--- a/src/protocol/methods/tempo/charge.rs
+++ b/src/protocol/methods/tempo/charge.rs
@@ -38,8 +38,18 @@ pub trait TempoChargeExt {
     /// Parse the method_details as Tempo-specific details.
     fn tempo_method_details(&self) -> Result<TempoMethodDetails>;
 
-    /// Check if server pays transaction fees (Tempo-specific feature).
+    /// Check if fee sponsorship is enabled.
+    ///
+    /// When true, the client should build and sign a TempoTransaction (type 0x76)
+    /// with a fee payer placeholder, then return it as a `transaction` credential.
+    /// The server will forward this to the fee payer service for broadcasting.
     fn fee_payer(&self) -> bool;
+
+    /// Get the fee payer service URL.
+    ///
+    /// Returns the configured `feePayerUrl` from methodDetails, or the default
+    /// testnet sponsor URL if not specified.
+    fn fee_payer_url(&self) -> Option<String>;
 
     /// Get the 2D nonce key.
     ///
@@ -103,6 +113,14 @@ impl TempoChargeExt for ChargeRequest {
             .unwrap_or(false)
     }
 
+    fn fee_payer_url(&self) -> Option<String> {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("feePayerUrl"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    }
+
     fn nonce_key(&self) -> U256 {
         self.method_details
             .as_ref()
@@ -157,6 +175,7 @@ mod tests {
             method_details: Some(serde_json::json!({
                 "chainId": 88153,
                 "feePayer": true,
+                "feePayerUrl": "https://custom.sponsor.xyz",
                 "nonceKey": "42",
                 "feeToken": "0xDEF",
                 "validBefore": "2025-01-01T00:00:00Z"
@@ -184,6 +203,21 @@ mod tests {
             ..test_charge_request()
         };
         assert!(!req_no_fee.fee_payer());
+    }
+
+    #[test]
+    fn test_fee_payer_url() {
+        let req = test_charge_request();
+        assert_eq!(
+            req.fee_payer_url(),
+            Some("https://custom.sponsor.xyz".to_string())
+        );
+
+        let req_no_url = ChargeRequest {
+            method_details: Some(serde_json::json!({"feePayer": true})),
+            ..test_charge_request()
+        };
+        assert_eq!(req_no_url.fee_payer_url(), None);
     }
 
     #[test]

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -8,27 +8,23 @@
 //! - [`TempoMethodDetails`]: Tempo-specific method details (2D nonces, fee payer)
 //! - [`TempoChargeExt`]: Extension trait for ChargeRequest with Tempo-specific accessors
 //! - [`transaction::TempoTransactionParams`]: Transaction params for building transactions
-//! - [`transaction::SubmissionMethod`]: Determines which RPC method to use
 //!
 //! # Constants
 //!
 //! - [`CHAIN_ID`]: Tempo Moderato chain ID (88153)
 //! - [`METHOD_NAME`]: Payment method name ("tempo")
 //!
+//! # Transaction Format
+//!
+//! All Tempo payments use TempoTransaction (type 0x76) format. The client builds
+//! and signs a TempoTransaction, returns it as a `transaction` credential, and the
+//! server submits it via `tempo_sendTransaction`.
+//!
 //! # Fee Sponsorship
 //!
-//! When a ChargeRequest has `feePayer: true` in method_details, the correct flow is:
-//!
-//! 1. **Server** sends a challenge with `feePayer: true` and optionally `feePayerUrl`
-//! 2. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder,
-//!    signs it, and returns it as a `transaction` credential (NOT broadcast)
-//! 3. **Server** receives the signed transaction and forwards to the fee payer
-//!    service (either `feePayerUrl` or the default testnet sponsor)
-//! 4. **Fee payer** adds its signature and broadcasts the transaction
-//! 5. **Server** verifies the receipt and transfer logs
-//!
-//! **Important**: The client does NOT submit the transaction directly. The server
-//! is responsible for forwarding to the fee payer service.
+//! When `feePayer: true` is set, the server forwards the signed transaction to a
+//! fee payer service (either `feePayerUrl` or the default testnet sponsor) which
+//! adds its signature and broadcasts.
 //!
 //! ```
 //! use mpay::protocol::intents::ChargeRequest;
@@ -69,7 +65,7 @@ pub mod transaction;
 pub mod types;
 
 pub use charge::TempoChargeExt;
-pub use transaction::{SubmissionMethod, TempoSendTransactionRequest, TempoTransactionParams};
+pub use transaction::{TempoSendTransactionRequest, TempoTransactionParams, TEMPO_SEND_TRANSACTION_METHOD};
 pub use types::{TempoMethodDetails, DEFAULT_FEE_PAYER_URL};
 
 /// Tempo Moderato testnet chain ID.

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! - [`TempoMethodDetails`]: Tempo-specific method details (2D nonces, fee payer)
 //! - [`TempoChargeExt`]: Extension trait for ChargeRequest with Tempo-specific accessors
-//! - [`transaction::TempoTransactionParams`]: Transaction params for `tempo_sendTransaction`
+//! - [`transaction::TempoTransactionParams`]: Transaction params for building transactions
 //! - [`transaction::SubmissionMethod`]: Determines which RPC method to use
 //!
 //! # Constants
@@ -17,24 +17,36 @@
 //!
 //! # Fee Sponsorship
 //!
-//! When a ChargeRequest has `feePayer: true` in method_details, the transaction
-//! should be submitted via `tempo_sendTransaction` instead of `eth_sendRawTransaction`.
-//! Use [`transaction::SubmissionMethod::from_charge_request`] to determine the
-//! appropriate submission method.
+//! When a ChargeRequest has `feePayer: true` in method_details, the correct flow is:
+//!
+//! 1. **Server** sends a challenge with `feePayer: true` and optionally `feePayerUrl`
+//! 2. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder,
+//!    signs it, and returns it as a `transaction` credential (NOT broadcast)
+//! 3. **Server** receives the signed transaction and forwards to the fee payer
+//!    service (either `feePayerUrl` or the default testnet sponsor)
+//! 4. **Fee payer** adds its signature and broadcasts the transaction
+//! 5. **Server** verifies the receipt and transfer logs
+//!
+//! **Important**: The client does NOT submit the transaction directly. The server
+//! is responsible for forwarding to the fee payer service.
 //!
 //! ```
-//! use mpay::protocol::core::parse_www_authenticate;
 //! use mpay::protocol::intents::ChargeRequest;
-//! use mpay::protocol::methods::tempo::{TempoChargeExt, transaction::SubmissionMethod};
+//! use mpay::protocol::methods::tempo::TempoChargeExt;
 //!
 //! # let req = ChargeRequest {
 //! #     amount: "1000".into(), currency: "0x".into(), recipient: None,
 //! #     expires: None, description: None, external_id: None,
-//! #     method_details: Some(serde_json::json!({"feePayer": true})),
+//! #     method_details: Some(serde_json::json!({
+//! #         "feePayer": true,
+//! #         "feePayerUrl": "https://sponsor.moderato.tempo.xyz"
+//! #     })),
 //! # };
-//! let method = SubmissionMethod::from_charge_request(&req);
 //! if req.fee_payer() {
-//!     assert_eq!(method.method_name(), "tempo_sendTransaction");
+//!     // Client should build and sign a TempoTransaction (0x76),
+//!     // then return it as a "transaction" credential.
+//!     // The server will forward to fee_payer_url for broadcasting.
+//!     let fee_payer_url = req.fee_payer_url();
 //! }
 //! ```
 //!
@@ -58,7 +70,7 @@ pub mod types;
 
 pub use charge::TempoChargeExt;
 pub use transaction::{SubmissionMethod, TempoSendTransactionRequest, TempoTransactionParams};
-pub use types::TempoMethodDetails;
+pub use types::{TempoMethodDetails, DEFAULT_FEE_PAYER_URL};
 
 /// Tempo Moderato testnet chain ID.
 pub const CHAIN_ID: u64 = 88153;

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -7,11 +7,36 @@
 //!
 //! - [`TempoMethodDetails`]: Tempo-specific method details (2D nonces, fee payer)
 //! - [`TempoChargeExt`]: Extension trait for ChargeRequest with Tempo-specific accessors
+//! - [`transaction::TempoTransactionParams`]: Transaction params for `tempo_sendTransaction`
+//! - [`transaction::SubmissionMethod`]: Determines which RPC method to use
 //!
 //! # Constants
 //!
 //! - [`CHAIN_ID`]: Tempo Moderato chain ID (88153)
 //! - [`METHOD_NAME`]: Payment method name ("tempo")
+//!
+//! # Fee Sponsorship
+//!
+//! When a ChargeRequest has `feePayer: true` in method_details, the transaction
+//! should be submitted via `tempo_sendTransaction` instead of `eth_sendRawTransaction`.
+//! Use [`transaction::SubmissionMethod::from_charge_request`] to determine the
+//! appropriate submission method.
+//!
+//! ```
+//! use mpay::protocol::core::parse_www_authenticate;
+//! use mpay::protocol::intents::ChargeRequest;
+//! use mpay::protocol::methods::tempo::{TempoChargeExt, transaction::SubmissionMethod};
+//!
+//! # let req = ChargeRequest {
+//! #     amount: "1000".into(), currency: "0x".into(), recipient: None,
+//! #     expires: None, description: None, external_id: None,
+//! #     method_details: Some(serde_json::json!({"feePayer": true})),
+//! # };
+//! let method = SubmissionMethod::from_charge_request(&req);
+//! if req.fee_payer() {
+//!     assert_eq!(method.method_name(), "tempo_sendTransaction");
+//! }
+//! ```
 //!
 //! # Examples
 //!
@@ -28,9 +53,11 @@
 //! ```
 
 pub mod charge;
+pub mod transaction;
 pub mod types;
 
 pub use charge::TempoChargeExt;
+pub use transaction::{SubmissionMethod, TempoSendTransactionRequest, TempoTransactionParams};
 pub use types::TempoMethodDetails;
 
 /// Tempo Moderato testnet chain ID.

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -65,7 +65,9 @@ pub mod transaction;
 pub mod types;
 
 pub use charge::TempoChargeExt;
-pub use transaction::{TempoSendTransactionRequest, TempoTransactionParams, TEMPO_SEND_TRANSACTION_METHOD};
+pub use transaction::{
+    TempoSendTransactionRequest, TempoTransactionParams, TEMPO_SEND_TRANSACTION_METHOD,
+};
 pub use types::{TempoMethodDetails, DEFAULT_FEE_PAYER_URL};
 
 /// Tempo Moderato testnet chain ID.

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -1,39 +1,35 @@
-//! Tempo transaction types for `tempo_sendTransaction` RPC method.
+//! Tempo transaction types for building and submitting transactions.
 //!
-//! This module provides types for building transactions that use Tempo's
-//! native `tempo_sendTransaction` RPC method, which supports fee sponsorship
-//! and other Tempo-specific features not available with `eth_sendRawTransaction`.
+//! This module provides types for building Tempo transactions. These are used
+//! by the **server** when it needs to forward client-signed transactions to
+//! a fee payer service or submit them directly.
 //!
-//! # Fee Sponsorship
+//! # Fee Sponsorship Flow
 //!
-//! When `fee_payer` is set to `true`, the transaction should be submitted via
-//! `tempo_sendTransaction` instead of `eth_sendRawTransaction`. The fee payer
-//! service will sign the transaction to cover gas fees on behalf of the sender.
+//! When `fee_payer` is `true` in a ChargeRequest, the correct flow is:
+//!
+//! 1. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder,
+//!    signs it, and returns it as a `transaction` credential (NOT broadcast)
+//! 2. **Server** receives the signed transaction and forwards to the fee payer
+//!    service via `eth_sendRawTransaction`
+//! 3. **Fee payer** adds its signature and broadcasts the transaction
+//!
+//! **Important**: The client does NOT submit the transaction directly.
+//!
+//! # Types
+//!
+//! - [`TempoTransactionParams`]: Parameters for building a transaction request
+//! - [`TempoSendTransactionRequest`]: JSON-RPC request for `tempo_sendTransaction`
+//! - [`SubmissionMethod`]: Indicates which RPC method the server should use
 //!
 //! # Examples
 //!
-//! ## Building a sponsored transaction request
-//!
-//! ```
-//! use mpay::protocol::methods::tempo::transaction::{
-//!     TempoTransactionParams, TempoSendTransactionRequest,
-//! };
-//!
-//! let params = TempoTransactionParams::new("0xSenderAddress", "0xRecipientAddress")
-//!     .with_value("1000000")
-//!     .with_fee_payer(true);
-//!
-//! // Convert to JSON-RPC request for tempo_sendTransaction
-//! let request = TempoSendTransactionRequest::new(params);
-//! let json = serde_json::to_value(&request).unwrap();
-//! ```
-//!
-//! ## Using with ChargeRequest
+//! ## Server-side: Forward sponsored transaction
 //!
 //! ```
 //! use mpay::protocol::intents::ChargeRequest;
 //! use mpay::protocol::methods::tempo::TempoChargeExt;
-//! use mpay::protocol::methods::tempo::transaction::TempoTransactionParams;
+//! use mpay::protocol::methods::tempo::transaction::SubmissionMethod;
 //!
 //! # let req = ChargeRequest {
 //! #     amount: "1000000".into(),
@@ -42,10 +38,11 @@
 //! #     expires: None, description: None, external_id: None,
 //! #     method_details: Some(serde_json::json!({"feePayer": true})),
 //! # };
-//! if req.fee_payer() {
-//!     // Build a sponsored transaction
-//!     let params = TempoTransactionParams::from_charge_request(&req, "0xSenderAddress");
-//!     // Submit via tempo_sendTransaction
+//! // Server receives a "transaction" credential with client-signed tx bytes
+//! let method = SubmissionMethod::from_charge_request(&req);
+//! if method == SubmissionMethod::TempoSendTransaction {
+//!     // Forward to fee_payer_url (server responsibility, not client)
+//!     let url = req.fee_payer_url();
 //! }
 //! ```
 

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -1,0 +1,430 @@
+//! Tempo transaction types for `tempo_sendTransaction` RPC method.
+//!
+//! This module provides types for building transactions that use Tempo's
+//! native `tempo_sendTransaction` RPC method, which supports fee sponsorship
+//! and other Tempo-specific features not available with `eth_sendRawTransaction`.
+//!
+//! # Fee Sponsorship
+//!
+//! When `fee_payer` is set to `true`, the transaction should be submitted via
+//! `tempo_sendTransaction` instead of `eth_sendRawTransaction`. The fee payer
+//! service will sign the transaction to cover gas fees on behalf of the sender.
+//!
+//! # Examples
+//!
+//! ## Building a sponsored transaction request
+//!
+//! ```
+//! use mpay::protocol::methods::tempo::transaction::{
+//!     TempoTransactionParams, TempoSendTransactionRequest,
+//! };
+//!
+//! let params = TempoTransactionParams::new("0xSenderAddress", "0xRecipientAddress")
+//!     .with_value("1000000")
+//!     .with_fee_payer(true);
+//!
+//! // Convert to JSON-RPC request for tempo_sendTransaction
+//! let request = TempoSendTransactionRequest::new(params);
+//! let json = serde_json::to_value(&request).unwrap();
+//! ```
+//!
+//! ## Using with ChargeRequest
+//!
+//! ```
+//! use mpay::protocol::intents::ChargeRequest;
+//! use mpay::protocol::methods::tempo::TempoChargeExt;
+//! use mpay::protocol::methods::tempo::transaction::TempoTransactionParams;
+//!
+//! # let req = ChargeRequest {
+//! #     amount: "1000000".into(),
+//! #     currency: "0xToken".into(),
+//! #     recipient: Some("0xRecipient".into()),
+//! #     expires: None, description: None, external_id: None,
+//! #     method_details: Some(serde_json::json!({"feePayer": true})),
+//! # };
+//! if req.fee_payer() {
+//!     // Build a sponsored transaction
+//!     let params = TempoTransactionParams::from_charge_request(&req, "0xSenderAddress");
+//!     // Submit via tempo_sendTransaction
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::intents::ChargeRequest;
+
+use super::TempoChargeExt;
+
+/// JSON-RPC method name for Tempo transactions.
+pub const TEMPO_SEND_TRANSACTION_METHOD: &str = "tempo_sendTransaction";
+
+/// JSON-RPC method name for standard Ethereum transactions.
+pub const ETH_SEND_RAW_TRANSACTION_METHOD: &str = "eth_sendRawTransaction";
+
+/// Parameters for a Tempo transaction.
+///
+/// This struct represents the transaction object passed to `tempo_sendTransaction`.
+/// It supports Tempo-specific fields like `feePayer` for gas sponsorship.
+///
+/// # Examples
+///
+/// ```
+/// use mpay::protocol::methods::tempo::transaction::TempoTransactionParams;
+///
+/// let params = TempoTransactionParams::new("0xSender", "0xRecipient")
+///     .with_value("1000000")
+///     .with_fee_payer(true)
+///     .with_nonce_key("42");
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TempoTransactionParams {
+    /// Transaction sender address
+    pub from: String,
+
+    /// Transaction recipient address
+    pub to: String,
+
+    /// Transaction value in wei (hex or decimal string)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+
+    /// Transaction data (hex encoded)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+
+    /// Gas limit
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas: Option<String>,
+
+    /// Max fee per gas (EIP-1559)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fee_per_gas: Option<String>,
+
+    /// Max priority fee per gas (EIP-1559)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_priority_fee_per_gas: Option<String>,
+
+    /// Whether a fee payer should sponsor gas fees.
+    /// When true, submit via `tempo_sendTransaction` to a fee payer service.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_payer: Option<bool>,
+
+    /// Token address for gas payment (TIP-20 fee payment).
+    /// If not specified, uses the network's default fee token.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_token: Option<String>,
+
+    /// 2D nonce key for parallel transaction streams.
+    /// If not specified, uses the default nonce stream (0).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce_key: Option<String>,
+
+    /// Chain ID
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_id: Option<u64>,
+}
+
+impl TempoTransactionParams {
+    /// Create new transaction params with required fields.
+    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
+        Self {
+            from: from.into(),
+            to: to.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Create transaction params from a ChargeRequest.
+    ///
+    /// Extracts Tempo-specific fields (fee_payer, nonce_key, fee_token, chain_id)
+    /// from the ChargeRequest's method_details.
+    pub fn from_charge_request(req: &ChargeRequest, from: impl Into<String>) -> Self {
+        let to = req.recipient.clone().unwrap_or_default();
+
+        let mut params = Self::new(from, to);
+
+        if req.fee_payer() {
+            params.fee_payer = Some(true);
+        }
+
+        let nonce_key = req.nonce_key();
+        if !nonce_key.is_zero() {
+            params.nonce_key = Some(nonce_key.to_string());
+        }
+
+        if let Some(fee_token) = req.fee_token() {
+            params.fee_token = Some(fee_token);
+        }
+
+        if let Some(chain_id) = req.chain_id() {
+            params.chain_id = Some(chain_id);
+        }
+
+        params
+    }
+
+    /// Set the transaction value.
+    pub fn with_value(mut self, value: impl Into<String>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Set the transaction data.
+    pub fn with_data(mut self, data: impl Into<String>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+
+    /// Set the gas limit.
+    pub fn with_gas(mut self, gas: impl Into<String>) -> Self {
+        self.gas = Some(gas.into());
+        self
+    }
+
+    /// Enable fee sponsorship.
+    pub fn with_fee_payer(mut self, fee_payer: bool) -> Self {
+        self.fee_payer = Some(fee_payer);
+        self
+    }
+
+    /// Set the fee token for TIP-20 gas payment.
+    pub fn with_fee_token(mut self, fee_token: impl Into<String>) -> Self {
+        self.fee_token = Some(fee_token.into());
+        self
+    }
+
+    /// Set the 2D nonce key for parallel transactions.
+    pub fn with_nonce_key(mut self, nonce_key: impl Into<String>) -> Self {
+        self.nonce_key = Some(nonce_key.into());
+        self
+    }
+
+    /// Set the chain ID.
+    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
+        self.chain_id = Some(chain_id);
+        self
+    }
+
+    /// Check if this transaction requires fee sponsorship.
+    pub fn requires_fee_payer(&self) -> bool {
+        self.fee_payer.unwrap_or(false)
+    }
+
+    /// Get the appropriate RPC method for this transaction.
+    ///
+    /// Returns `tempo_sendTransaction` if fee sponsorship is requested,
+    /// otherwise returns `eth_sendRawTransaction`.
+    pub fn rpc_method(&self) -> &'static str {
+        if self.requires_fee_payer() {
+            TEMPO_SEND_TRANSACTION_METHOD
+        } else {
+            ETH_SEND_RAW_TRANSACTION_METHOD
+        }
+    }
+}
+
+/// JSON-RPC request for `tempo_sendTransaction`.
+///
+/// This is the complete request structure for submitting a Tempo transaction
+/// via JSON-RPC.
+///
+/// # Examples
+///
+/// ```
+/// use mpay::protocol::methods::tempo::transaction::{
+///     TempoTransactionParams, TempoSendTransactionRequest,
+/// };
+///
+/// let params = TempoTransactionParams::new("0xSender", "0xRecipient")
+///     .with_fee_payer(true);
+///
+/// let request = TempoSendTransactionRequest::new(params);
+/// let json = serde_json::to_string(&request).unwrap();
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TempoSendTransactionRequest {
+    /// JSON-RPC version
+    pub jsonrpc: String,
+
+    /// RPC method name
+    pub method: String,
+
+    /// Transaction parameters
+    pub params: Vec<TempoTransactionParams>,
+
+    /// Request ID
+    pub id: u64,
+}
+
+impl TempoSendTransactionRequest {
+    /// Create a new tempo_sendTransaction request.
+    pub fn new(params: TempoTransactionParams) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: TEMPO_SEND_TRANSACTION_METHOD.to_string(),
+            params: vec![params],
+            id: 1,
+        }
+    }
+
+    /// Create a new request with a specific ID.
+    pub fn with_id(params: TempoTransactionParams, id: u64) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            method: TEMPO_SEND_TRANSACTION_METHOD.to_string(),
+            params: vec![params],
+            id,
+        }
+    }
+}
+
+/// Submission method recommendation for a transaction.
+///
+/// Indicates which RPC method should be used to submit a transaction
+/// based on its parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmissionMethod {
+    /// Use `eth_sendRawTransaction` for standard transactions.
+    EthSendRawTransaction,
+    /// Use `tempo_sendTransaction` for sponsored or Tempo-specific transactions.
+    TempoSendTransaction,
+}
+
+impl SubmissionMethod {
+    /// Get the RPC method name.
+    pub fn method_name(&self) -> &'static str {
+        match self {
+            Self::EthSendRawTransaction => ETH_SEND_RAW_TRANSACTION_METHOD,
+            Self::TempoSendTransaction => TEMPO_SEND_TRANSACTION_METHOD,
+        }
+    }
+
+    /// Determine submission method from a ChargeRequest.
+    ///
+    /// Returns `TempoSendTransaction` if fee sponsorship is requested,
+    /// otherwise returns `EthSendRawTransaction`.
+    pub fn from_charge_request(req: &ChargeRequest) -> Self {
+        if req.fee_payer() {
+            Self::TempoSendTransaction
+        } else {
+            Self::EthSendRawTransaction
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tempo_transaction_params_builder() {
+        let params = TempoTransactionParams::new("0xSender", "0xRecipient")
+            .with_value("1000000")
+            .with_fee_payer(true)
+            .with_nonce_key("42")
+            .with_chain_id(88153);
+
+        assert_eq!(params.from, "0xSender");
+        assert_eq!(params.to, "0xRecipient");
+        assert_eq!(params.value, Some("1000000".to_string()));
+        assert!(params.requires_fee_payer());
+        assert_eq!(params.nonce_key, Some("42".to_string()));
+        assert_eq!(params.chain_id, Some(88153));
+    }
+
+    #[test]
+    fn test_rpc_method_selection() {
+        let sponsored = TempoTransactionParams::new("0xA", "0xB").with_fee_payer(true);
+        assert_eq!(sponsored.rpc_method(), "tempo_sendTransaction");
+
+        let standard = TempoTransactionParams::new("0xA", "0xB");
+        assert_eq!(standard.rpc_method(), "eth_sendRawTransaction");
+    }
+
+    #[test]
+    fn test_tempo_send_transaction_request_serialization() {
+        let params = TempoTransactionParams::new("0xSender", "0xRecipient")
+            .with_value("0x1000")
+            .with_fee_payer(true);
+
+        let request = TempoSendTransactionRequest::new(params);
+        let json = serde_json::to_value(&request).unwrap();
+
+        assert_eq!(json["jsonrpc"], "2.0");
+        assert_eq!(json["method"], "tempo_sendTransaction");
+        assert_eq!(json["params"][0]["from"], "0xSender");
+        assert_eq!(json["params"][0]["to"], "0xRecipient");
+        assert_eq!(json["params"][0]["value"], "0x1000");
+        assert_eq!(json["params"][0]["feePayer"], true);
+    }
+
+    #[test]
+    fn test_from_charge_request() {
+        let req = ChargeRequest {
+            amount: "1000000".to_string(),
+            currency: "0xToken".to_string(),
+            recipient: Some("0xRecipient".to_string()),
+            expires: None,
+            description: None,
+            external_id: None,
+            method_details: Some(serde_json::json!({
+                "feePayer": true,
+                "nonceKey": "42",
+                "feeToken": "0xFeeToken",
+                "chainId": 88153
+            })),
+        };
+
+        let params = TempoTransactionParams::from_charge_request(&req, "0xSender");
+
+        assert_eq!(params.from, "0xSender");
+        assert_eq!(params.to, "0xRecipient");
+        assert!(params.requires_fee_payer());
+        assert_eq!(params.nonce_key, Some("42".to_string()));
+        assert_eq!(params.fee_token, Some("0xFeeToken".to_string()));
+        assert_eq!(params.chain_id, Some(88153));
+    }
+
+    #[test]
+    fn test_submission_method() {
+        let req_sponsored = ChargeRequest {
+            amount: "1000".to_string(),
+            currency: "0x".to_string(),
+            recipient: None,
+            expires: None,
+            description: None,
+            external_id: None,
+            method_details: Some(serde_json::json!({"feePayer": true})),
+        };
+        assert_eq!(
+            SubmissionMethod::from_charge_request(&req_sponsored),
+            SubmissionMethod::TempoSendTransaction
+        );
+
+        let req_standard = ChargeRequest {
+            amount: "1000".to_string(),
+            currency: "0x".to_string(),
+            recipient: None,
+            expires: None,
+            description: None,
+            external_id: None,
+            method_details: None,
+        };
+        assert_eq!(
+            SubmissionMethod::from_charge_request(&req_standard),
+            SubmissionMethod::EthSendRawTransaction
+        );
+    }
+
+    #[test]
+    fn test_skip_serializing_none_fields() {
+        let params = TempoTransactionParams::new("0xA", "0xB");
+        let json = serde_json::to_value(&params).unwrap();
+
+        assert!(json.get("value").is_none());
+        assert!(json.get("data").is_none());
+        assert!(json.get("feePayer").is_none());
+        assert!(json.get("nonceKey").is_none());
+    }
+}

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -1,49 +1,35 @@
 //! Tempo transaction types for building and submitting transactions.
 //!
-//! This module provides types for building Tempo transactions. These are used
-//! by the **server** when it needs to forward client-signed transactions to
-//! a fee payer service or submit them directly.
+//! This module provides types for building Tempo transactions (type 0x76).
+//! All Tempo payments use TempoTransaction format regardless of whether
+//! fee sponsorship is enabled.
 //!
-//! # Fee Sponsorship Flow
+//! # Transaction Flow
 //!
-//! When `fee_payer` is `true` in a ChargeRequest, the correct flow is:
+//! 1. **Client** builds a TempoTransaction (type 0x76), signs it, and returns
+//!    it as a `transaction` credential
+//! 2. **Server** submits via `tempo_sendTransaction` (direct or via fee payer)
 //!
-//! 1. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder,
-//!    signs it, and returns it as a `transaction` credential (NOT broadcast)
-//! 2. **Server** receives the signed transaction and forwards to the fee payer
-//!    service via `eth_sendRawTransaction`
-//! 3. **Fee payer** adds its signature and broadcasts the transaction
-//!
-//! **Important**: The client does NOT submit the transaction directly.
+//! When `fee_payer` is `true`, the server forwards the signed transaction to
+//! a fee payer service which adds its signature before broadcasting.
 //!
 //! # Types
 //!
 //! - [`TempoTransactionParams`]: Parameters for building a transaction request
 //! - [`TempoSendTransactionRequest`]: JSON-RPC request for `tempo_sendTransaction`
-//! - [`SubmissionMethod`]: Indicates which RPC method the server should use
 //!
 //! # Examples
 //!
-//! ## Server-side: Forward sponsored transaction
-//!
 //! ```
-//! use mpay::protocol::intents::ChargeRequest;
-//! use mpay::protocol::methods::tempo::TempoChargeExt;
-//! use mpay::protocol::methods::tempo::transaction::SubmissionMethod;
+//! use mpay::protocol::methods::tempo::transaction::{
+//!     TempoTransactionParams, TempoSendTransactionRequest,
+//! };
 //!
-//! # let req = ChargeRequest {
-//! #     amount: "1000000".into(),
-//! #     currency: "0xToken".into(),
-//! #     recipient: Some("0xRecipient".into()),
-//! #     expires: None, description: None, external_id: None,
-//! #     method_details: Some(serde_json::json!({"feePayer": true})),
-//! # };
-//! // Server receives a "transaction" credential with client-signed tx bytes
-//! let method = SubmissionMethod::from_charge_request(&req);
-//! if method == SubmissionMethod::TempoSendTransaction {
-//!     // Forward to fee_payer_url (server responsibility, not client)
-//!     let url = req.fee_payer_url();
-//! }
+//! let params = TempoTransactionParams::new("0xSender", "0xRecipient")
+//!     .with_value("1000000")
+//!     .with_fee_payer(true);
+//!
+//! let request = TempoSendTransactionRequest::new(params);
 //! ```
 
 use serde::{Deserialize, Serialize};
@@ -54,9 +40,6 @@ use super::TempoChargeExt;
 
 /// JSON-RPC method name for Tempo transactions.
 pub const TEMPO_SEND_TRANSACTION_METHOD: &str = "tempo_sendTransaction";
-
-/// JSON-RPC method name for standard Ethereum transactions.
-pub const ETH_SEND_RAW_TRANSACTION_METHOD: &str = "eth_sendRawTransaction";
 
 /// Parameters for a Tempo transaction.
 ///
@@ -208,16 +191,12 @@ impl TempoTransactionParams {
         self.fee_payer.unwrap_or(false)
     }
 
-    /// Get the appropriate RPC method for this transaction.
+    /// Get the RPC method for this transaction.
     ///
-    /// Returns `tempo_sendTransaction` if fee sponsorship is requested,
-    /// otherwise returns `eth_sendRawTransaction`.
+    /// Always returns `tempo_sendTransaction` - all Tempo payments use
+    /// the same transaction format regardless of fee sponsorship.
     pub fn rpc_method(&self) -> &'static str {
-        if self.requires_fee_payer() {
-            TEMPO_SEND_TRANSACTION_METHOD
-        } else {
-            ETH_SEND_RAW_TRANSACTION_METHOD
-        }
+        TEMPO_SEND_TRANSACTION_METHOD
     }
 }
 
@@ -276,40 +255,6 @@ impl TempoSendTransactionRequest {
     }
 }
 
-/// Submission method recommendation for a transaction.
-///
-/// Indicates which RPC method should be used to submit a transaction
-/// based on its parameters.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SubmissionMethod {
-    /// Use `eth_sendRawTransaction` for standard transactions.
-    EthSendRawTransaction,
-    /// Use `tempo_sendTransaction` for sponsored or Tempo-specific transactions.
-    TempoSendTransaction,
-}
-
-impl SubmissionMethod {
-    /// Get the RPC method name.
-    pub fn method_name(&self) -> &'static str {
-        match self {
-            Self::EthSendRawTransaction => ETH_SEND_RAW_TRANSACTION_METHOD,
-            Self::TempoSendTransaction => TEMPO_SEND_TRANSACTION_METHOD,
-        }
-    }
-
-    /// Determine submission method from a ChargeRequest.
-    ///
-    /// Returns `TempoSendTransaction` if fee sponsorship is requested,
-    /// otherwise returns `EthSendRawTransaction`.
-    pub fn from_charge_request(req: &ChargeRequest) -> Self {
-        if req.fee_payer() {
-            Self::TempoSendTransaction
-        } else {
-            Self::EthSendRawTransaction
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,12 +276,12 @@ mod tests {
     }
 
     #[test]
-    fn test_rpc_method_selection() {
+    fn test_rpc_method_always_tempo() {
         let sponsored = TempoTransactionParams::new("0xA", "0xB").with_fee_payer(true);
         assert_eq!(sponsored.rpc_method(), "tempo_sendTransaction");
 
         let standard = TempoTransactionParams::new("0xA", "0xB");
-        assert_eq!(standard.rpc_method(), "eth_sendRawTransaction");
+        assert_eq!(standard.rpc_method(), "tempo_sendTransaction");
     }
 
     #[test]
@@ -381,37 +326,6 @@ mod tests {
         assert_eq!(params.nonce_key, Some("42".to_string()));
         assert_eq!(params.fee_token, Some("0xFeeToken".to_string()));
         assert_eq!(params.chain_id, Some(88153));
-    }
-
-    #[test]
-    fn test_submission_method() {
-        let req_sponsored = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x".to_string(),
-            recipient: None,
-            expires: None,
-            description: None,
-            external_id: None,
-            method_details: Some(serde_json::json!({"feePayer": true})),
-        };
-        assert_eq!(
-            SubmissionMethod::from_charge_request(&req_sponsored),
-            SubmissionMethod::TempoSendTransaction
-        );
-
-        let req_standard = ChargeRequest {
-            amount: "1000".to_string(),
-            currency: "0x".to_string(),
-            recipient: None,
-            expires: None,
-            description: None,
-            external_id: None,
-            method_details: None,
-        };
-        assert_eq!(
-            SubmissionMethod::from_charge_request(&req_standard),
-            SubmissionMethod::EthSendRawTransaction
-        );
     }
 
     #[test]

--- a/src/protocol/methods/tempo/types.rs
+++ b/src/protocol/methods/tempo/types.rs
@@ -10,6 +10,21 @@ use crate::evm::U256;
 /// Extends the base EVM method details with Tempo-specific features:
 /// - 2D nonces (nonce_key for parallel transaction streams)
 /// - TIP-20 token support (fee_token for gas payment in tokens)
+/// - Fee sponsorship (fee_payer + fee_payer_url)
+///
+/// # Fee Sponsorship Flow
+///
+/// When `fee_payer` is `true`, the correct flow is:
+///
+/// 1. **Server** sends a challenge with `feePayer: true` and optionally `feePayerUrl`
+/// 2. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder,
+///    signs it, and returns it as a `transaction` credential (NOT broadcast)
+/// 3. **Server** receives the signed transaction and forwards to the fee payer
+///    service (either `feePayerUrl` or the default testnet sponsor)
+/// 4. **Fee payer** adds its signature and broadcasts the transaction
+/// 5. **Server** verifies the receipt and transfer logs
+///
+/// The client does NOT submit the transaction directly.
 ///
 /// # Examples
 ///
@@ -19,6 +34,7 @@ use crate::evm::U256;
 /// let details = TempoMethodDetails {
 ///     chain_id: Some(88153),
 ///     fee_payer: Some(true),
+///     fee_payer_url: Some("https://sponsor.moderato.tempo.xyz".to_string()),
 ///     nonce_key: None, // Uses default nonce stream
 ///     fee_token: None, // Uses same token as payment
 ///     valid_from: None,
@@ -31,9 +47,21 @@ pub struct TempoMethodDetails {
     #[serde(rename = "chainId", skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<u64>,
 
-    /// Whether server pays transaction fees
+    /// Whether fee sponsorship is enabled.
+    ///
+    /// When true, the client should build and sign a TempoTransaction (type 0x76)
+    /// with a fee payer placeholder, then return it as a `transaction` credential.
+    /// The server will forward this to the fee payer service for broadcasting.
     #[serde(rename = "feePayer", skip_serializing_if = "Option::is_none")]
     pub fee_payer: Option<bool>,
+
+    /// URL of the fee payer service.
+    ///
+    /// When `fee_payer` is true, the server forwards the client-signed transaction
+    /// to this URL. The fee payer service adds its signature and broadcasts.
+    /// Defaults to `https://sponsor.moderato.tempo.xyz` (Tempo testnet).
+    #[serde(rename = "feePayerUrl", skip_serializing_if = "Option::is_none")]
+    pub fee_payer_url: Option<String>,
 
     /// 2D nonce key for parallel transaction streams.
     /// If not specified, uses the default nonce stream (0).
@@ -54,10 +82,22 @@ pub struct TempoMethodDetails {
     pub valid_before: Option<String>,
 }
 
+/// Default fee payer URL for Tempo testnet.
+pub const DEFAULT_FEE_PAYER_URL: &str = "https://sponsor.moderato.tempo.xyz";
+
 impl TempoMethodDetails {
-    /// Check if server pays transaction fees.
+    /// Check if fee sponsorship is enabled.
     pub fn fee_payer(&self) -> bool {
         self.fee_payer.unwrap_or(false)
+    }
+
+    /// Get the fee payer service URL.
+    ///
+    /// Returns the configured `fee_payer_url` or the default testnet sponsor.
+    pub fn fee_payer_url(&self) -> &str {
+        self.fee_payer_url
+            .as_deref()
+            .unwrap_or(DEFAULT_FEE_PAYER_URL)
     }
 
     /// Get the nonce key as U256 for 2D nonces.
@@ -86,6 +126,7 @@ mod tests {
         let details = TempoMethodDetails {
             chain_id: Some(88153),
             fee_payer: Some(true),
+            fee_payer_url: Some("https://custom.sponsor.xyz".to_string()),
             nonce_key: Some("1".to_string()),
             fee_token: Some("0x123".to_string()),
             valid_from: None,
@@ -95,6 +136,7 @@ mod tests {
         let json = serde_json::to_string(&details).unwrap();
         assert!(json.contains("\"chainId\":88153"));
         assert!(json.contains("\"feePayer\":true"));
+        assert!(json.contains("\"feePayerUrl\":\"https://custom.sponsor.xyz\""));
         assert!(json.contains("\"nonceKey\":\"1\""));
         assert!(json.contains("\"feeToken\":\"0x123\""));
         assert!(json.contains("\"validBefore\":"));
@@ -103,6 +145,7 @@ mod tests {
         let parsed: TempoMethodDetails = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.chain_id, Some(88153));
         assert!(parsed.fee_payer());
+        assert_eq!(parsed.fee_payer_url(), "https://custom.sponsor.xyz");
         assert!(parsed.is_tempo_moderato());
     }
 
@@ -122,6 +165,21 @@ mod tests {
     fn test_fee_payer_default() {
         let details = TempoMethodDetails::default();
         assert!(!details.fee_payer());
+    }
+
+    #[test]
+    fn test_fee_payer_url_default() {
+        let details = TempoMethodDetails::default();
+        assert_eq!(details.fee_payer_url(), DEFAULT_FEE_PAYER_URL);
+    }
+
+    #[test]
+    fn test_fee_payer_url_custom() {
+        let details = TempoMethodDetails {
+            fee_payer_url: Some("https://my.sponsor.xyz".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(details.fee_payer_url(), "https://my.sponsor.xyz");
     }
 
     #[test]

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -54,7 +54,8 @@
 //!
 //! ## EVM-specific accessors (with "evm" feature)
 //!
-//! ```
+#![cfg_attr(feature = "tempo", doc = "```")]
+#![cfg_attr(not(feature = "tempo"), doc = "```ignore")]
 //! use mpay::protocol::core::parse_www_authenticate;
 //! use mpay::protocol::intents::ChargeRequest;
 //! use mpay::protocol::methods::tempo::TempoChargeExt;
@@ -68,7 +69,8 @@
 //!
 //! ## Tempo-specific accessors (with "tempo" feature)
 //!
-//! ```
+#![cfg_attr(feature = "tempo", doc = "```")]
+#![cfg_attr(not(feature = "tempo"), doc = "```ignore")]
 //! use mpay::protocol::core::parse_www_authenticate;
 //! use mpay::protocol::intents::ChargeRequest;
 //! use mpay::protocol::methods::tempo::TempoChargeExt;


### PR DESCRIPTION
## Summary

Adds the `fee_payer_url` field to the Tempo types and fixes documentation to clarify the correct fee sponsorship flow.

## Changes

### New Field: `fee_payer_url`

Added to both `TempoMethodDetails` and `TempoChargeExt` trait:

```rust
// In TempoMethodDetails
#[serde(rename = "feePayerUrl", skip_serializing_if = "Option::is_none")]
pub fee_payer_url: Option<String>,

// Accessor with default
pub fn fee_payer_url(&self) -> &str {
    self.fee_payer_url.as_deref().unwrap_or(DEFAULT_FEE_PAYER_URL)
}
```

### New Constant

```rust
pub const DEFAULT_FEE_PAYER_URL: &str = "https://sponsor.moderato.tempo.xyz";
```

### Documentation Fixes

Updated docs in `mod.rs`, `types.rs`, and `transaction.rs` to clarify the correct fee sponsorship flow:

1. **Server** sends a challenge with `feePayer: true` and optionally `feePayerUrl`
2. **Client** builds a TempoTransaction (type 0x76) with fee payer placeholder, signs it, and returns it as a `transaction` credential (**NOT** broadcast)
3. **Server** receives the signed transaction and forwards to the fee payer service
4. **Fee payer** adds its signature and broadcasts the transaction
5. **Server** verifies the receipt and transfer logs

**Important**: The client does NOT submit the transaction directly.

## Testing

- All 92 unit tests pass
- All 31 doc-tests pass

## Related

- Companion PR for mpay-python: https://github.com/tempoxyz/mpay-python/pull/1