### PR TITLE
refactor: switch payment token from AlphaUSD to PathUSD

### DIFF
--- a/.changelog/vast-frogs-wink.md
+++ b/.changelog/vast-frogs-wink.md
@@ -1,0 +1,5 @@
+---
+mpay: patch
+---
+
+Updated currency address from AlphaUSD to PathUSD across all examples, documentation, and tests.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ use mpay::ChargeRequest;
 
 let request = ChargeRequest {
     amount: "1000000".into(),
-    currency: "0x20c0000000000000000000000000000000000001".into(),
+    currency: "0x20c0000000000000000000000000000000000000".into(),
     recipient: Some("0x742d35Cc...".into()),
     expires: Some("2025-01-15T12:00:00Z".into()),
     ..Default::default()

--- a/examples/axum-server.md
+++ b/examples/axum-server.md
@@ -28,7 +28,7 @@ use std::sync::Arc;
 // Create payment handler at startup
 let mpay = Arc::new(Mpay::create(
     tempo(TempoConfig {
-        currency: "0x20c0000000000000000000000000000000000001",
+        currency: "0x20c0000000000000000000000000000000000000",
         recipient: "0xabc...123",
     })
     .rpc_url("https://rpc.moderato.tempo.xyz")

--- a/examples/custom-methods.md
+++ b/examples/custom-methods.md
@@ -256,7 +256,7 @@ assert_eq!(method.method(), "tempo");
 // In your server handler:
 let request = ChargeRequest {
     amount: "1000000".into(),
-    currency: "0x20c0000000000000000000000000000000000001".into(),
+    currency: "0x20c0000000000000000000000000000000000000".into(),
     recipient: Some("0x742d35Cc...".into()),
     ..Default::default()
 };

--- a/examples/server/src/main.rs
+++ b/examples/server/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
 
     let payment = Mpay::create(
         tempo(TempoConfig {
-            currency: "0x20c0000000000000000000000000000000000001",
+            currency: "0x20c0000000000000000000000000000000000000",
             recipient: &merchant_address,
         })
         .rpc_url(RPC_URL)

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -28,7 +28,7 @@
 //!     "my-server-secret",
 //!     "api.example.com",
 //!     "1000000",
-//!     "0x20c0000000000000000000000000000000000001",
+//!     "0x20c0000000000000000000000000000000000000",
 //!     "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
 //! ).unwrap();
 //!
@@ -36,7 +36,7 @@
 //! use mpay::protocol::intents::ChargeRequest;
 //! let request = ChargeRequest {
 //!     amount: "1000000".into(),
-//!     currency: "0x20c0000000000000000000000000000000000001".into(),
+//!     currency: "0x20c0000000000000000000000000000000000000".into(),
 //!     recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
 //!     method_details: Some(serde_json::json!({"feePayer": true})),
 //!     ..Default::default()
@@ -154,7 +154,7 @@ pub const INTENT_CHARGE: &str = "charge";
 ///     "my-server-secret",
 ///     "api.example.com",
 ///     "1000000",
-///     "0x20c0000000000000000000000000000000000001",
+///     "0x20c0000000000000000000000000000000000000",
 ///     "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
 /// ).unwrap();
 ///
@@ -203,7 +203,7 @@ pub fn charge_challenge(
 ///
 /// let request = ChargeRequest {
 ///     amount: "1000000".into(),
-///     currency: "0x20c0000000000000000000000000000000000001".into(),
+///     currency: "0x20c0000000000000000000000000000000000000".into(),
 ///     recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
 ///     method_details: Some(serde_json::json!({"feePayer": true})),
 ///     ..Default::default()
@@ -363,7 +363,7 @@ pub fn generate_challenge_id(
 ///     "charge",
 ///     &json!({
 ///         "amount": "1000000",
-///         "currency": "0x20c0000000000000000000000000000000000001",
+///         "currency": "0x20c0000000000000000000000000000000000000",
 ///         "recipient": "0x1234567890abcdef1234567890abcdef12345678"
 ///     }),
 ///     None,
@@ -418,7 +418,7 @@ mod tests {
 
         let request = ChargeRequest {
             amount: "1000000".into(),
-            currency: "0x20c0000000000000000000000000000000000001".into(),
+            currency: "0x20c0000000000000000000000000000000000000".into(),
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             ..Default::default()
         };
@@ -453,7 +453,7 @@ mod tests {
             TEST_SECRET,
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -470,7 +470,7 @@ mod tests {
             TEST_SECRET,
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -479,7 +479,7 @@ mod tests {
             TEST_SECRET,
             "api.example.com",
             "2000000", // Different amount
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -496,7 +496,7 @@ mod tests {
             TEST_SECRET,
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -505,7 +505,7 @@ mod tests {
             TEST_SECRET,
             "api.other.com", // Different realm
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -522,7 +522,7 @@ mod tests {
             TEST_SECRET,
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -548,7 +548,7 @@ mod tests {
             "secret-one",
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -557,7 +557,7 @@ mod tests {
             "secret-two", // Different secret
             "api.example.com",
             "1000000",
-            "0x20c0000000000000000000000000000000000001",
+            "0x20c0000000000000000000000000000000000000",
             "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
         )
         .unwrap();
@@ -584,7 +584,7 @@ mod tests {
                 "charge",
                 &json!({
                     "amount": "1000000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
+                    "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0x1234567890abcdef1234567890abcdef12345678"
                 }),
                 None,
@@ -604,7 +604,7 @@ mod tests {
                 "charge",
                 &json!({
                     "amount": "5000000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
+                    "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0xabcdef1234567890abcdef1234567890abcdef12"
                 }),
                 Some("2026-01-29T12:00:00Z"),
@@ -644,7 +644,7 @@ mod tests {
                 "charge",
                 &json!({
                     "amount": "10000000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
+                    "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
                     "description": "API access fee",
                     "externalId": "order-12345"
@@ -666,7 +666,7 @@ mod tests {
                 "charge",
                 &json!({
                     "amount": "1000000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
+                    "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0x1234567890abcdef1234567890abcdef12345678"
                 }),
                 None,
@@ -723,7 +723,7 @@ mod tests {
                 "charge",
                 &json!({
                     "amount": "5000000",
-                    "currency": "0x20c0000000000000000000000000000000000001",
+                    "currency": "0x20c0000000000000000000000000000000000000",
                     "recipient": "0x2222222222222222222222222222222222222222",
                     "methodDetails": {
                         "chainId": 42431,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,7 +6,7 @@
 //! use mpay::server::{Mpay, tempo, TempoConfig};
 //!
 //! let mpay = Mpay::create(tempo(TempoConfig {
-//!     currency: "0x20c0000000000000000000000000000000000001",
+//!     currency: "0x20c0000000000000000000000000000000000000",
 //!     recipient: "0xabc...123",
 //! }))?;
 //!
@@ -128,14 +128,14 @@ pub struct ChargeOptions<'a> {
 ///
 /// // Minimal
 /// let mpay = Mpay::create(tempo(TempoConfig {
-///     currency: "0x20c0000000000000000000000000000000000001",
+///     currency: "0x20c0000000000000000000000000000000000000",
 ///     recipient: "0xabc...123",
 /// }))?;
 ///
 /// // With overrides
 /// let mpay = Mpay::create(
 ///     tempo(TempoConfig {
-///         currency: "0x20c0000000000000000000000000000000000001",
+///         currency: "0x20c0000000000000000000000000000000000000",
 ///         recipient: "0xabc...123",
 ///     })
 ///     .rpc_url("https://rpc.moderato.tempo.xyz")

--- a/src/server/mpay.rs
+++ b/src/server/mpay.rs
@@ -9,7 +9,7 @@
 //! use mpay::server::{Mpay, tempo};
 //!
 //! let mpay = Mpay::create(tempo(mpay::server::TempoConfig {
-//!     currency: "0x20c0000000000000000000000000000000000001",
+//!     currency: "0x20c0000000000000000000000000000000000000",
 //!     recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
 //! }))?;
 //!
@@ -38,7 +38,7 @@ const DEFAULT_DECIMALS: u32 = 6;
 /// use mpay::server::{Mpay, tempo, TempoConfig};
 ///
 /// let mpay = Mpay::create(tempo(TempoConfig {
-///     currency: "0x20c0000000000000000000000000000000000001",
+///     currency: "0x20c0000000000000000000000000000000000000",
 ///     recipient: "0xabc...123",
 /// }))?;
 ///
@@ -275,7 +275,7 @@ impl Mpay<super::TempoChargeMethod<super::TempoProvider>> {
     /// use mpay::server::{Mpay, tempo, TempoConfig};
     ///
     /// let mpay = Mpay::create(tempo(TempoConfig {
-    ///     currency: "0x20c0000000000000000000000000000000000001",
+    ///     currency: "0x20c0000000000000000000000000000000000000",
     ///     recipient: "0xabc...123",
     /// }))?;
     ///
@@ -421,7 +421,7 @@ mod tests {
         let challenge = payment
             .charge_challenge(
                 "1000000",
-                "0x20c0000000000000000000000000000000000001",
+                "0x20c0000000000000000000000000000000000000",
                 "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
             )
             .unwrap();
@@ -471,7 +471,7 @@ mod tests {
     fn create_test_mpay() -> Mpay<crate::server::TempoChargeMethod<crate::server::TempoProvider>> {
         Mpay::create(
             tempo(TempoConfig {
-                currency: "0x20c0000000000000000000000000000000000001",
+                currency: "0x20c0000000000000000000000000000000000000",
                 recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
             })
             .secret_key("test-secret"),
@@ -486,7 +486,7 @@ mod tests {
         assert_eq!(mpay.realm(), "MPP Payment");
         assert_eq!(
             mpay.currency(),
-            Some("0x20c0000000000000000000000000000000000001")
+            Some("0x20c0000000000000000000000000000000000000")
         );
         assert_eq!(
             mpay.recipient(),
@@ -509,7 +509,7 @@ mod tests {
         assert_eq!(request.amount, "100000");
         assert_eq!(
             request.currency,
-            "0x20c0000000000000000000000000000000000001"
+            "0x20c0000000000000000000000000000000000000"
         );
         assert_eq!(
             request.recipient,
@@ -546,7 +546,7 @@ mod tests {
     async fn test_verify_credential_decodes_request() {
         let request = ChargeRequest {
             amount: "500000".into(),
-            currency: "0x20c0000000000000000000000000000000000001".into(),
+            currency: "0x20c0000000000000000000000000000000000000".into(),
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             ..Default::default()
         };


### PR DESCRIPTION
## Summary
Switch all payment defaults from AlphaUSD (`0x20c0...0001`) to PathUSD (`0x20c0...0000`). AlphaUSD was a testnet-only fake coin.

## Changes (7 files)
- `src/protocol/methods/tempo/mod.rs` — doc comments + test fixtures
- `src/server/mpay.rs`, `src/server/mod.rs` — doc comments + test fixtures
- `README.md`, `examples/` — updated addresses

## Testing
`cargo check` passes.