### PR TITLE
feat: add GitHub Releases workflow for tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,23 @@
+# This crate is distributed via GitHub Releases rather than crates.io because
+# it depends on tempo-alloy and tempo-primitives, which are not published to
+# crates.io (they live in the tempoxyz/tempo repo as git dependencies).
+#
+# Users consume this crate via git dependency in their Cargo.toml:
+#   mpay = { git = "https://github.com/tempoxyz/mpay-rs", tag = "v0.2.1", features = ["tempo", "client"] }
+
 name: Release
 on:
   push:
+    tags: ["v*"]
     branches:
       - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  release:
-    name: Version
+  changelog:
+    name: Changelog
+    if: github.ref_type == 'branch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,5 +27,29 @@ jobs:
         uses: wevm/changelogs-rs@changelogs@0.6.0
         with:
           conventional-commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build
+        run: cargo build --release --all-features
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,22 +2,23 @@
 # it depends on tempo-alloy and tempo-primitives, which are not published to
 # crates.io (they live in the tempoxyz/tempo repo as git dependencies).
 #
+# GitHub Releases are created automatically by changelogs-rs when a "Version
+# Packages" PR is merged.
+#
 # Users consume this crate via git dependency in their Cargo.toml:
 #   mpay = { git = "https://github.com/tempoxyz/mpay-rs", tag = "v0.2.1", features = ["tempo", "client"] }
 
 name: Release
 on:
   push:
-    tags: ["v*"]
     branches:
       - main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  changelog:
-    name: Changelog
-    if: github.ref_type == 'branch'
+  release:
+    name: Version
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,29 +28,5 @@ jobs:
         uses: wevm/changelogs-rs@changelogs@0.6.0
         with:
           conventional-commit: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release:
-    name: Release
-    if: github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Build
-        run: cargo build --release --all-features
-
-      - name: Test
-        run: cargo test --all-features
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a comment to the release workflow explaining why this crate is distributed via GitHub Releases instead of crates.io: `tempo-alloy` and `tempo-primitives` are git dependencies from `tempoxyz/tempo` and not published to crates.io.

No functional changes — `changelogs-rs` already handles creating GitHub Releases when RC PRs merge.