### PR TITLE
fix: tempo payment method parity with TypeScript SDK

### DIFF
--- a/src/protocol/methods/tempo/charge.rs
+++ b/src/protocol/methods/tempo/charge.rs
@@ -40,6 +40,9 @@ pub trait TempoChargeExt {
     /// Check if fee sponsorship is enabled.
     fn fee_payer(&self) -> bool;
 
+    /// Get the memo from methodDetails, if present.
+    fn memo(&self) -> Option<String>;
+
     /// Check if this request is for Tempo Moderato network.
     fn is_tempo_moderato(&self) -> bool;
 }
@@ -82,6 +85,14 @@ impl TempoChargeExt for ChargeRequest {
             .and_then(|v| v.get("feePayer"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
+    }
+
+    fn memo(&self) -> Option<String> {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("memo"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
     }
 
     fn is_tempo_moderato(&self) -> bool {
@@ -138,5 +149,23 @@ mod tests {
             ..test_charge_request()
         };
         assert!(!req_other_chain.is_tempo_moderato());
+    }
+
+    #[test]
+    fn test_memo() {
+        let req = test_charge_request();
+        assert!(req.memo().is_none());
+
+        let req_with_memo = ChargeRequest {
+            method_details: Some(serde_json::json!({
+                "chainId": 42431,
+                "memo": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            })),
+            ..test_charge_request()
+        };
+        assert_eq!(
+            req_with_memo.memo(),
+            Some("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string())
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -24,11 +24,13 @@
 //! ```
 
 use alloy::network::ReceiptResponse;
-use alloy::primitives::{Address, Bytes, B256, U256};
+use alloy::primitives::{hex, Address, Bytes, TxKind, B256, U256};
 use alloy::providers::Provider;
+use alloy::rlp::Decodable as _;
 use std::future::Future;
 use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
+use tempo_primitives::TempoTransaction;
 
 use crate::protocol::core::{PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
@@ -40,6 +42,28 @@ use super::{parse_iso8601_timestamp, TempoChargeExt, CHAIN_ID, INTENT_CHARGE, ME
 /// TIP-20 is Tempo's token standard (compatible with ERC-20 Transfer events).
 const TRANSFER_EVENT_TOPIC: B256 =
     alloy::primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+/// TIP-20 TransferWithMemo event topic: keccak256("TransferWithMemo(address,address,uint256,bytes32)")
+const TRANSFER_WITH_MEMO_EVENT_TOPIC: B256 =
+    alloy::primitives::b256!("57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0");
+
+/// TIP-20 transfer function selector: bytes4(keccak256("transfer(address,uint256)"))
+const TRANSFER_SELECTOR: [u8; 4] = [0xa9, 0x05, 0x9c, 0xbb];
+
+/// TIP-20 transferWithMemo function selector: bytes4(keccak256("transferWithMemo(address,uint256,bytes32)"))
+const TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = [0x4a, 0x7a, 0x13, 0x64];
+
+/// Parse a hex string (with or without 0x prefix) into a B256.
+fn parse_b256_hex(s: &str) -> Option<B256> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    hex::decode(s).ok().and_then(|bytes| {
+        if bytes.len() == 32 {
+            Some(B256::from_slice(&bytes))
+        } else {
+            None
+        }
+    })
+}
 
 /// Tempo charge method for one-time payment verification.
 ///
@@ -53,8 +77,9 @@ const TRANSFER_EVENT_TOPIC: B256 =
 /// # Verification Flow
 ///
 /// 1. Parse the credential payload (hash or signed transaction)
-/// 2. Fetch the transaction receipt from Tempo RPC
-/// 3. Verify transfer amount, recipient, and currency match
+/// 2. For transaction credentials: validate call data before broadcasting
+/// 3. Fetch the transaction receipt from Tempo RPC
+/// 4. Verify transfer amount, recipient, and currency match
 ///
 /// # Credential Types
 ///
@@ -139,9 +164,16 @@ where
         let currency = charge.currency_address().map_err(|e| {
             VerificationError::new(format!("Invalid currency address in request: {}", e))
         })?;
+        let memo = charge.memo();
 
         // Tempo uses TIP-20 tokens exclusively (no native token transfers)
-        self.verify_tip20_transfer(&receipt, currency, expected_recipient, expected_amount)?;
+        self.verify_tip20_transfer(
+            &receipt,
+            currency,
+            expected_recipient,
+            expected_amount,
+            memo.as_deref(),
+        )?;
 
         Ok(Receipt::success(METHOD_NAME, tx_hash))
     }
@@ -152,6 +184,7 @@ where
         currency: Address,
         expected_recipient: Address,
         expected_amount: U256,
+        memo: Option<&str>,
     ) -> Result<(), VerificationError> {
         let receipt_json = serde_json::to_value(receipt)
             .map_err(|e| VerificationError::new(format!("Failed to serialize receipt: {}", e)))?;
@@ -160,6 +193,9 @@ where
             .get("logs")
             .and_then(|v| v.as_array())
             .ok_or_else(|| VerificationError::new("Receipt has no logs".to_string()))?;
+
+        // Parse expected memo if present
+        let expected_memo = memo.and_then(parse_b256_hex);
 
         for log in logs {
             let log_address = log
@@ -177,13 +213,40 @@ where
                 .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
                 .unwrap_or_default();
 
-            if topics.len() < 3 {
+            if topics.is_empty() {
                 continue;
             }
 
             let topic0 = topics[0].parse::<B256>().unwrap_or_default();
 
-            if topic0 != TRANSFER_EVENT_TOPIC {
+            // Check for TransferWithMemo when memo is expected
+            if let Some(exp_memo) = expected_memo {
+                if topic0 == TRANSFER_WITH_MEMO_EVENT_TOPIC && topics.len() >= 3 {
+                    let to_topic = topics[2];
+                    let to_address =
+                        Address::from_slice(&to_topic.parse::<B256>().unwrap_or_default()[12..]);
+
+                    if to_address != expected_recipient {
+                        continue;
+                    }
+
+                    let data = log.get("data").and_then(|v| v.as_str()).unwrap_or("0x");
+                    // Data contains: amount (32 bytes) + memo (32 bytes)
+                    if data.len() >= 130 {
+                        // 0x + 64 (amount) + 64 (memo)
+                        let amount = U256::from_str_radix(&data[2..66], 16).unwrap_or(U256::ZERO);
+                        let memo_bytes = parse_b256_hex(&data[66..130]).unwrap_or_default();
+
+                        if amount == expected_amount && memo_bytes == exp_memo {
+                            return Ok(());
+                        }
+                    }
+                }
+                continue;
+            }
+
+            // Standard Transfer event
+            if topic0 != TRANSFER_EVENT_TOPIC || topics.len() < 3 {
                 continue;
             }
 
@@ -199,16 +262,24 @@ where
 
             if data.len() >= 66 {
                 let amount = U256::from_str_radix(&data[2..], 16).unwrap_or(U256::ZERO);
-                if amount >= expected_amount {
+                // Use exact equality per TypeScript SDK behavior
+                if amount == expected_amount {
                     return Ok(());
                 }
             }
         }
 
-        Err(VerificationError::new(format!(
-            "No matching Transfer event found: expected {} {} to {}",
-            expected_amount, currency, expected_recipient
-        )))
+        if memo.is_some() {
+            Err(VerificationError::new(format!(
+                "No matching TransferWithMemo event found: expected {} {} to {} with memo",
+                expected_amount, currency, expected_recipient
+            )))
+        } else {
+            Err(VerificationError::new(format!(
+                "No matching Transfer event found: expected {} {} to {}",
+                expected_amount, currency, expected_recipient
+            )))
+        }
     }
 
     fn check_expiration(&self, expires: &str) -> Result<(), VerificationError> {
@@ -232,10 +303,126 @@ where
         Ok(())
     }
 
-    async fn broadcast_transaction(&self, signed_tx: &str) -> Result<B256, VerificationError> {
+    /// Validate that a transaction contains the expected payment call.
+    ///
+    /// This performs pre-broadcast validation by deserializing the transaction
+    /// and checking that it contains a transfer/transferWithMemo call with the
+    /// expected recipient, amount, and (optionally) memo.
+    fn validate_transaction(
+        &self,
+        tx_bytes: &[u8],
+        currency: Address,
+        expected_recipient: Address,
+        expected_amount: U256,
+        memo: Option<&str>,
+    ) -> Result<(), VerificationError> {
+        // Skip type byte (0x76) for Tempo transactions
+        let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
+            &tx_bytes[1..]
+        } else {
+            tx_bytes
+        };
+
+        let tx = TempoTransaction::decode(&mut &tx_data[..])
+            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
+
+        // Parse expected memo if present
+        let expected_memo = memo.and_then(parse_b256_hex);
+
+        // Search for matching call in transaction
+        for call in &tx.calls {
+            // Check if this call targets the currency contract
+            let call_to = match &call.to {
+                TxKind::Call(addr) => addr,
+                TxKind::Create => continue,
+            };
+
+            if call_to != &currency {
+                continue;
+            }
+
+            let data = &call.input;
+            if data.len() < 4 {
+                continue;
+            }
+
+            let selector: [u8; 4] = data[..4].try_into().unwrap_or([0; 4]);
+
+            if let Some(exp_memo) = expected_memo {
+                // Look for transferWithMemo(address,uint256,bytes32)
+                if selector == TRANSFER_WITH_MEMO_SELECTOR && data.len() >= 100 {
+                    // 4 + 32 + 32 + 32
+                    let to = Address::from_slice(&data[16..36]);
+                    let amount = U256::from_be_slice(&data[36..68]);
+                    let memo_bytes = B256::from_slice(&data[68..100]);
+
+                    if to == expected_recipient
+                        && amount == expected_amount
+                        && memo_bytes == exp_memo
+                    {
+                        return Ok(());
+                    }
+                }
+            } else {
+                // Look for transfer(address,uint256)
+                if selector == TRANSFER_SELECTOR && data.len() >= 68 {
+                    // 4 + 32 + 32
+                    let to = Address::from_slice(&data[16..36]);
+                    let amount = U256::from_be_slice(&data[36..68]);
+
+                    if to == expected_recipient && amount == expected_amount {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
+        if memo.is_some() {
+            Err(VerificationError::new(format!(
+                "Invalid transaction: no matching transferWithMemo call found for {} {} to {}",
+                expected_amount, currency, expected_recipient
+            )))
+        } else {
+            Err(VerificationError::new(format!(
+                "Invalid transaction: no matching transfer call found for {} {} to {}",
+                expected_amount, currency, expected_recipient
+            )))
+        }
+    }
+
+    async fn broadcast_transaction(
+        &self,
+        signed_tx: &str,
+        charge: &ChargeRequest,
+    ) -> Result<B256, VerificationError> {
         let tx_bytes = signed_tx
             .parse::<Bytes>()
             .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {}", e)))?;
+
+        // Pre-broadcast validation: verify transaction contains expected payment call
+        let expected_recipient = charge.recipient_address().map_err(|e| {
+            VerificationError::new(format!("Invalid recipient address in request: {}", e))
+        })?;
+        let expected_amount = charge
+            .amount_u256()
+            .map_err(|e| VerificationError::new(format!("Invalid amount in request: {}", e)))?;
+        let currency = charge.currency_address().map_err(|e| {
+            VerificationError::new(format!("Invalid currency address in request: {}", e))
+        })?;
+        let memo = charge.memo();
+
+        self.validate_transaction(
+            &tx_bytes,
+            currency,
+            expected_recipient,
+            expected_amount,
+            memo.as_deref(),
+        )?;
+
+        // Fee payer support: if feePayer is requested, the server would need to
+        // add its signature here. This requires a signer to be configured.
+        // For now, we just broadcast the transaction as-is.
+        // TODO: Implement fee payer co-signing when signer is provided
 
         let pending = self
             .provider
@@ -313,12 +500,29 @@ where
                 this.verify_hash(credential.payload.tx_hash().unwrap(), &request)
                     .await
             } else {
-                // Client sent signed transaction, we need to broadcast it
+                // Client sent signed transaction, validate and broadcast it
                 let tx_hash = this
-                    .broadcast_transaction(credential.payload.signed_tx().unwrap())
+                    .broadcast_transaction(credential.payload.signed_tx().unwrap(), &request)
                     .await?;
                 this.verify_hash(&format!("{:#x}", tx_hash), &request).await
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_transfer_selector() {
+        // transfer(address,uint256) = 0xa9059cbb
+        assert_eq!(TRANSFER_SELECTOR, [0xa9, 0x05, 0x9c, 0xbb]);
+    }
+
+    #[test]
+    fn test_transfer_with_memo_selector() {
+        // transferWithMemo(address,uint256,bytes32) = 0x4a7a1364
+        assert_eq!(TRANSFER_WITH_MEMO_SELECTOR, [0x4a, 0x7a, 0x13, 0x64]);
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -186,6 +186,23 @@ where
         expected_amount: U256,
         memo: Option<&str>,
     ) -> Result<(), VerificationError> {
+        // Security guards: reject zero values that could match parse failures
+        if expected_amount.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid amount: expected_amount must be greater than zero".to_string(),
+            ));
+        }
+        if expected_recipient.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid recipient: expected_recipient cannot be the zero address".to_string(),
+            ));
+        }
+        if currency.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid currency: currency cannot be the zero address".to_string(),
+            ));
+        }
+
         let receipt_json = serde_json::to_value(receipt)
             .map_err(|e| VerificationError::new(format!("Failed to serialize receipt: {}", e)))?;
 
@@ -344,7 +361,25 @@ where
         expected_recipient: Address,
         expected_amount: U256,
         memo: Option<&str>,
+        expected_chain_id: u64,
     ) -> Result<(), VerificationError> {
+        // Security guards: reject zero values that could match parse failures
+        if expected_amount.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid amount: expected_amount must be greater than zero".to_string(),
+            ));
+        }
+        if expected_recipient.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid recipient: expected_recipient cannot be the zero address".to_string(),
+            ));
+        }
+        if currency.is_zero() {
+            return Err(VerificationError::new(
+                "Invalid currency: currency cannot be the zero address".to_string(),
+            ));
+        }
+
         // Skip type byte (0x76) for Tempo transactions
         let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
             &tx_bytes[1..]
