### PR TITLE
perf: use eth_sendRawTransactionSync to eliminate redundant RPC calls

### DIFF
--- a/.changelog/old-rocks-fold.md
+++ b/.changelog/old-rocks-fold.md
@@ -1,0 +1,5 @@
+---
+mpay: patch
+---
+
+Refactored transaction verification to use `eth_sendRawTransactionSync` instead of separate broadcast and receipt fetch operations, eliminating redundant RPC calls and improving performance.

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -27,6 +27,7 @@ use alloy::network::ReceiptResponse;
 use alloy::primitives::{hex, Address, Bytes, TxKind, B256, U256};
 use alloy::providers::Provider;
 use alloy::rlp::Decodable as _;
+use std::borrow::Cow;
 use std::future::Future;
 use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
@@ -148,6 +149,15 @@ where
                 ))
             })?;
 
+        self.verify_receipt(&receipt, tx_hash, charge)
+    }
+
+    fn verify_receipt(
+        &self,
+        receipt: &<TempoNetwork as alloy::network::Network>::ReceiptResponse,
+        tx_hash: &str,
+        charge: &ChargeRequest,
+    ) -> Result<Receipt, VerificationError> {
         if !receipt.status() {
             return Err(VerificationError::transaction_failed(format!(
                 "Transaction {} reverted",
@@ -166,9 +176,8 @@ where
         })?;
         let memo = charge.memo();
 
-        // Tempo uses TIP-20 tokens exclusively (no native token transfers)
         self.verify_tip20_transfer(
-            &receipt,
+            receipt,
             currency,
             expected_recipient,
             expected_amount,
@@ -475,7 +484,7 @@ where
         signed_tx: &str,
         charge: &ChargeRequest,
         expected_chain_id: u64,
-    ) -> Result<B256, VerificationError> {
+    ) -> Result<Receipt, VerificationError> {
         let tx_bytes = signed_tx
             .parse::<Bytes>()
             .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {}", e)))?;
@@ -510,25 +519,15 @@ where
             ));
         }
 
-        let pending = self
+        let canonical_tx = format!("0x{}", hex::encode(&tx_bytes));
+        let receipt: <TempoNetwork as alloy::network::Network>::ReceiptResponse = self
             .provider
-            .send_raw_transaction(&tx_bytes)
+            .raw_request(Cow::Borrowed("eth_sendRawTransactionSync"), (canonical_tx,))
             .await
             .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
 
-        // Wait for transaction to be mined
-        let receipt = pending.get_receipt().await.map_err(|e| {
-            VerificationError::network_error(format!("Failed to get receipt: {}", e))
-        })?;
-
-        if !receipt.status() {
-            return Err(VerificationError::transaction_failed(format!(
-                "Transaction {} reverted",
-                receipt.transaction_hash()
-            )));
-        }
-
-        Ok(receipt.transaction_hash())
+        let tx_hash = format!("{:#x}", receipt.transaction_hash());
+        self.verify_receipt(&receipt, &tx_hash, charge)
     }
 }
 
