### PR TITLE
spec: remove failed receipt state, return 402 for failures

### DIFF
--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -340,25 +340,9 @@ impl Receipt {
         }
     }
 
-    /// Create a failed payment receipt.
-    pub fn failed(method: impl Into<MethodName>, error_msg: &str) -> Self {
-        Self {
-            status: ReceiptStatus::Failed,
-            method: method.into(),
-            timestamp: now_iso8601(),
-            reference: String::new(),
-            error: Some(error_msg.to_string()),
-        }
-    }
-
     /// Check if the payment was successful.
     pub fn is_success(&self) -> bool {
         self.status == ReceiptStatus::Success
-    }
-
-    /// Check if the payment failed.
-    pub fn is_failed(&self) -> bool {
-        self.status == ReceiptStatus::Failed
     }
 
     /// Format as Payment-Receipt header value.
@@ -504,16 +488,5 @@ mod tests {
             error: None,
         };
         assert!(success.is_success());
-        assert!(!success.is_failed());
-
-        let failed = Receipt {
-            status: ReceiptStatus::Failed,
-            method: "tempo".into(),
-            timestamp: "2024-01-01T00:00:00Z".to_string(),
-            reference: "".to_string(),
-            error: Some("Payment failed".to_string()),
-        };
-        assert!(!failed.is_success());
-        assert!(failed.is_failed());
     }
 }

--- a/src/protocol/core/types.rs
+++ b/src/protocol/core/types.rs
@@ -357,15 +357,12 @@ impl fmt::Display for PayloadType {
 pub enum ReceiptStatus {
     /// Payment succeeded
     Success,
-    /// Payment failed
-    Failed,
 }
 
 impl fmt::Display for ReceiptStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Success => write!(f, "success"),
-            Self::Failed => write!(f, "failed"),
         }
     }
 }
@@ -504,10 +501,6 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&ReceiptStatus::Success).unwrap(),
             "\"success\""
-        );
-        assert_eq!(
-            serde_json::to_string(&ReceiptStatus::Failed).unwrap(),
-            "\"failed\""
         );
     }
 }

--- a/src/server/mpay.rs
+++ b/src/server/mpay.rs
@@ -248,6 +248,28 @@ mod tests {
         }
     }
 
+    /// Mock method that returns a transaction_failed error (simulates reverted tx)
+    #[derive(Clone)]
+    struct FailedTransactionMethod;
+
+    impl ChargeMethod for FailedTransactionMethod {
+        fn method(&self) -> &str {
+            "mock"
+        }
+
+        fn verify(
+            &self,
+            _credential: &PaymentCredential,
+            _request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
+            async {
+                Err(VerificationError::transaction_failed(
+                    "Transaction reverted on-chain",
+                ))
+            }
+        }
+    }
+
     fn test_credential(secret_key: &str) -> PaymentCredential {
         let request = "eyJ0ZXN0IjoidmFsdWUifQ";
         let id = {
@@ -329,5 +351,28 @@ mod tests {
         let receipt = result.unwrap();
         assert!(receipt.is_success());
         assert_eq!(receipt.reference, "0xabc123");
+    }
+
+    /// Verify that transaction failures return VerificationError (which becomes 402).
+    #[tokio::test]
+    async fn test_verify_returns_error_for_failed_transaction() {
+        use crate::error::{MppError, PaymentError};
+        use crate::protocol::traits::ErrorCode;
+
+        let payment = Mpay::new(FailedTransactionMethod, "api.example.com", "secret");
+        let credential = test_credential("secret");
+        let request = test_request();
+
+        let result = payment.verify(&credential, &request).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, Some(ErrorCode::TransactionFailed));
+        assert!(err.message.contains("reverted"));
+
+        // Verify it converts to MppError with 402 status
+        let mpp_err: MppError = err.into();
+        let problem = mpp_err.to_problem_details(None);
+        assert_eq!(problem.status, 402);
     }
 }

--- a/src/server/mpay.rs
+++ b/src/server/mpay.rs
@@ -203,15 +203,6 @@ where
 
         let receipt = self.method.verify(credential, request).await?;
 
-        // Per spec, synchronous flows MUST NOT return 200 with a failed receipt.
-        // Convert failed receipts to VerificationError.
-        if receipt.is_failed() {
-            return Err(VerificationError::transaction_failed(format!(
-                "payment failed: {}",
-                receipt.reference
-            )));
-        }
-
         Ok(receipt)
     }
 }
@@ -236,24 +227,6 @@ mod tests {
             _request: &ChargeRequest,
         ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
             async { Ok(Receipt::success("mock", "mock_ref")) }
-        }
-    }
-
-    /// Mock method that returns a failed receipt
-    #[derive(Clone)]
-    struct FailedReceiptMethod;
-
-    impl ChargeMethod for FailedReceiptMethod {
-        fn method(&self) -> &str {
-            "mock"
-        }
-
-        fn verify(
-            &self,
-            _credential: &PaymentCredential,
-            _request: &ChargeRequest,
-        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
-            async { Ok(Receipt::failed("mock", "tx reverted on-chain")) }
         }
     }
 
@@ -341,26 +314,6 @@ mod tests {
         assert_eq!(challenge.intent.as_str(), "charge");
         // ID should be 43 chars (base64url SHA256)
         assert_eq!(challenge.id.len(), 43);
-    }
-
-    /// Per IETF spec, synchronous flows MUST NOT return 200 with a failed receipt.
-    /// When verify() returns a receipt with status: "failed", Mpay::verify should
-    /// convert it to a VerificationError.
-    #[tokio::test]
-    async fn test_verify_returns_error_for_failed_receipt() {
-        let payment = Mpay::new(FailedReceiptMethod, "api.example.com", "secret");
-        let credential = test_credential("secret");
-        let request = test_request();
-
-        let result = payment.verify(&credential, &request).await;
-
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.message.contains("payment failed"));
-        assert_eq!(
-            err.code,
-            Some(crate::protocol::traits::ErrorCode::TransactionFailed)
-        );
     }
 
     /// Verify that successful receipts are returned normally.


### PR DESCRIPTION
Per spec change in https://github.com/tempoxyz/payment-auth-spec/pull/101

## Changes
- Remove `ReceiptStatus::Failed` enum variant
- Remove `Receipt::failed()` constructor and `is_failed()` method  
- Remove the `is_failed()` check in verify handler (now unreachable)
- Remove related tests

Receipts can now only have `success` status. Transaction failures now return 402 directly via `VerificationError::transaction_failed()`.