@@ -354,6 +389,14 @@ where
 
         let tx = TempoTransaction::decode(&mut &tx_data[..])
             .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
+
+        // Validate chain_id to prevent cross-chain replay attacks
+        if tx.chain_id != expected_chain_id {
+            return Err(VerificationError::new(format!(
+                "Transaction chain_id mismatch: expected {}, got {}",
+                expected_chain_id, tx.chain_id
+            )));
+        }
 
         // Parse expected memo if present - fail if memo is present but invalid
         let expected_memo = match memo {
@@ -431,6 +474,7 @@ where
         &self,
         signed_tx: &str,
         charge: &ChargeRequest,
+        expected_chain_id: u64,
     ) -> Result<B256, VerificationError> {
         let tx_bytes = signed_tx
             .parse::<Bytes>()
@@ -454,6 +498,7 @@ where
             expected_recipient,
             expected_amount,
             memo.as_deref(),
+            expected_chain_id,
         )?;
 
         // Fail fast if fee payer is requested but not configured.
@@ -543,7 +588,11 @@ where
             } else {
                 // Client sent signed transaction, validate and broadcast it
                 let tx_hash = this
-                    .broadcast_transaction(credential.payload.signed_tx().unwrap(), &request)
+                    .broadcast_transaction(
+                        credential.payload.signed_tx().unwrap(),
+                        &request,
+                        expected_chain_id,
+                    )
                     .await?;
                 this.verify_hash(&format!("{:#x}", tx_hash), &request).await
             }