@@ -586,15 +585,14 @@ where
                 this.verify_hash(credential.payload.tx_hash().unwrap(), &request)
                     .await
             } else {
-                // Client sent signed transaction, validate and broadcast it
-                let tx_hash = this
-                    .broadcast_transaction(
-                        credential.payload.signed_tx().unwrap(),
-                        &request,
-                        expected_chain_id,
-                    )
-                    .await?;
-                this.verify_hash(&format!("{:#x}", tx_hash), &request).await
+                // Client sent signed transaction, broadcast via eth_sendRawTransactionSync
+                // which returns the receipt directly, avoiding extra RPC round-trips
+                this.broadcast_transaction(
+                    credential.payload.signed_tx().unwrap(),
+                    &request,
+                    expected_chain_id,
+                )
+                .await
             }
         }
     }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -601,6 +601,235 @@ where
 #[cfg(test)]
 mod tests {
     use super::{super::MODERATO_CHAIN_ID, *};
+    use tempo_alloy::rpc::TempoTransactionReceipt;
+
+    const CURRENCY: &str = "0x20c0000000000000000000000000000000000001";
+    const RECIPIENT: &str = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77";
+    const TX_HASH: &str = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn test_charge(amount: &str) -> ChargeRequest {
+        ChargeRequest {
+            amount: amount.to_string(),
+            currency: CURRENCY.to_string(),
+            recipient: Some(RECIPIENT.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn test_charge_with_memo(amount: &str, memo: &str) -> ChargeRequest {
+        ChargeRequest {
+            amount: amount.to_string(),
+            currency: CURRENCY.to_string(),
+            recipient: Some(RECIPIENT.to_string()),
+            method_details: Some(serde_json::json!({ "memo": memo })),
+            ..Default::default()
+        }
+    }
+
+    fn make_receipt(status: bool, logs: serde_json::Value) -> TempoTransactionReceipt {
+        let receipt_json = serde_json::json!({
+            "transactionHash": TX_HASH,
+            "transactionIndex": "0x0",
+            "blockHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "blockNumber": "0x1",
+            "from": "0x0000000000000000000000000000000000000001",
+            "to": CURRENCY,
+            "cumulativeGasUsed": "0x5208",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x3b9aca00",
+            "logs": logs,
+            "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            "status": if status { "0x1" } else { "0x0" },
+            "type": "0x76",
+            "feePayer": "0x0000000000000000000000000000000000000001"
+        });
+        serde_json::from_value(receipt_json).expect("valid receipt JSON")
+    }
+
+    fn transfer_log(currency: &str, from: &str, to: &str, amount_hex: &str) -> serde_json::Value {
+        let from_topic = format!("0x000000000000000000000000{}", &from[2..]);
+        let to_topic = format!("0x000000000000000000000000{}", &to[2..]);
+        serde_json::json!({
+            "address": currency,
+            "topics": [
+                format!("0x{}", hex::encode(TRANSFER_EVENT_TOPIC)),
+                from_topic,
+                to_topic
+            ],
+            "data": format!("0x{}", amount_hex),
+            "blockNumber": "0x1",
+            "transactionHash": TX_HASH,
+            "transactionIndex": "0x0",
+            "blockHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "logIndex": "0x0",
+            "removed": false
+        })
+    }
+
+    fn transfer_with_memo_log(
+        currency: &str,
+        from: &str,
+        to: &str,
+        amount_hex: &str,
+        memo_hex: &str,
+    ) -> serde_json::Value {
+        let from_topic = format!("0x000000000000000000000000{}", &from[2..]);
+        let to_topic = format!("0x000000000000000000000000{}", &to[2..]);
+        serde_json::json!({
+            "address": currency,
+            "topics": [
+                format!("0x{}", hex::encode(TRANSFER_WITH_MEMO_EVENT_TOPIC)),
+                from_topic,
+                to_topic
+            ],
+            "data": format!("0x{}{}", amount_hex, memo_hex),
+            "blockNumber": "0x1",
+            "transactionHash": TX_HASH,
+            "transactionIndex": "0x0",
+            "blockHash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "logIndex": "0x0",
+            "removed": false
+        })
+    }
+
+    fn dummy_charge_method() -> ChargeMethod<crate::server::TempoProvider> {
+        let provider = crate::server::tempo_provider("http://localhost:1234").unwrap();
+        ChargeMethod::new(provider)
+    }
+
+    #[test]
+    fn test_verify_receipt_success() {
+        let method = dummy_charge_method();
+        let amount_hex = "00000000000000000000000000000000000000000000000000000000000f4240"; // 1000000
+        let log = transfer_log(
+            CURRENCY,
+            "0x0000000000000000000000000000000000000001",
+            RECIPIENT,
+            amount_hex,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert!(r.is_success());
+        assert_eq!(r.reference, TX_HASH);
+    }
+
+    #[test]
+    fn test_verify_receipt_reverted() {
+        let method = dummy_charge_method();
+        let receipt = make_receipt(false, serde_json::json!([]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("reverted"));
+    }
+
+    #[test]
+    fn test_verify_receipt_no_matching_transfer() {
+        let method = dummy_charge_method();
+        let receipt = make_receipt(true, serde_json::json!([]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("No matching Transfer"));
+    }
+
+    #[test]
+    fn test_verify_receipt_wrong_amount() {
+        let method = dummy_charge_method();
+        let amount_hex = "0000000000000000000000000000000000000000000000000000000000000001"; // 1 (wrong)
+        let log = transfer_log(
+            CURRENCY,
+            "0x0000000000000000000000000000000000000001",
+            RECIPIENT,
+            amount_hex,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_receipt_wrong_recipient() {
+        let method = dummy_charge_method();
+        let amount_hex = "00000000000000000000000000000000000000000000000000000000000f4240";
+        let log = transfer_log(
+            CURRENCY,
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000099", // wrong recipient
+            amount_hex,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_receipt_wrong_currency() {
+        let method = dummy_charge_method();
+        let amount_hex = "00000000000000000000000000000000000000000000000000000000000f4240";
+        let log = transfer_log(
+            "0x0000000000000000000000000000000000000099", // wrong currency
+            "0x0000000000000000000000000000000000000001",
+            RECIPIENT,
+            amount_hex,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge("1000000");
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_receipt_with_memo_success() {
+        let method = dummy_charge_method();
+        let memo_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let amount_hex = "00000000000000000000000000000000000000000000000000000000000f4240";
+        let log = transfer_with_memo_log(
+            CURRENCY,
+            "0x0000000000000000000000000000000000000001",
+            RECIPIENT,
+            amount_hex,
+            memo_hex,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge_with_memo("1000000", &format!("0x{}", memo_hex));
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_receipt_with_memo_wrong_memo() {
+        let method = dummy_charge_method();
+        let memo_hex = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef";
+        let wrong_memo = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let amount_hex = "00000000000000000000000000000000000000000000000000000000000f4240";
+        let log = transfer_with_memo_log(
+            CURRENCY,
+            "0x0000000000000000000000000000000000000001",
+            RECIPIENT,
+            amount_hex,
+            wrong_memo,
+        );
+        let receipt = make_receipt(true, serde_json::json!([log]));
+        let charge = test_charge_with_memo("1000000", &format!("0x{}", memo_hex));
+
+        let result = method.verify_receipt(&receipt, TX_HASH, &charge);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_transfer_selector() {


### PR DESCRIPTION
## Summary
Use `eth_sendRawTransactionSync` instead of `send_raw_transaction` + polling for receipt, cutting the broadcast path from 3 RPCs down to 1.

## Motivation
The old flow did:
1. `eth_sendRawTransaction` — broadcast
2. `eth_getTransactionReceipt` — wait for mining (inside `pending.get_receipt()`)
3. `eth_getTransactionReceipt` — re-fetch in `verify_hash()` to validate transfer events

Tempo supports `eth_sendRawTransactionSync` which blocks until the tx is mined and returns the receipt directly.

## Changes
- `broadcast_transaction()` now calls `eth_sendRawTransactionSync` via `raw_request` and returns a verified `Receipt`
- Extracted `verify_receipt()` from `verify_hash()` so receipt validation can be reused without re-fetching
- Canonicalize tx bytes to 0x-hex before sending to avoid encoding mismatches
- `verify()` no longer calls `verify_hash()` after broadcast since the receipt is already validated

## Testing
`make check` — fmt, clippy, 57 unit tests, build all pass.

Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1770519297307799