### PR TITLE
feat: use tempo-alloy for transaction types instead of reimplementing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming", "authentication", "cryptography"]
 [features]
 default = ["tempo"]
 evm = ["alloy", "alloy-signer-local", "hex", "rand"]
-tempo = ["evm"]
+tempo = ["evm", "tempo-alloy", "tempo-primitives"]
 utils = ["hex", "rand"]
 http = ["reqwest"]
 middleware = ["http", "reqwest-middleware", "async-trait", "anyhow", "http-types"]
@@ -31,6 +31,10 @@ base64 = "0.22"
 rand = { version = "0.8", optional = true }
 alloy = { version = "1.2", features = ["full"], optional = true }
 alloy-signer-local = { version = "1.2", optional = true }
+
+# Tempo dependencies (optional, git-based)
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", default-features = false, optional = true }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", default-features = false, features = ["serde"], optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", features = ["json"], optional = true }

--- a/src/http/provider.rs
+++ b/src/http/provider.rs
@@ -51,13 +51,19 @@ fn assert_payment_provider_is_object_safe<P: PaymentProvider>() {}
 /// Tempo payment provider using EVM signing.
 ///
 /// Executes payments on the Tempo blockchain by building and signing
-/// transactions for the charge request.
+/// TempoTransactions (type 0x76) for charge requests.
 ///
 /// This provider:
 /// 1. Parses the charge request from the challenge
-/// 2. Builds and signs a transaction using the provided signer
-/// 3. Submits it via the RPC endpoint
+/// 2. Builds and signs a TempoTransaction using the provided signer
+/// 3. Submits it via the Tempo RPC endpoint
 /// 4. Returns a credential with the transaction hash
+///
+/// # Features
+///
+/// - **2D Nonces**: Supports parallel transaction streams via `nonce_key`
+/// - **TIP-20 Fees**: Supports paying gas fees in TIP-20 tokens via `fee_token`
+/// - **ERC-20 Transfers**: Handles both native transfers and ERC-20 token transfers
 ///
 /// # Examples
 ///