@@ -659,5 +708,33 @@ mod tests {
                 let _selector: [u8; 4] = input[..4].try_into().unwrap_or([0; 4]);
             }
         }
+    }
+
+    #[test]
+    fn test_zero_amount_rejected() {
+        // Zero amounts should be rejected to prevent parse-failure bypasses
+        let zero = U256::ZERO;
+        assert!(zero.is_zero());
+
+        let non_zero = U256::from(1u64);
+        assert!(!non_zero.is_zero());
+    }
+
+    #[test]
+    fn test_zero_address_detection() {
+        // Zero addresses should be rejected to prevent parse-failure bypasses
+        let zero_addr = Address::ZERO;
+        assert!(zero_addr.is_zero());
+
+        let valid_addr: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        assert!(!valid_addr.is_zero());
+    }
+
+    #[test]
+    fn test_chain_id_constant() {
+        // Verify the Tempo Moderato chain ID constant
+        assert_eq!(CHAIN_ID, 42431);
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -194,8 +194,16 @@ where
             .and_then(|v| v.as_array())
             .ok_or_else(|| VerificationError::new("Receipt has no logs".to_string()))?;
 
-        // Parse expected memo if present
-        let expected_memo = memo.and_then(parse_b256_hex);
+        // Parse expected memo if present - fail if memo is present but invalid
+        let expected_memo = match memo {
+            Some(m) => Some(parse_b256_hex(m).ok_or_else(|| {
+                VerificationError::new(format!(
+                    "Invalid memo: must be 32-byte hex string, got: {}",
+                    m
+                ))
+            })?),
+            None => None,
+        };
 
         for log in logs {
             let log_address = log
@@ -217,14 +225,21 @@ where
                 continue;
             }
 
-            let topic0 = topics[0].parse::<B256>().unwrap_or_default();
+            // Skip logs with unparseable topic0 rather than defaulting to zero
+            let topic0 = match topics[0].parse::<B256>() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
 
             // Check for TransferWithMemo when memo is expected
             if let Some(exp_memo) = expected_memo {
                 if topic0 == TRANSFER_WITH_MEMO_EVENT_TOPIC && topics.len() >= 3 {
                     let to_topic = topics[2];
-                    let to_address =
-                        Address::from_slice(&to_topic.parse::<B256>().unwrap_or_default()[12..]);
+                    // Skip if to_address topic is unparseable
+                    let to_address = match to_topic.parse::<B256>() {
+                        Ok(b) => Address::from_slice(&b[12..]),
+                        Err(_) => continue,
+                    };
 
                     if to_address != expected_recipient {
                         continue;
@@ -234,8 +249,15 @@ where
                     // Data contains: amount (32 bytes) + memo (32 bytes)
                     if data.len() >= 130 {
                         // 0x + 64 (amount) + 64 (memo)
-                        let amount = U256::from_str_radix(&data[2..66], 16).unwrap_or(U256::ZERO);
-                        let memo_bytes = parse_b256_hex(&data[66..130]).unwrap_or_default();
+                        // Skip if amount or memo parsing fails
+                        let amount = match U256::from_str_radix(&data[2..66], 16) {
+                            Ok(a) => a,
+                            Err(_) => continue,
+                        };
+                        let memo_bytes = match parse_b256_hex(&data[66..130]) {
+                            Some(m) => m,
+                            None => continue,
+                        };
 
                         if amount == expected_amount && memo_bytes == exp_memo {
                             return Ok(());
@@ -251,8 +273,11 @@ where
             }
 
             let to_topic = topics[2];
-            let to_address =
-                Address::from_slice(&to_topic.parse::<B256>().unwrap_or_default()[12..]);
+            // Skip if to_address topic is unparseable
+            let to_address = match to_topic.parse::<B256>() {
+                Ok(b) => Address::from_slice(&b[12..]),
+                Err(_) => continue,
+            };
 
             if to_address != expected_recipient {
                 continue;
@@ -261,7 +286,11 @@ where
             let data = log.get("data").and_then(|v| v.as_str()).unwrap_or("0x");
 
             if data.len() >= 66 {
-                let amount = U256::from_str_radix(&data[2..], 16).unwrap_or(U256::ZERO);
+                // Skip if amount parsing fails
+                let amount = match U256::from_str_radix(&data[2..], 16) {
+                    Ok(a) => a,
+                    Err(_) => continue,
+                };
                 // Use exact equality per TypeScript SDK behavior
                 if amount == expected_amount {
                     return Ok(());
@@ -326,8 +355,16 @@ where
         let tx = TempoTransaction::decode(&mut &tx_data[..])
             .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
 
-        // Parse expected memo if present
-        let expected_memo = memo.and_then(parse_b256_hex);
+        // Parse expected memo if present - fail if memo is present but invalid
+        let expected_memo = match memo {
+            Some(m) => Some(parse_b256_hex(m).ok_or_else(|| {
+                VerificationError::new(format!(
+                    "Invalid memo: must be 32-byte hex string, got: {}",
+                    m
+                ))
+            })?),
+            None => None,
+        };
 
         // Search for matching call in transaction
         for call in &tx.calls {
@@ -350,8 +387,8 @@ where
 
             if let Some(exp_memo) = expected_memo {
                 // Look for transferWithMemo(address,uint256,bytes32)
-                if selector == TRANSFER_WITH_MEMO_SELECTOR && data.len() >= 100 {
-                    // 4 + 32 + 32 + 32
+                // Exact length: 4 (selector) + 32 (address) + 32 (amount) + 32 (memo) = 100 bytes
+                if selector == TRANSFER_WITH_MEMO_SELECTOR && data.len() == 100 {
                     let to = Address::from_slice(&data[16..36]);
                     let amount = U256::from_be_slice(&data[36..68]);
                     let memo_bytes = B256::from_slice(&data[68..100]);
@@ -365,8 +402,8 @@ where
                 }
             } else {
                 // Look for transfer(address,uint256)
-                if selector == TRANSFER_SELECTOR && data.len() >= 68 {
-                    // 4 + 32 + 32
+                // Exact length: 4 (selector) + 32 (address) + 32 (amount) = 68 bytes
+                if selector == TRANSFER_SELECTOR && data.len() == 68 {
                     let to = Address::from_slice(&data[16..36]);
                     let amount = U256::from_be_slice(&data[36..68]);
 
@@ -419,10 +456,14 @@ where
             memo.as_deref(),
         )?;
 
-        // Fee payer support: if feePayer is requested, the server would need to
-        // add its signature here. This requires a signer to be configured.
-        // For now, we just broadcast the transaction as-is.
-        // TODO: Implement fee payer co-signing when signer is provided
+        // Fail fast if fee payer is requested but not configured.
+        // Full fee payer support requires passing a signer to ChargeMethod.
+        if charge.fee_payer() {
+            return Err(VerificationError::new(
+                "feePayer requested but fee sponsorship is not configured on this server"
+                    .to_string(),
+            ));
+        }
 
         let pending = self
             .provider
@@ -524,5 +565,99 @@ mod tests {
     fn test_transfer_with_memo_selector() {
         // transferWithMemo(address,uint256,bytes32) = 0x4a7a1364
         assert_eq!(TRANSFER_WITH_MEMO_SELECTOR, [0x4a, 0x7a, 0x13, 0x64]);
+    }
+
+    #[test]
+    fn test_parse_b256_hex_valid() {
+        let valid = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let result = parse_b256_hex(valid);
+        assert!(result.is_some());
+
+        // Without 0x prefix
+        let valid_no_prefix = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let result = parse_b256_hex(valid_no_prefix);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_parse_b256_hex_invalid_length() {
+        // Too short (only 3 bytes)
+        let too_short = "0xabcdef";
+        assert!(parse_b256_hex(too_short).is_none());
+
+        // Too long (33 bytes)
+        let too_long = "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef00";
+        assert!(parse_b256_hex(too_long).is_none());
+
+        // Empty
+        assert!(parse_b256_hex("").is_none());
+        assert!(parse_b256_hex("0x").is_none());
+    }
+
+    #[test]
+    fn test_parse_b256_hex_invalid_chars() {
+        // Invalid hex characters
+        let invalid = "0xgggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg";
+        assert!(parse_b256_hex(invalid).is_none());
+    }
+
+    #[test]
+    fn test_event_topics() {
+        // Verify event topic constants match keccak256 of event signatures
+        // Transfer(address,address,uint256)
+        assert_eq!(
+            TRANSFER_EVENT_TOPIC,
+            alloy::primitives::b256!(
+                "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+            )
+        );
+
+        // TransferWithMemo(address,address,uint256,bytes32)
+        assert_eq!(
+            TRANSFER_WITH_MEMO_EVENT_TOPIC,
+            alloy::primitives::b256!(
+                "57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0"
+            )
+        );
+    }
+
+    #[test]
+    fn test_parse_b256_hex_case_insensitive() {
+        // Test case insensitivity - both should parse to the same value
+        let lower = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+        let upper = "0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890";
+        let mixed = "0xAbCdEf1234567890AbCdEf1234567890AbCdEf1234567890AbCdEf1234567890";
+
+        let lower_result = parse_b256_hex(lower).unwrap();
+        let upper_result = parse_b256_hex(upper).unwrap();
+        let mixed_result = parse_b256_hex(mixed).unwrap();
+
+        assert_eq!(lower_result, upper_result);
+        assert_eq!(lower_result, mixed_result);
+    }
+
+    #[test]
+    fn test_calldata_length_constants() {
+        // Verify the expected calldata lengths match ABI encoding
+        // transfer(address,uint256): 4 + 32 + 32 = 68
+        // transferWithMemo(address,uint256,bytes32): 4 + 32 + 32 + 32 = 100
+        const TRANSFER_CALLDATA_LEN: usize = 4 + 32 + 32;
+        const TRANSFER_WITH_MEMO_CALLDATA_LEN: usize = 4 + 32 + 32 + 32;
+
+        assert_eq!(TRANSFER_CALLDATA_LEN, 68);
+        assert_eq!(TRANSFER_WITH_MEMO_CALLDATA_LEN, 100);
+    }
+
+    #[test]
+    fn test_selector_parsing_short_input() {
+        // Ensure short inputs don't panic - test with various short lengths
+        let short_inputs: Vec<&[u8]> = vec![&[], &[0xa9], &[0xa9, 0x05], &[0xa9, 0x05, 0x9c]];
+
+        for input in short_inputs {
+            // This mimics the parsing logic - should not panic
+            if input.len() >= 4 {
+                let _selector: [u8; 4] = input[..4].try_into().unwrap_or([0; 4]);
+            }
+        }
     }
 }

--- a/src/protocol/methods/tempo/types.rs
+++ b/src/protocol/methods/tempo/types.rs
@@ -40,6 +40,13 @@ pub struct TempoMethodDetails {
     /// The server adds its fee payer signature before broadcasting.
     #[serde(rename = "feePayer", skip_serializing_if = "Option::is_none")]
     pub fee_payer: Option<bool>,
+
+    /// Optional memo for `transferWithMemo` calls.
+    ///
+    /// When present, the server verifies `TransferWithMemo` logs instead of `Transfer`.
+    /// Must be a 32-byte hex string (with or without 0x prefix).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memo: Option<String>,
 }
 
 impl TempoMethodDetails {
@@ -51,6 +58,11 @@ impl TempoMethodDetails {
     /// Check if this is for the Tempo Moderato network.
     pub fn is_tempo_moderato(&self) -> bool {
         self.chain_id == Some(CHAIN_ID)
+    }
+
+    /// Get the memo as a reference, if present.
+    pub fn memo(&self) -> Option<&str> {
+        self.memo.as_deref()
     }
 }
 
@@ -94,5 +106,37 @@ mod tests {
             ..Default::default()
         };
         assert!(!other.is_tempo_moderato());
+    }
+
+    #[test]
+    fn test_memo() {
+        let details = TempoMethodDetails::default();
+        assert!(details.memo().is_none());
+
+        let details_with_memo = TempoMethodDetails {
+            memo: Some(
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+            ),
+            ..Default::default()
+        };
+        assert_eq!(
+            details_with_memo.memo(),
+            Some("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+        );
+    }
+
+    #[test]
+    fn test_serialization_with_memo() {
+        let details = TempoMethodDetails {
+            chain_id: Some(42431),
+            fee_payer: Some(true),
+            memo: Some("0xabcdef".to_string()),
+        };
+
+        let json = serde_json::to_string(&details).unwrap();
+        assert!(json.contains("\"memo\":\"0xabcdef\""));
+
+        let parsed: TempoMethodDetails = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.memo(), Some("0xabcdef"));
     }
 }

--- a/src/protocol/methods/tempo/types.rs
+++ b/src/protocol/methods/tempo/types.rs
@@ -25,6 +25,7 @@ use super::CHAIN_ID;
 /// let details = TempoMethodDetails {
 ///     chain_id: Some(42431),
 ///     fee_payer: Some(true),
+///     memo: None,
 /// };
 /// assert!(details.fee_payer());
 /// ```
@@ -75,6 +76,7 @@ mod tests {
         let details = TempoMethodDetails {
             chain_id: Some(42431),
             fee_payer: Some(true),
+            memo: None,
         };
 
         let json = serde_json::to_string(&details).unwrap();


### PR DESCRIPTION
## Summary

This PR fixes several parity issues between the Rust SDK and the canonical TypeScript SDK implementation for the Tempo payment method.

## Changes

### 1. Amount verification (method.rs L233)
- **Before**: Used `>=` comparison, allowing overpayment
- **After**: Uses exact equality (`==`) per TypeScript SDK behavior
- TS reference: `log.args.amount.toString() === amount`

### 2. Pre-broadcast transaction validation (method.rs)
- **New**: Before broadcasting transaction credentials, we now deserialize the TempoTransaction and validate it contains the expected TIP-20 transfer call
- Validates: recipient, amount, currency, and memo (if present)
- Prevents broadcasting transactions that would fail post-broadcast verification
- Matches TS behavior of inspecting `Transaction.deserialize()` calls before `sendRawTransactionSync`

### 3. Memo support (types.rs, charge.rs, method.rs)
- Added `memo` field to `TempoMethodDetails` struct
- Added `memo()` accessor to `TempoChargeExt` trait
- When memo is present:
  - Log verification checks `TransferWithMemo` events instead of `Transfer`
  - Pre-broadcast validation checks for `transferWithMemo` selector (`0x4a7a1364`)
- TS reference: Checks `TransferWithMemo` logs when `methodDetails?.memo` is present

### 4. Fee payer groundwork
- Added TODO comment for fee payer co-signing implementation
- Full implementation requires passing a signer to ChargeMethod (architectural decision needed)
- TS reference: `signTransaction(client, { ...transaction, account: feePayer, feePayer })`

## Testing
- `make check` passes (fmt, clippy, tests, build)
- Added new tests for memo functionality in types.rs and charge.rs

## References
- TypeScript SDK: `mpay/src/tempo/server/Method.ts`
- Transfer selector: `0xa9059cbb`
- TransferWithMemo selector: `0x4a7a1364`
- TransferWithMemo event topic: `0x57bc7354aa85aed339e000bccffabbc529466af35f0772c8f8ee1145927de7f0`