@@ -118,20 +124,21 @@ impl PaymentProvider for TempoProvider {
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
-        use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
-        use alloy::network::EthereumWallet;
+        use crate::protocol::methods::tempo::{TempoChargeExt, TempoTransactionRequest, CHAIN_ID};
+        use alloy::network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
         use alloy::providers::{Provider, ProviderBuilder};
+        use tempo_alloy::TempoNetwork;
 
         let charge: ChargeRequest = challenge.request.decode()?;
         let expected_chain_id = charge.chain_id().unwrap_or(CHAIN_ID);
         let address = self.signer.address();
 
         let wallet = EthereumWallet::from(self.signer.clone());
-        let provider = ProviderBuilder::new()
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .wallet(wallet)
             .connect_http(self.rpc_url.clone());
 
-        let actual_chain_id = provider
+        let actual_chain_id: u64 = provider
             .get_chain_id()
             .await
             .map_err(|e| MppError::Http(format!("failed to get chain ID: {}", e)))?;
@@ -147,10 +154,22 @@ impl PaymentProvider for TempoProvider {
         let amount = charge.amount_u256()?;
         let currency = charge.currency_address()?;
 
+        let nonce_key = charge.nonce_key();
+        let fee_token = charge
+            .fee_token()
+            .and_then(|s| crate::evm::parse_address(&s).ok());
+
         let tx_hash = if currency == alloy::primitives::Address::ZERO {
-            let tx = alloy::rpc::types::TransactionRequest::default()
-                .to(recipient)
-                .value(amount);
+            let mut tx = TempoTransactionRequest::default();
+            tx.set_to(recipient);
+            tx.set_value(amount);
+
+            if !nonce_key.is_zero() {
+                tx.set_nonce_key(nonce_key);
+            }
+            if let Some(fee_token_addr) = fee_token {
+                tx = tx.with_fee_token(fee_token_addr);
+            }
 
             let pending = provider
                 .send_transaction(tx)
@@ -174,6 +193,7 @@ impl PaymentProvider for TempoProvider {
             tx_hash
         } else {
             use alloy::sol;
+            use tempo_alloy::rpc::TempoCallBuilderExt;
 
             sol! {
                 #[sol(rpc)]
@@ -183,8 +203,17 @@ impl PaymentProvider for TempoProvider {
             }
 
             let token = IERC20::new(currency, &provider);
-            let pending = token
-                .transfer(recipient, amount)
+
+            let mut call = token.transfer(recipient, amount);
+
+            if !nonce_key.is_zero() {
+                call = call.nonce_key(nonce_key);
+            }
+            if let Some(fee_token_addr) = fee_token {
+                call = call.fee_token(fee_token_addr);
+            }
+
+            let pending = call
                 .send()
                 .await
                 .map_err(|e| MppError::Http(format!("token transfer send failed: {}", e)))?;

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -7,7 +7,8 @@
 //!
 //! - [`TempoMethodDetails`]: Tempo-specific method details (2D nonces, fee payer)
 //! - [`TempoChargeExt`]: Extension trait for ChargeRequest with Tempo-specific accessors
-//! - [`transaction::TempoTransactionParams`]: Transaction params for building transactions
+//! - [`TempoTransactionRequest`]: Transaction request builder (from tempo-alloy)
+//! - [`TempoTransaction`]: Full Tempo transaction type 0x76 (from tempo-primitives)
 //!
 //! # Constants
 //!
@@ -66,7 +67,8 @@ pub mod types;
 
 pub use charge::TempoChargeExt;
 pub use transaction::{
-    TempoSendTransactionRequest, TempoTransactionParams, TEMPO_SEND_TRANSACTION_METHOD,
+    Call, SignatureType, TempoTransaction, TempoTransactionRequest, TEMPO_SEND_TRANSACTION_METHOD,
+    TEMPO_TX_TYPE_ID,
 };
 pub use types::{TempoMethodDetails, DEFAULT_FEE_PAYER_URL};
 

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -1,8 +1,12 @@
 //! Tempo transaction types for building and submitting transactions.
 //!
-//! This module provides types for building Tempo transactions (type 0x76).
-//! All Tempo payments use TempoTransaction format regardless of whether
-//! fee sponsorship is enabled.
+//! This module re-exports transaction types from `tempo-alloy` and `tempo-primitives`
+//! for building Tempo transactions (type 0x76).
+//!
+//! # Transaction Types
+//!
+//! - [`TempoTransactionRequest`]: Builder for Tempo transactions (from tempo-alloy)
+//! - [`TempoTransaction`]: Full Tempo transaction with RLP encoding (from tempo-primitives)
 //!
 //! # Transaction Flow
 //!
@@ -13,329 +17,44 @@
 //! When `fee_payer` is `true`, the server forwards the signed transaction to
 //! a fee payer service which adds its signature before broadcasting.
 //!
-//! # Types
-//!
-//! - [`TempoTransactionParams`]: Parameters for building a transaction request
-//! - [`TempoSendTransactionRequest`]: JSON-RPC request for `tempo_sendTransaction`
-//!
 //! # Examples
 //!
-//! ```
-//! use mpay::protocol::methods::tempo::transaction::{
-//!     TempoTransactionParams, TempoSendTransactionRequest,
-//! };
+//! Using the tempo-alloy transaction request builder:
 //!
-//! let params = TempoTransactionParams::new("0xSender", "0xRecipient")
-//!     .with_value("1000000")
-//!     .with_fee_payer(true);
+//! ```ignore
+//! use mpay::protocol::methods::tempo::transaction::TempoTransactionRequest;
+//! use alloy::primitives::{Address, U256};
 //!
-//! let request = TempoSendTransactionRequest::new(params);
+//! let request = TempoTransactionRequest::default()
+//!     .with_nonce_key(U256::from(42u64))
+//!     .with_fee_token(fee_token_address);
+//!
+//! // Build a TempoTransaction (0x76)
+//! let tx = request.build_aa()?;
 //! ```
 
-use serde::{Deserialize, Serialize};
+/// Re-export TempoTransactionRequest from tempo-alloy.
+///
+/// This is the main builder type for Tempo transactions, wrapping alloy's
+/// `TransactionRequest` with Tempo-specific fields:
+/// - `fee_token`: Optional TIP-20 token for gas payment
+/// - `nonce_key`: 2D nonce key for parallel transaction streams
+/// - `calls`: Optional multi-call support
+/// - `tempo_authorization_list`: Tempo-specific authorization list
+pub use tempo_alloy::rpc::TempoTransactionRequest;
 
-use crate::protocol::intents::ChargeRequest;
+/// Re-export TempoTransaction from tempo-primitives.
+///
+/// This is the full Tempo transaction type (0x76) with:
+/// - RLP encoding/decoding
+/// - 2D nonce system (nonce_key)
+/// - Fee payer signature support
+/// - Multi-call support
+/// - TIP-20 fee token support
+pub use tempo_primitives::TempoTransaction;
 
-use super::TempoChargeExt;
+/// Re-export transaction primitives from tempo-primitives.
+pub use tempo_primitives::transaction::{Call, SignatureType, TEMPO_TX_TYPE_ID};
 
 /// JSON-RPC method name for Tempo transactions.
 pub const TEMPO_SEND_TRANSACTION_METHOD: &str = "tempo_sendTransaction";
-
-/// Parameters for a Tempo transaction.
-///
-/// This struct represents the transaction object passed to `tempo_sendTransaction`.
-/// It supports Tempo-specific fields like `feePayer` for gas sponsorship.
-///
-/// # Examples
-///
-/// ```
-/// use mpay::protocol::methods::tempo::transaction::TempoTransactionParams;
-///
-/// let params = TempoTransactionParams::new("0xSender", "0xRecipient")
-///     .with_value("1000000")
-///     .with_fee_payer(true)
-///     .with_nonce_key("42");
-/// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TempoTransactionParams {
-    /// Transaction sender address
-    pub from: String,
-
-    /// Transaction recipient address
-    pub to: String,
-
-    /// Transaction value in wei (hex or decimal string)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub value: Option<String>,
-
-    /// Transaction data (hex encoded)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<String>,
-
-    /// Gas limit
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub gas: Option<String>,
-
-    /// Max fee per gas (EIP-1559)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_fee_per_gas: Option<String>,
-
-    /// Max priority fee per gas (EIP-1559)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_priority_fee_per_gas: Option<String>,
-
-    /// Whether a fee payer should sponsor gas fees.
-    /// When true, submit via `tempo_sendTransaction` to a fee payer service.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fee_payer: Option<bool>,
-
-    /// Token address for gas payment (TIP-20 fee payment).
-    /// If not specified, uses the network's default fee token.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fee_token: Option<String>,
-
-    /// 2D nonce key for parallel transaction streams.
-    /// If not specified, uses the default nonce stream (0).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nonce_key: Option<String>,
-
-    /// Chain ID
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub chain_id: Option<u64>,
-}
-
-impl TempoTransactionParams {
-    /// Create new transaction params with required fields.
-    pub fn new(from: impl Into<String>, to: impl Into<String>) -> Self {
-        Self {
-            from: from.into(),
-            to: to.into(),
-            ..Default::default()
-        }
-    }
-
-    /// Create transaction params from a ChargeRequest.
-    ///
-    /// Extracts Tempo-specific fields (fee_payer, nonce_key, fee_token, chain_id)
-    /// from the ChargeRequest's method_details.
-    pub fn from_charge_request(req: &ChargeRequest, from: impl Into<String>) -> Self {
-        let to = req.recipient.clone().unwrap_or_default();
-
-        let mut params = Self::new(from, to);
-
-        if req.fee_payer() {
-            params.fee_payer = Some(true);
-        }
-
-        let nonce_key = req.nonce_key();
-        if !nonce_key.is_zero() {
-            params.nonce_key = Some(nonce_key.to_string());
-        }
-
-        if let Some(fee_token) = req.fee_token() {
-            params.fee_token = Some(fee_token);
-        }
-
-        if let Some(chain_id) = req.chain_id() {
-            params.chain_id = Some(chain_id);
-        }
-
-        params
-    }
-
-    /// Set the transaction value.
-    pub fn with_value(mut self, value: impl Into<String>) -> Self {
-        self.value = Some(value.into());
-        self
-    }
-
-    /// Set the transaction data.
-    pub fn with_data(mut self, data: impl Into<String>) -> Self {
-        self.data = Some(data.into());
-        self
-    }
-
-    /// Set the gas limit.
-    pub fn with_gas(mut self, gas: impl Into<String>) -> Self {
-        self.gas = Some(gas.into());
-        self
-    }
-
-    /// Enable fee sponsorship.
-    pub fn with_fee_payer(mut self, fee_payer: bool) -> Self {
-        self.fee_payer = Some(fee_payer);
-        self
-    }
-
-    /// Set the fee token for TIP-20 gas payment.
-    pub fn with_fee_token(mut self, fee_token: impl Into<String>) -> Self {
-        self.fee_token = Some(fee_token.into());
-        self
-    }
-
-    /// Set the 2D nonce key for parallel transactions.
-    pub fn with_nonce_key(mut self, nonce_key: impl Into<String>) -> Self {
-        self.nonce_key = Some(nonce_key.into());
-        self
-    }
-
-    /// Set the chain ID.
-    pub fn with_chain_id(mut self, chain_id: u64) -> Self {
-        self.chain_id = Some(chain_id);
-        self
-    }
-
-    /// Check if this transaction requires fee sponsorship.
-    pub fn requires_fee_payer(&self) -> bool {
-        self.fee_payer.unwrap_or(false)
-    }
-
-    /// Get the RPC method for this transaction.
-    ///
-    /// Always returns `tempo_sendTransaction` - all Tempo payments use
-    /// the same transaction format regardless of fee sponsorship.
-    pub fn rpc_method(&self) -> &'static str {
-        TEMPO_SEND_TRANSACTION_METHOD
-    }
-}
-
-/// JSON-RPC request for `tempo_sendTransaction`.
-///
-/// This is the complete request structure for submitting a Tempo transaction
-/// via JSON-RPC.
-///
-/// # Examples
-///
-/// ```
-/// use mpay::protocol::methods::tempo::transaction::{
-///     TempoTransactionParams, TempoSendTransactionRequest,
-/// };
-///
-/// let params = TempoTransactionParams::new("0xSender", "0xRecipient")
-///     .with_fee_payer(true);
-///
-/// let request = TempoSendTransactionRequest::new(params);
-/// let json = serde_json::to_string(&request).unwrap();
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TempoSendTransactionRequest {
-    /// JSON-RPC version
-    pub jsonrpc: String,
-
-    /// RPC method name
-    pub method: String,
-
-    /// Transaction parameters
-    pub params: Vec<TempoTransactionParams>,
-
-    /// Request ID
-    pub id: u64,
-}
-
-impl TempoSendTransactionRequest {
-    /// Create a new tempo_sendTransaction request.
-    pub fn new(params: TempoTransactionParams) -> Self {
-        Self {
-            jsonrpc: "2.0".to_string(),
-            method: TEMPO_SEND_TRANSACTION_METHOD.to_string(),
-            params: vec![params],
-            id: 1,
-        }
-    }
-
-    /// Create a new request with a specific ID.
-    pub fn with_id(params: TempoTransactionParams, id: u64) -> Self {
-        Self {
-            jsonrpc: "2.0".to_string(),
-            method: TEMPO_SEND_TRANSACTION_METHOD.to_string(),
-            params: vec![params],
-            id,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_tempo_transaction_params_builder() {
-        let params = TempoTransactionParams::new("0xSender", "0xRecipient")
-            .with_value("1000000")
-            .with_fee_payer(true)
-            .with_nonce_key("42")
-            .with_chain_id(88153);
-
-        assert_eq!(params.from, "0xSender");
-        assert_eq!(params.to, "0xRecipient");
-        assert_eq!(params.value, Some("1000000".to_string()));
-        assert!(params.requires_fee_payer());
-        assert_eq!(params.nonce_key, Some("42".to_string()));
-        assert_eq!(params.chain_id, Some(88153));
-    }
-
-    #[test]
-    fn test_rpc_method_always_tempo() {
-        let sponsored = TempoTransactionParams::new("0xA", "0xB").with_fee_payer(true);
-        assert_eq!(sponsored.rpc_method(), "tempo_sendTransaction");
-
-        let standard = TempoTransactionParams::new("0xA", "0xB");
-        assert_eq!(standard.rpc_method(), "tempo_sendTransaction");
-    }
-
-    #[test]
-    fn test_tempo_send_transaction_request_serialization() {
-        let params = TempoTransactionParams::new("0xSender", "0xRecipient")
-            .with_value("0x1000")
-            .with_fee_payer(true);
-
-        let request = TempoSendTransactionRequest::new(params);
-        let json = serde_json::to_value(&request).unwrap();
-
-        assert_eq!(json["jsonrpc"], "2.0");
-        assert_eq!(json["method"], "tempo_sendTransaction");
-        assert_eq!(json["params"][0]["from"], "0xSender");
-        assert_eq!(json["params"][0]["to"], "0xRecipient");
-        assert_eq!(json["params"][0]["value"], "0x1000");
-        assert_eq!(json["params"][0]["feePayer"], true);
-    }
-
-    #[test]
-    fn test_from_charge_request() {
-        let req = ChargeRequest {
-            amount: "1000000".to_string(),
-            currency: "0xToken".to_string(),
-            recipient: Some("0xRecipient".to_string()),
-            expires: None,
-            description: None,
-            external_id: None,
-            method_details: Some(serde_json::json!({
-                "feePayer": true,
-                "nonceKey": "42",
-                "feeToken": "0xFeeToken",
-                "chainId": 88153
-            })),
-        };
-
-        let params = TempoTransactionParams::from_charge_request(&req, "0xSender");
-
-        assert_eq!(params.from, "0xSender");
-        assert_eq!(params.to, "0xRecipient");
-        assert!(params.requires_fee_payer());
-        assert_eq!(params.nonce_key, Some("42".to_string()));
-        assert_eq!(params.fee_token, Some("0xFeeToken".to_string()));
-        assert_eq!(params.chain_id, Some(88153));
-    }
-
-    #[test]
-    fn test_skip_serializing_none_fields() {
-        let params = TempoTransactionParams::new("0xA", "0xB");
-        let json = serde_json::to_value(&params).unwrap();
-
-        assert!(json.get("value").is_none());
-        assert!(json.get("data").is_none());
-        assert!(json.get("feePayer").is_none());
-        assert!(json.get("nonceKey").is_none());
-    }
-}


### PR DESCRIPTION
## Summary

Replaces the custom `TempoTransactionParams` with proper re-exports from tempo-alloy and tempo-primitives, eliminating ~250 lines of duplicated transaction type code.

## Changes

### Dependencies
- Add `tempo-alloy` git dependency from tempo repo (default-features = false)
- Add `tempo-primitives` git dependency with serde feature

### Transaction Types
- **Remove** custom `TempoTransactionParams` struct (200+ lines)
- **Remove** `TempoSendTransactionRequest` JSON-RPC wrapper
- **Add** re-exports from tempo-alloy:
  - `TempoTransactionRequest` - the transaction builder
  - `TempoTransaction` - full 0x76 transaction type with RLP encoding
  - `Call`, `SignatureType`, `TEMPO_TX_TYPE_ID` primitives

### TempoProvider Updates
- Use `ProviderBuilder::new_with_network::<TempoNetwork>()` for proper fillers
- Use `TransactionBuilder` trait for `set_to()`, `set_value()`
- Use `TempoCallBuilderExt` for contract calls with `nonce_key()` and `fee_token()`
- Use `ReceiptResponse` trait for `status()` on Tempo receipts

## Benefits

1. **Single source of truth** - Uses same transaction types as tempo node
2. **Full RLP encoding** - `TempoTransaction` has proper encode/decode for type 0x76
3. **2D nonce support** - Native `nonce_key` field support
4. **TIP-20 fees** - Native `fee_token` field support
5. **Less maintenance** - No need to sync custom types with upstream

## Testing

```
make check
# 86 tests passed
# All features (tempo, http, middleware) compile
```