### PR TITLE
feat: update description, pluggable SSE stream, axum middleware

### DIFF
--- a/.changelog/plain-pandas-shout.md
+++ b/.changelog/plain-pandas-shout.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added Axum middleware support with extractors and response types, updated library description to "402 Protocol", and made SSE stream pluggable by returning a `Stream` instead of `Receiver`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpp"
 version = "0.2.1"
 edition = "2021"
-description = "Machine Payment Protocol - Rust library for Web Payment Auth"
+description = "Rust implementation of the \"Payment\" HTTP Authentication Scheme (402 Protocol)."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tempoxyz/mpp-rs"
 homepage = "https://github.com/tempoxyz/mpp-rs"
@@ -16,7 +16,7 @@ default = []
 
 # Side selection
 client = ["reqwest"]
-server = ["tokio", "futures-core"]
+server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
 evm = ["alloy", "alloy-signer-local", "hex", "rand"]
@@ -30,6 +30,9 @@ middleware = ["client", "reqwest-middleware", "async-trait", "anyhow", "http-typ
 
 # Tower middleware support (server-side)
 tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", "server"]
+
+# Axum middleware support (server-side convenience)
+axum = ["dep:axum-core", "dep:axum", "tower"]
 
 [dependencies]
 # Core dependencies (always included)
@@ -48,6 +51,7 @@ rand = { version = "0.9", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
+async-stream = { version = "0.3", optional = true }
 alloy = { version = "1.2", features = ["full"], optional = true }
 alloy-signer-local = { version = "1.2", optional = true }
 
@@ -70,6 +74,10 @@ http-types = { package = "http", version = "1", optional = true }
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 http-body = { version = "1", optional = true }
+
+# Axum dependencies (optional)
+axum-core = { version = "0.5", optional = true }
+axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ middleware = ["client", "reqwest-middleware", "async-trait", "anyhow", "http-typ
 tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", "server"]
 
 # Axum middleware support (server-side convenience)
-axum = ["dep:axum-core", "dep:axum", "server", "http-types"]
+axum = ["dep:axum-core", "server", "http-types"]
 
 [dependencies]
 # Core dependencies (always included)
@@ -77,7 +77,6 @@ http-body = { version = "1", optional = true }
 
 # Axum dependencies (optional)
 axum-core = { version = "0.5", optional = true }
-axum = { version = "0.8", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mpp"
 version = "0.2.1"
 edition = "2021"
-description = "Rust implementation of the \"Payment\" HTTP Authentication Scheme (402 Protocol)."
+description = "Rust SDK for the Machine Payments Protocol (MPP)"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tempoxyz/mpp-rs"
 homepage = "https://github.com/tempoxyz/mpp-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ middleware = ["client", "reqwest-middleware", "async-trait", "anyhow", "http-typ
 tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", "server"]
 
 # Axum middleware support (server-side convenience)
-axum = ["dep:axum-core", "dep:axum", "tower"]
+axum = ["dep:axum-core", "dep:axum", "server", "http-types"]
 
 [dependencies]
 # Core dependencies (always included)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Both support a `decimals` field for human-readable amounts (e.g., `"1.5"` with `
 use mpp::server::{Mpp, tempo, TempoConfig};
 
 let mpp = Mpp::create(tempo(TempoConfig {
-    currency: "0x20c0000000000000000000000000000000000000",
     recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+    currency: None, // defaults to pathUSD
 }))?;
 
 let challenge = mpp.charge("1")?;

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ use mpp::server::{Mpp, tempo, TempoConfig};
 
 let mpp = Mpp::create(tempo(TempoConfig {
     recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
-    currency: None, // defaults to pathUSD
 }))?;
 
 let challenge = mpp.charge("1")?;

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Standalone, runnable examples demonstrating the mpp HTTP 402 payment flow.
 | Example | Description |
 |---------|-------------|
 | [basic](./basic/) | Payment-gated Fortune Teller API |
+| [axum-extractor](./axum-extractor/) | Axum extractors with per-route pricing (`MppCharge`, `MppChargeFor`) |
 | [session/multi-fetch](./session/multi-fetch/) | Multiple paid requests over a single payment channel |
 | [session/sse](./session/sse/) | Pay-per-token LLM streaming with SSE |
 
@@ -19,6 +20,11 @@ Each example is a standalone Cargo crate with a server and client binary.
 cd examples/basic
 cargo run --bin basic-server   # Terminal 1
 cargo run --bin basic-client   # Terminal 2
+
+# Axum extractor (per-route pricing)
+cd examples/axum-extractor
+cargo run --bin axum-server    # Terminal 1
+cargo run --bin axum-client    # Terminal 2
 
 # Session multi-fetch
 cd examples/session/multi-fetch

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@ Standalone, runnable examples demonstrating the mpp HTTP 402 payment flow.
 | Example | Description |
 |---------|-------------|
 | [basic](./basic/) | Payment-gated Fortune Teller API |
-| [axum-extractor](./axum-extractor/) | Axum extractors with per-route pricing (`MppCharge`, `MppChargeFor`) |
+| [axum-extractor](./axum-extractor/) | Axum extractors with per-route pricing (`MppCharge<C>`) |
 | [session/multi-fetch](./session/multi-fetch/) | Multiple paid requests over a single payment channel |
 | [session/sse](./session/sse/) | Pay-per-token LLM streaming with SSE |
 

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "axum-extractor-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "axum-server"
+path = "src/server.rs"
+
+[[bin]]
+name = "axum-client"
+path = "src/client.rs"
+
+[dependencies]
+mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
+alloy = { version = "1.2", features = ["provider-http"] }
+tempo-alloy = "1"
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1"
+hex = "0.4"
+rand = "0.9"
+
+[patch.crates-io]
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/axum-extractor/README.md
+++ b/examples/axum-extractor/README.md
@@ -1,0 +1,65 @@
+# Axum Extractor
+
+Demonstrates payment-gated endpoints using mpp's axum extractors (`MppCharge` and `MppChargeFor`).
+
+The server exposes three endpoints:
+
+- `GET /api/health` — Free, returns `{"status": "ok"}`
+- `GET /api/fortune` — Costs $0.01 (default `MppCharge` extractor)
+- `GET /api/premium` — Costs $1.00 (custom `MppChargeFor<OneDollar>` extractor)
+
+The extractors handle the full 402 Payment Required flow automatically — no manual header parsing needed.
+
+## Running
+
+### 1. Start the server
+
+```bash
+cd examples/axum-extractor
+cargo run --bin axum-server
+```
+
+The server listens on `http://localhost:3000`.
+
+### 2. Run the client
+
+In another terminal:
+
+```bash
+cd examples/axum-extractor
+cargo run --bin axum-client
+```
+
+The client fetches both the cheap and premium fortune, handling 402 challenges automatically.
+
+## Per-route pricing
+
+The key pattern for per-route pricing:
+
+```rust
+use mpp::server::axum::{ChargeAmount, MppCharge, MppChargeFor, WithReceipt};
+
+// Define a custom price
+struct OneDollar;
+impl ChargeAmount for OneDollar {
+    fn amount() -> &'static str { "1.00" }
+}
+
+// Default $0.01
+async fn cheap(charge: MppCharge) -> WithReceipt<&'static str> {
+    WithReceipt { receipt: charge.receipt, body: "cheap" }
+}
+
+// Custom $1.00
+async fn expensive(charge: MppChargeFor<OneDollar>) -> WithReceipt<&'static str> {
+    WithReceipt { receipt: charge.receipt, body: "premium" }
+}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PRIVATE_KEY` | Random | Client's private key (hex, with or without `0x` prefix) |
+| `BASE_URL` | `http://localhost:3000` | Client's base URL for the server |
+| `RPC_URL` | `https://rpc.moderato.tempo.xyz` | Tempo RPC endpoint |

--- a/examples/axum-extractor/README.md
+++ b/examples/axum-extractor/README.md
@@ -1,12 +1,12 @@
 # Axum Extractor
 
-Demonstrates payment-gated endpoints using mpp's axum extractors (`MppCharge` and `MppChargeFor`).
+Demonstrates payment-gated endpoints using mpp's axum `MppCharge<C>` extractor.
 
 The server exposes three endpoints:
 
 - `GET /api/health` — Free, returns `{"status": "ok"}`
-- `GET /api/fortune` — Costs $0.01 (default `MppCharge` extractor)
-- `GET /api/premium` — Costs $1.00 (custom `MppChargeFor<OneDollar>` extractor)
+- `GET /api/fortune` — Costs $0.01 (`MppCharge<OneCent>`)
+- `GET /api/premium` — Costs $1.00 (`MppCharge<OneDollar>`)
 
 The extractors handle the full 402 Payment Required flow automatically — no manual header parsing needed.
 
@@ -34,24 +34,27 @@ The client fetches both the cheap and premium fortune, handling 402 challenges a
 
 ## Per-route pricing
 
-The key pattern for per-route pricing:
+Define a `ChargeConfig` for each price point:
 
 ```rust
-use mpp::server::axum::{ChargeAmount, MppCharge, MppChargeFor, WithReceipt};
+use mpp::server::axum::{ChargeConfig, MppCharge, WithReceipt};
 
-// Define a custom price
-struct OneDollar;
-impl ChargeAmount for OneDollar {
-    fn amount() -> &'static str { "1.00" }
+struct OneCent;
+impl ChargeConfig for OneCent {
+    fn amount() -> &'static str { "0.01" }
 }
 
-// Default $0.01
-async fn cheap(charge: MppCharge) -> WithReceipt<&'static str> {
+struct OneDollar;
+impl ChargeConfig for OneDollar {
+    fn amount() -> &'static str { "1.00" }
+    fn description() -> Option<&'static str> { Some("Premium content") }
+}
+
+async fn cheap(charge: MppCharge<OneCent>) -> WithReceipt<&'static str> {
     WithReceipt { receipt: charge.receipt, body: "cheap" }
 }
 
-// Custom $1.00
-async fn expensive(charge: MppChargeFor<OneDollar>) -> WithReceipt<&'static str> {
+async fn expensive(charge: MppCharge<OneDollar>) -> WithReceipt<&'static str> {
     WithReceipt { receipt: charge.receipt, body: "premium" }
 }
 ```

--- a/examples/axum-extractor/src/client.rs
+++ b/examples/axum-extractor/src/client.rs
@@ -1,0 +1,96 @@
+//! # Axum Extractor Example — Client
+//!
+//! Fetches fortunes from the axum-extractor server, demonstrating
+//! automatic 402 payment handling at two price points.
+//!
+//! ## Running
+//!
+//! ```bash
+//! # First start the server:
+//! cargo run --bin axum-server
+//!
+//! # Then in another terminal:
+//! cargo run --bin axum-client
+//! ```
+
+use alloy::primitives::B256;
+use alloy::providers::{Provider, ProviderBuilder};
+use mpp::client::{Fetch, TempoProvider};
+use mpp::{parse_receipt, PrivateKeySigner};
+use reqwest::Client;
+use tempo_alloy::TempoNetwork;
+
+#[tokio::main]
+async fn main() {
+    let signer = match std::env::var("PRIVATE_KEY") {
+        Ok(key) => {
+            let bytes = hex::decode(key.strip_prefix("0x").unwrap_or(&key))
+                .expect("invalid PRIVATE_KEY hex");
+            PrivateKeySigner::from_slice(&bytes).expect("invalid private key")
+        }
+        Err(_) => {
+            let signer = PrivateKeySigner::random();
+            println!("Generated wallet: {}", signer.address());
+            signer
+        }
+    };
+
+    let rpc_url = std::env::var("RPC_URL")
+        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+
+    // Fund via testnet faucet.
+    println!("Funding account via faucet...");
+    let rpc_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(rpc_url.parse().unwrap());
+    let _: Vec<B256> = rpc_provider
+        .raw_request("tempo_fundAddress".into(), (signer.address(),))
+        .await
+        .expect("faucet funding failed");
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let provider =
+        TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
+
+    let base_url =
+        std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let client = Client::new();
+
+    // 1. Cheap fortune ($0.01)
+    println!("\n--- Fetching $0.01 fortune ---");
+    fetch_fortune(&client, &provider, &format!("{base_url}/api/fortune")).await;
+
+    // 2. Premium fortune ($1.00)
+    println!("\n--- Fetching $1.00 premium fortune ---");
+    fetch_fortune(&client, &provider, &format!("{base_url}/api/premium")).await;
+}
+
+async fn fetch_fortune(client: &Client, provider: &TempoProvider, url: &str) {
+    println!("GET {url}");
+
+    let resp = client
+        .get(url)
+        .send_with_payment(provider)
+        .await
+        .expect("request failed");
+
+    println!("Status: {}", resp.status());
+
+    if let Some(receipt_hdr) = resp.headers().get("payment-receipt") {
+        if let Ok(receipt_str) = receipt_hdr.to_str() {
+            if let Ok(receipt) = parse_receipt(receipt_str) {
+                println!(
+                    "Payment tx: https://explore.moderato.tempo.xyz/tx/{}",
+                    receipt.reference
+                );
+            }
+        }
+    }
+
+    let body: serde_json::Value = resp.json().await.expect("failed to parse response");
+
+    if let Some(fortune) = body.get("fortune").and_then(|v| v.as_str()) {
+        println!("Fortune: {fortune}");
+    } else {
+        println!("Response: {body}");
+    }
+}

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -3,8 +3,8 @@
 //! Demonstrates payment-gated endpoints using mpp's axum extractors.
 //!
 //! - `/api/health` — Free health check
-//! - `/api/fortune` — $0.01 (default `MppCharge`)
-//! - `/api/premium` — $1.00 (custom `MppChargeFor<OneDollar>`)
+//! - `/api/fortune` — $0.01 (`MppCharge<OneCent>`)
+//! - `/api/premium` — $1.00 (`MppCharge<OneDollar>`)
 //!
 //! ## Running
 //!
@@ -17,7 +17,7 @@
 use axum::{routing::get, Json, Router};
 use alloy::primitives::B256;
 use alloy::providers::{Provider, ProviderBuilder};
-use mpp::server::axum::{ChargeAmount, ChargeChallenger, MppCharge, MppChargeFor, WithReceipt};
+use mpp::server::axum::{ChargeChallenger, ChargeConfig, MppCharge, WithReceipt};
 use mpp::server::{tempo, Mpp, TempoConfig};
 use mpp::PrivateKeySigner;
 use rand::seq::IndexedRandom;
@@ -47,13 +47,22 @@ const PREMIUM_FORTUNES: &[&str] = &[
     "The answer you seek is already within you. Trust your instincts.",
 ];
 
-// -- Per-route pricing via ChargeAmount trait --
+struct OneCent;
+
+impl ChargeConfig for OneCent {
+    fn amount() -> &'static str {
+        "0.01"
+    }
+}
 
 struct OneDollar;
 
-impl ChargeAmount for OneDollar {
+impl ChargeConfig for OneDollar {
     fn amount() -> &'static str {
         "1.00"
+    }
+    fn description() -> Option<&'static str> {
+        Some("Premium fortune reading")
     }
 }
 
@@ -86,7 +95,6 @@ async fn main() {
     )
     .expect("failed to create payment handler");
 
-    // Cast to Arc<dyn ChargeChallenger> for the axum extractors.
     let state: Arc<dyn ChargeChallenger> = Arc::new(mpp);
 
     let app = Router::new()
@@ -101,8 +109,8 @@ async fn main() {
 
     println!("Axum Extractor Example listening on http://localhost:3000");
     println!("  GET /api/health   — free");
-    println!("  GET /api/fortune  — $0.01 (MppCharge)");
-    println!("  GET /api/premium  — $1.00 (MppChargeFor<OneDollar>)");
+    println!("  GET /api/fortune  — $0.01");
+    println!("  GET /api/premium  — $1.00");
     axum::serve(listener, app).await.expect("server error");
 }
 
@@ -110,11 +118,7 @@ async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({ "status": "ok" }))
 }
 
-/// $0.01 fortune — uses the default `MppCharge` extractor.
-///
-/// The extractor handles the full 402 flow automatically:
-/// no credential → 402 with challenge, valid credential → receipt.
-async fn fortune(charge: MppCharge) -> WithReceipt<Json<serde_json::Value>> {
+async fn fortune(charge: MppCharge<OneCent>) -> WithReceipt<Json<serde_json::Value>> {
     let fortune = FORTUNES
         .choose(&mut rand::rng())
         .unwrap_or(&"No fortune today.");
@@ -125,9 +129,8 @@ async fn fortune(charge: MppCharge) -> WithReceipt<Json<serde_json::Value>> {
     }
 }
 
-/// $1.00 premium fortune — uses `MppChargeFor<OneDollar>`.
 async fn premium_fortune(
-    charge: MppChargeFor<OneDollar>,
+    charge: MppCharge<OneDollar>,
 ) -> WithReceipt<Json<serde_json::Value>> {
     let fortune = PREMIUM_FORTUNES
         .choose(&mut rand::rng())

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -24,8 +24,6 @@ use rand::seq::IndexedRandom;
 use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
 
-const PATH_USD: &str = "0x20c0000000000000000000000000000000000000";
-
 const FORTUNES: &[&str] = &[
     "A beautiful, smart, and loving person will come into your life.",
     "A dubious friend may be an enemy in camouflage.",
@@ -86,8 +84,8 @@ async fn main() {
 
     let mpp = Mpp::create(
         tempo(TempoConfig {
-            currency: PATH_USD,
             recipient: &recipient,
+            currency: None,
         })
         .rpc_url(&rpc_url)
         .fee_payer(true)

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -1,0 +1,143 @@
+//! # Axum Extractor Example — Server
+//!
+//! Demonstrates payment-gated endpoints using mpp's axum extractors.
+//!
+//! - `/api/health` — Free health check
+//! - `/api/fortune` — $0.01 (default `MppCharge`)
+//! - `/api/premium` — $1.00 (custom `MppChargeFor<OneDollar>`)
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo run --bin axum-server
+//! ```
+//!
+//! The server listens on `http://localhost:3000`.
+
+use axum::{routing::get, Json, Router};
+use alloy::primitives::B256;
+use alloy::providers::{Provider, ProviderBuilder};
+use mpp::server::axum::{ChargeAmount, ChargeChallenger, MppCharge, MppChargeFor, WithReceipt};
+use mpp::server::{tempo, Mpp, TempoConfig};
+use mpp::PrivateKeySigner;
+use rand::seq::IndexedRandom;
+use std::sync::Arc;
+use tempo_alloy::TempoNetwork;
+
+const PATH_USD: &str = "0x20c0000000000000000000000000000000000000";
+
+const FORTUNES: &[&str] = &[
+    "A beautiful, smart, and loving person will come into your life.",
+    "A dubious friend may be an enemy in camouflage.",
+    "A faithful friend is a strong defense.",
+    "A fresh start will put you on your way.",
+    "A golden egg of opportunity falls into your lap this month.",
+    "A good time to finish up old tasks.",
+    "A hunch is creativity trying to tell you something.",
+    "A lifetime of happiness lies ahead of you.",
+    "A light heart carries you through all the hard times.",
+    "A new perspective will come with the new year.",
+];
+
+const PREMIUM_FORTUNES: &[&str] = &[
+    "The cosmos has aligned in your favor — expect an extraordinary opportunity this week.",
+    "A partnership forged in trust will yield ten-fold returns.",
+    "Your code will compile on the first try. Today is your day.",
+    "An unexpected windfall arrives before the next full moon.",
+    "The answer you seek is already within you. Trust your instincts.",
+];
+
+// -- Per-route pricing via ChargeAmount trait --
+
+struct OneDollar;
+
+impl ChargeAmount for OneDollar {
+    fn amount() -> &'static str {
+        "1.00"
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let signer = PrivateKeySigner::random();
+    let recipient = format!("{}", signer.address());
+    println!("Server recipient: {recipient}");
+
+    let rpc_url = std::env::var("RPC_URL")
+        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+
+    // Fund the server account via testnet faucet.
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect_http(rpc_url.parse().unwrap());
+    let _: Vec<B256> = provider
+        .raw_request("tempo_fundAddress".into(), (signer.address(),))
+        .await
+        .expect("faucet funding failed");
+    println!("Server account funded");
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            currency: PATH_USD,
+            recipient: &recipient,
+        })
+        .rpc_url(&rpc_url)
+        .fee_payer(true)
+        .fee_payer_signer(signer),
+    )
+    .expect("failed to create payment handler");
+
+    // Cast to Arc<dyn ChargeChallenger> for the axum extractors.
+    let state: Arc<dyn ChargeChallenger> = Arc::new(mpp);
+
+    let app = Router::new()
+        .route("/api/health", get(health))
+        .route("/api/fortune", get(fortune))
+        .route("/api/premium", get(premium_fortune))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
+        .await
+        .expect("failed to bind");
+
+    println!("Axum Extractor Example listening on http://localhost:3000");
+    println!("  GET /api/health   — free");
+    println!("  GET /api/fortune  — $0.01 (MppCharge)");
+    println!("  GET /api/premium  — $1.00 (MppChargeFor<OneDollar>)");
+    axum::serve(listener, app).await.expect("server error");
+}
+
+async fn health() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+/// $0.01 fortune — uses the default `MppCharge` extractor.
+///
+/// The extractor handles the full 402 flow automatically:
+/// no credential → 402 with challenge, valid credential → receipt.
+async fn fortune(charge: MppCharge) -> WithReceipt<Json<serde_json::Value>> {
+    let fortune = FORTUNES
+        .choose(&mut rand::rng())
+        .unwrap_or(&"No fortune today.");
+
+    WithReceipt {
+        receipt: charge.receipt,
+        body: Json(serde_json::json!({ "fortune": fortune })),
+    }
+}
+
+/// $1.00 premium fortune — uses `MppChargeFor<OneDollar>`.
+async fn premium_fortune(
+    charge: MppChargeFor<OneDollar>,
+) -> WithReceipt<Json<serde_json::Value>> {
+    let fortune = PREMIUM_FORTUNES
+        .choose(&mut rand::rng())
+        .unwrap_or(&"The stars are silent.");
+
+    WithReceipt {
+        receipt: charge.receipt,
+        body: Json(serde_json::json!({
+            "fortune": fortune,
+            "tier": "premium",
+        })),
+    }
+}

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -85,7 +85,6 @@ async fn main() {
     let mpp = Mpp::create(
         tempo(TempoConfig {
             recipient: &recipient,
-            currency: None,
         })
         .rpc_url(&rpc_url)
         .fee_payer(true)

--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -30,8 +30,6 @@ use tempo_alloy::TempoNetwork;
 
 type Payment = Mpp<TempoChargeMethod<mpp::server::TempoProvider>>;
 
-const PATH_USD: &str = "0x20c0000000000000000000000000000000000000";
-
 const FORTUNES: &[&str] = &[
     "A beautiful, smart, and loving person will come into your life.",
     "A dubious friend may be an enemy in camouflage.",
@@ -65,8 +63,8 @@ async fn main() {
 
     let payment = Mpp::create(
         tempo(TempoConfig {
-            currency: PATH_USD,
             recipient: &recipient,
+            currency: None,
         })
         .rpc_url(&rpc_url)
         .fee_payer(true)

--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -64,7 +64,6 @@ async fn main() {
     let payment = Mpp::create(
         tempo(TempoConfig {
             recipient: &recipient,
-            currency: None,
         })
         .rpc_url(&rpc_url)
         .fee_payer(true)

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -61,8 +61,8 @@ async fn main() {
     // Create the base payment handler (charge method).
     let base_payment = Mpp::create(
         tempo(TempoConfig {
-            currency: CURRENCY,
             recipient: &recipient,
+            currency: None,
         })
         .rpc_url(RPC_URL)
         .fee_payer(true),

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -62,7 +62,6 @@ async fn main() {
     let base_payment = Mpp::create(
         tempo(TempoConfig {
             recipient: &recipient,
-            currency: None,
         })
         .rpc_url(RPC_URL)
         .fee_payer(true),

--- a/examples/session/sse/src/server.rs
+++ b/examples/session/sse/src/server.rs
@@ -190,7 +190,7 @@ async fn chat(
 
     // Use mpp's sse::serve for metered streaming with automatic
     // balance tracking, need-voucher events, and final receipt.
-    let mut rx = mpp::server::sse::serve(mpp::server::sse::ServeOptions {
+    let event_stream = mpp::server::sse::serve(mpp::server::sse::ServeOptions {
         store: state.store.clone(),
         channel_id,
         challenge_id,
@@ -200,7 +200,8 @@ async fn chat(
     });
 
     let body_stream = async_stream::stream! {
-        while let Some(event) = rx.recv().await {
+        let mut event_stream = std::pin::pin!(event_stream);
+        while let Some(event) = StreamExt::next(&mut event_stream).await {
             yield Ok::<_, std::convert::Infallible>(event);
         }
     };

--- a/examples/session/sse/src/server.rs
+++ b/examples/session/sse/src/server.rs
@@ -78,7 +78,6 @@ async fn main() {
     let base = Mpp::create(
         tempo(TempoConfig {
             recipient: &recipient,
-            currency: None,
         })
         .rpc_url(RPC_URL)
         .fee_payer(true),

--- a/examples/session/sse/src/server.rs
+++ b/examples/session/sse/src/server.rs
@@ -77,8 +77,8 @@ async fn main() {
     // Create the base payment handler.
     let base = Mpp::create(
         tempo(TempoConfig {
-            currency: CURRENCY,
             recipient: &recipient,
+            currency: None,
         })
         .rpc_url(RPC_URL)
         .fee_payer(true),

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -49,7 +49,7 @@ const TRANSFER_WITH_MEMO_EVENT_TOPIC: B256 =
 const TRANSFER_SELECTOR: [u8; 4] = [0xa9, 0x05, 0x9c, 0xbb];
 
 /// TIP-20 transferWithMemo function selector: bytes4(keccak256("transferWithMemo(address,uint256,bytes32)"))
-const TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = [0x4a, 0x7a, 0x13, 0x64];
+const TRANSFER_WITH_MEMO_SELECTOR: [u8; 4] = [0x95, 0x77, 0x7d, 0x59];
 
 /// Parse a hex string (with or without 0x prefix) into a B256.
 fn parse_b256_hex(s: &str) -> Option<B256> {
@@ -455,9 +455,17 @@ where
                     }
                 }
             } else {
-                // Look for transfer(address,uint256)
-                // Exact length: 4 (selector) + 32 (address) + 32 (amount) = 68 bytes
+                // No memo specified — accept either transfer or transferWithMemo
+                // (clients may attach attribution memos even when the request doesn't require one)
                 if selector == TRANSFER_SELECTOR && data.len() == 68 {
+                    let to = Address::from_slice(&data[16..36]);
+                    let amount = U256::from_be_slice(&data[36..68]);
+
+                    if to == expected_recipient && amount == expected_amount {
+                        return Ok(());
+                    }
+                }
+                if selector == TRANSFER_WITH_MEMO_SELECTOR && data.len() == 100 {
                     let to = Address::from_slice(&data[16..36]);
                     let amount = U256::from_be_slice(&data[36..68]);
 
@@ -655,8 +663,8 @@ mod tests {
 
     #[test]
     fn test_transfer_with_memo_selector() {
-        // transferWithMemo(address,uint256,bytes32) = 0x4a7a1364
-        assert_eq!(TRANSFER_WITH_MEMO_SELECTOR, [0x4a, 0x7a, 0x13, 0x64]);
+        // transferWithMemo(address,uint256,bytes32) = 0x95777d59
+        assert_eq!(TRANSFER_WITH_MEMO_SELECTOR, [0x95, 0x77, 0x7d, 0x59]);
     }
 
     #[test]

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -135,6 +135,9 @@ pub const MODERATO_CHAIN_ID: u64 = 42431;
 /// Default RPC URL for Tempo mainnet.
 pub const DEFAULT_RPC_URL: &str = "https://rpc.tempo.xyz";
 
+/// Default currency address (pathUSD).
+pub const DEFAULT_CURRENCY: &str = "0x20c0000000000000000000000000000000000000";
+
 /// Default challenge expiration in minutes.
 pub const DEFAULT_EXPIRES_MINUTES: u64 = 5;
 

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -11,12 +11,33 @@
 //! implementations for [`PaymentChallenge`] (402 response) and
 //! [`Receipt`] (response header).
 //!
-//! # Example
+//! # Per-route pricing
+//!
+//! The default [`MppCharge`] charges `$0.01`. To set a different amount
+//! per route, define a [`ChargeAmount`] type and use [`MppChargeFor<P>`]:
+//!
+//! ```ignore
+//! use mpp::server::axum::{ChargeAmount, MppChargeFor};
+//!
+//! struct OneDollar;
+//! impl ChargeAmount for OneDollar {
+//!     fn amount() -> &'static str { "1.00" }
+//! }
+//!
+//! async fn expensive(charge: MppChargeFor<OneDollar>) -> &'static str {
+//!     "premium content"
+//! }
+//! ```
+//!
+//! # State setup
+//!
+//! The extractors require `Arc<dyn ChargeChallenger>` in the router state
+//! (either directly or via [`FromRef`](axum_core::extract::FromRef)):
 //!
 //! ```ignore
 //! use axum::{routing::get, Router, Json};
 //! use mpp::server::{Mpp, tempo, TempoConfig};
-//! use mpp::server::axum::MppCharge;
+//! use mpp::server::axum::{MppCharge, ChargeChallenger};
 //! use std::sync::Arc;
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
@@ -25,18 +46,17 @@
 //! })).unwrap();
 //!
 //! async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
-//!     // charge.receipt is the verified Receipt
 //!     Json(serde_json::json!({ "paid": true }))
 //! }
 //!
 //! let app = Router::new()
 //!     .route("/api/premium", get(handler))
-//!     .with_state(Arc::new(mpp));
+//!     .with_state(Arc::new(mpp) as Arc<dyn ChargeChallenger>);
 //! ```
 
 use std::sync::Arc;
 
-use axum_core::extract::FromRequestParts;
+use axum_core::extract::{FromRef, FromRequestParts};
 use axum_core::response::IntoResponse;
 use http_types::{header, HeaderValue, StatusCode};
 
@@ -45,7 +65,6 @@ use crate::protocol::core::headers::{
     PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
 };
 use crate::protocol::core::{PaymentChallenge, Receipt};
-use crate::protocol::traits::ChargeMethod;
 
 // ==================== IntoResponse for PaymentChallenge ====================
 
@@ -93,26 +112,58 @@ impl IntoResponse for PaymentRequired {
     }
 }
 
+// ==================== Charge amount policy ====================
+
+/// Trait for specifying the charge amount on a per-route basis.
+///
+/// Implement this on a marker type and use [`MppChargeFor<P>`] as your
+/// extractor to control the dollar amount charged per route.
+///
+/// # Example
+///
+/// ```ignore
+/// use mpp::server::axum::{ChargeAmount, MppChargeFor};
+///
+/// struct TenCents;
+/// impl ChargeAmount for TenCents {
+///     fn amount() -> &'static str { "0.10" }
+/// }
+///
+/// async fn handler(charge: MppChargeFor<TenCents>) -> &'static str {
+///     "paid content"
+/// }
+/// ```
+pub trait ChargeAmount {
+    /// The dollar amount to charge (e.g., `"0.01"`, `"1.00"`).
+    fn amount() -> &'static str;
+}
+
+/// Default charge amount: $0.01.
+pub struct DefaultAmount;
+
+impl ChargeAmount for DefaultAmount {
+    fn amount() -> &'static str {
+        "0.01"
+    }
+}
+
 // ==================== MppCharge extractor ====================
 
 /// Axum extractor that gates a handler behind charge payment verification.
 ///
-/// Extracts the `Authorization: Payment ...` header, verifies the credential
-/// using the [`Mpp`](super::Mpp) instance from state, and provides the
-/// verified [`Receipt`] to the handler.
-///
-/// If no credential or an invalid credential is provided, the extractor
-/// short-circuits with a 402 response containing the challenge.
+/// Uses the default charge amount of `$0.01`. For custom amounts, use
+/// [`MppChargeFor`] with a [`ChargeAmount`] implementation.
 ///
 /// # State Requirements
 ///
-/// Requires `Arc<Mpp<M, S>>` in the router state where `M: ChargeMethod`.
+/// Requires `Arc<dyn ChargeChallenger>` in the router state, either directly or
+/// via [`FromRef`](axum_core::extract::FromRef).
 ///
 /// # Example
 ///
 /// ```ignore
 /// use axum::{routing::get, Router, Json};
-/// use mpp::server::axum::MppCharge;
+/// use mpp::server::axum::{MppCharge, ChargeChallenger};
 /// use mpp::server::{Mpp, tempo, TempoConfig};
 /// use std::sync::Arc;
 ///
@@ -122,20 +173,40 @@ impl IntoResponse for PaymentRequired {
 /// })).unwrap();
 ///
 /// async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
-///     let receipt_header = charge.receipt.to_header().unwrap_or_default();
 ///     Json(serde_json::json!({ "status": "paid", "ref": charge.receipt.reference }))
 /// }
 ///
 /// let app = Router::new()
 ///     .route("/premium", get(handler))
-///     .with_state(Arc::new(mpp));
+///     .with_state(Arc::new(mpp) as Arc<dyn ChargeChallenger>);
 /// ```
-pub struct MppCharge {
+pub type MppCharge = MppChargeFor<DefaultAmount>;
+
+/// Axum extractor that gates a handler with a configurable charge amount.
+///
+/// The type parameter `A` determines the dollar amount via [`ChargeAmount`].
+///
+/// # Example
+///
+/// ```ignore
+/// use mpp::server::axum::{ChargeAmount, MppChargeFor};
+///
+/// struct OneDollar;
+/// impl ChargeAmount for OneDollar {
+///     fn amount() -> &'static str { "1.00" }
+/// }
+///
+/// async fn expensive(charge: MppChargeFor<OneDollar>) -> &'static str {
+///     "premium content"
+/// }
+/// ```
+pub struct MppChargeFor<A: ChargeAmount> {
     /// The verified payment receipt.
     pub receipt: Receipt,
+    _amount: std::marker::PhantomData<A>,
 }
 
-/// Rejection type for [`MppCharge`] extractor.
+/// Rejection type for [`MppCharge`] and [`MppChargeFor`] extractors.
 pub enum MppChargeRejection {
     /// No credential — return 402 with challenge.
     Challenge(PaymentRequired),
@@ -160,15 +231,20 @@ impl IntoResponse for MppChargeRejection {
     }
 }
 
-/// Helper trait for [`MppCharge`] to generate challenges from the `Mpp` state.
-///
-/// This is automatically implemented for `Mpp` types that have the `tempo`
-/// feature enabled and bound currency/recipient.
-pub trait ChargeChallenger: Send + Sync + 'static {
-    /// Generate a charge challenge for a default amount.
-    fn default_challenge(&self) -> Result<PaymentChallenge, String>;
+// ==================== ChargeChallenger ====================
 
-    /// Verify a credential string.
+/// Trait for generating payment challenges and verifying credentials.
+///
+/// Implemented automatically for `Mpp<TempoChargeMethod<P>, S>` when
+/// the `tempo` feature is enabled. Can also be implemented manually
+/// for custom payment methods.
+///
+/// The extractors require `Arc<dyn ChargeChallenger>` in router state.
+pub trait ChargeChallenger: Send + Sync + 'static {
+    /// Generate a charge challenge for the given dollar amount.
+    fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String>;
+
+    /// Verify a credential string and return a receipt.
     fn verify_payment(
         &self,
         credential_str: &str,
@@ -176,11 +252,13 @@ pub trait ChargeChallenger: Send + Sync + 'static {
 }
 
 #[cfg(feature = "tempo")]
-impl<S: Clone + Send + Sync + 'static> ChargeChallenger
-    for super::Mpp<super::TempoChargeMethod<super::TempoProvider>, S>
+impl<P, S> ChargeChallenger for super::Mpp<super::TempoChargeMethod<P>, S>
+where
+    P: alloy::providers::Provider<tempo_alloy::TempoNetwork> + Clone + Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
 {
-    fn default_challenge(&self) -> Result<PaymentChallenge, String> {
-        self.charge("0.01").map_err(|e| e.to_string())
+    fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String> {
+        self.charge(amount).map_err(|e| e.to_string())
     }
 
     fn verify_payment(
@@ -205,18 +283,19 @@ impl<S: Clone + Send + Sync + 'static> ChargeChallenger
     }
 }
 
-impl<S, M> FromRequestParts<Arc<super::Mpp<M, S>>> for MppCharge
+impl<S, A> FromRequestParts<S> for MppChargeFor<A>
 where
-    M: ChargeMethod + Clone + Send + Sync + 'static,
-    S: Clone + Send + Sync + 'static,
-    super::Mpp<M, S>: ChargeChallenger,
+    Arc<dyn ChargeChallenger>: FromRef<S>,
+    A: ChargeAmount,
+    S: Send + Sync,
 {
     type Rejection = MppChargeRejection;
 
     fn from_request_parts(
         parts: &mut http_types::request::Parts,
-        state: &Arc<super::Mpp<M, S>>,
+        state: &S,
     ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
+        let challenger: Arc<dyn ChargeChallenger> = FromRef::from_ref(state);
         let auth_header = parts
             .headers
             .get(header::AUTHORIZATION)
@@ -224,25 +303,26 @@ where
             .and_then(extract_payment_scheme)
             .map(|s| s.to_string());
 
-        let state = Arc::clone(state);
-
         async move {
             let credential_str = match auth_header {
                 Some(c) => c,
                 None => {
-                    let challenge = state
-                        .default_challenge()
+                    let challenge = challenger
+                        .challenge(A::amount())
                         .map_err(MppChargeRejection::InternalError)?;
                     return Err(MppChargeRejection::Challenge(PaymentRequired(challenge)));
                 }
             };
 
-            let receipt = state
+            let receipt = challenger
                 .verify_payment(&credential_str)
                 .await
                 .map_err(MppChargeRejection::VerificationFailed)?;
 
-            Ok(MppCharge { receipt })
+            Ok(MppChargeFor {
+                receipt,
+                _amount: std::marker::PhantomData,
+            })
         }
     }
 }
@@ -338,5 +418,10 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+    }
+
+    #[test]
+    fn test_default_amount() {
+        assert_eq!(DefaultAmount::amount(), "0.01");
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -83,6 +83,7 @@ use crate::protocol::core::{PaymentChallenge, Receipt};
 ///     PaymentRequired(challenge)
 /// }
 /// ```
+#[derive(Debug)]
 pub struct PaymentRequired(pub PaymentChallenge);
 
 impl IntoResponse for PaymentRequired {
@@ -94,9 +95,11 @@ impl IntoResponse for PaymentRequired {
                     serde_json::json!({ "error": "Payment Required" }).to_string(),
                 )
                     .into_response();
-                if let Ok(val) = HeaderValue::from_str(&www_auth) {
-                    resp.headers_mut().insert(WWW_AUTHENTICATE_HEADER, val);
-                }
+                resp.headers_mut().insert(
+                    WWW_AUTHENTICATE_HEADER,
+                    HeaderValue::from_str(&www_auth)
+                        .unwrap_or_else(|_| HeaderValue::from_static("Payment")),
+                );
                 resp.headers_mut().insert(
                     header::CONTENT_TYPE,
                     HeaderValue::from_static("application/json"),
@@ -114,10 +117,14 @@ impl IntoResponse for PaymentRequired {
 
 // ==================== Charge amount policy ====================
 
-/// Trait for specifying the charge amount on a per-route basis.
+/// Trait for specifying a static charge amount on a per-route basis.
 ///
 /// Implement this on a marker type and use [`MppChargeFor<P>`] as your
 /// extractor to control the dollar amount charged per route.
+///
+/// This is designed for fixed per-route pricing. For dynamic pricing
+/// (per-user, per-request, etc.), implement [`ChargeChallenger`] directly
+/// or use a custom extractor.
 ///
 /// # Example
 ///
@@ -139,6 +146,7 @@ pub trait ChargeAmount {
 }
 
 /// Default charge amount: $0.01.
+#[derive(Debug)]
 pub struct DefaultAmount;
 
 impl ChargeAmount for DefaultAmount {
@@ -200,6 +208,7 @@ pub type MppCharge = MppChargeFor<DefaultAmount>;
 ///     "premium content"
 /// }
 /// ```
+#[derive(Debug)]
 pub struct MppChargeFor<A: ChargeAmount> {
     /// The verified payment receipt.
     pub receipt: Receipt,
@@ -207,11 +216,13 @@ pub struct MppChargeFor<A: ChargeAmount> {
 }
 
 /// Rejection type for [`MppCharge`] and [`MppChargeFor`] extractors.
+#[derive(Debug)]
+#[non_exhaustive]
 pub enum MppChargeRejection {
     /// No credential — return 402 with challenge.
     Challenge(PaymentRequired),
-    /// Verification failed — return 402 with error.
-    VerificationFailed(String),
+    /// Verification failed — return 402 with challenge for retry.
+    VerificationFailed(PaymentRequired),
     /// Internal error generating challenge.
     InternalError(String),
 }
@@ -220,9 +231,9 @@ impl IntoResponse for MppChargeRejection {
     fn into_response(self) -> axum_core::response::Response {
         match self {
             MppChargeRejection::Challenge(pr) => pr.into_response(),
-            MppChargeRejection::VerificationFailed(msg) => {
-                let body = serde_json::json!({ "error": msg });
-                (StatusCode::PAYMENT_REQUIRED, body.to_string()).into_response()
+            MppChargeRejection::VerificationFailed(pr) => {
+                // Return 402 with challenge so the client can retry.
+                pr.into_response()
             }
             MppChargeRejection::InternalError(msg) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
@@ -314,10 +325,17 @@ where
                 }
             };
 
-            let receipt = challenger
-                .verify_payment(&credential_str)
-                .await
-                .map_err(MppChargeRejection::VerificationFailed)?;
+            let receipt = match challenger.verify_payment(&credential_str).await {
+                Ok(r) => r,
+                Err(_) => {
+                    let challenge = challenger
+                        .challenge(A::amount())
+                        .map_err(MppChargeRejection::InternalError)?;
+                    return Err(MppChargeRejection::VerificationFailed(PaymentRequired(
+                        challenge,
+                    )));
+                }
+            };
 
             Ok(MppChargeFor {
                 receipt,
@@ -368,28 +386,91 @@ impl<T: IntoResponse> IntoResponse for WithReceipt<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::core::Base64UrlJson;
 
-    #[test]
-    fn test_payment_required_into_response() {
-        use crate::protocol::core::Base64UrlJson;
+    // ==================== Test helpers ====================
 
-        let challenge = PaymentChallenge::new(
+    fn test_challenge() -> PaymentChallenge {
+        PaymentChallenge::new(
             "test-id",
             "test-realm",
             "tempo",
             "charge",
             Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
-        );
-        let resp = PaymentRequired(challenge).into_response();
+        )
+    }
+
+    /// Mock [`ChargeChallenger`] for extractor tests.
+    struct MockChallenger {
+        accept: bool,
+    }
+
+    impl ChargeChallenger for MockChallenger {
+        fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String> {
+            Ok(PaymentChallenge::new(
+                "mock-id",
+                "mock-realm",
+                "tempo",
+                "charge",
+                Base64UrlJson::from_value(&serde_json::json!({"amount": amount})).unwrap(),
+            ))
+        }
+
+        fn verify_payment(
+            &self,
+            _credential_str: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        {
+            let accept = self.accept;
+            Box::pin(async move {
+                if accept {
+                    Ok(Receipt {
+                        status: crate::protocol::core::ReceiptStatus::Success,
+                        method: crate::protocol::core::MethodName::new("tempo"),
+                        timestamp: "2025-01-01T00:00:00Z".into(),
+                        reference: "0xabc".into(),
+                    })
+                } else {
+                    Err("payment rejected".into())
+                }
+            })
+        }
+    }
+
+    // ==================== PaymentRequired tests ====================
+
+    #[test]
+    fn test_payment_required_into_response() {
+        let resp = PaymentRequired(test_challenge()).into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
     }
 
     #[test]
-    fn test_rejection_verification_failed() {
-        let rejection = MppChargeRejection::VerificationFailed("bad payment".into());
+    fn test_payment_required_has_json_content_type() {
+        let resp = PaymentRequired(test_challenge()).into_response();
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+    }
+
+    // ==================== MppChargeRejection tests ====================
+
+    #[test]
+    fn test_rejection_challenge_returns_402_with_header() {
+        let rejection = MppChargeRejection::Challenge(PaymentRequired(test_challenge()));
         let resp = rejection.into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+    }
+
+    #[test]
+    fn test_rejection_verification_failed_returns_402_with_header() {
+        let rejection = MppChargeRejection::VerificationFailed(PaymentRequired(test_challenge()));
+        let resp = rejection.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
     }
 
     #[test]
@@ -398,6 +479,26 @@ mod tests {
         let resp = rejection.into_response();
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
+
+    // ==================== ChargeAmount tests ====================
+
+    #[test]
+    fn test_default_amount() {
+        assert_eq!(DefaultAmount::amount(), "0.01");
+    }
+
+    #[test]
+    fn test_custom_amount() {
+        struct FiveDollars;
+        impl ChargeAmount for FiveDollars {
+            fn amount() -> &'static str {
+                "5.00"
+            }
+        }
+        assert_eq!(FiveDollars::amount(), "5.00");
+    }
+
+    // ==================== WithReceipt tests ====================
 
     #[test]
     fn test_with_receipt_attaches_header() {
@@ -420,8 +521,104 @@ mod tests {
         assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
     }
 
+    // ==================== ChargeChallenger mock tests ====================
+
     #[test]
-    fn test_default_amount() {
-        assert_eq!(DefaultAmount::amount(), "0.01");
+    fn test_mock_challenger_generates_challenge() {
+        let challenger = MockChallenger { accept: true };
+        let challenge = challenger.challenge("0.50").unwrap();
+        assert_eq!(challenge.id, "mock-id");
+    }
+
+    #[tokio::test]
+    async fn test_mock_challenger_verify_accept() {
+        let challenger = MockChallenger { accept: true };
+        let result = challenger.verify_payment("Payment eyJ...").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().reference, "0xabc");
+    }
+
+    #[tokio::test]
+    async fn test_mock_challenger_verify_reject() {
+        let challenger = MockChallenger { accept: false };
+        let result = challenger.verify_payment("Payment eyJ...").await;
+        assert!(result.is_err());
+    }
+
+    // ==================== FromRequestParts integration tests ====================
+
+    /// Helper to run the extractor against a mock request.
+    async fn run_extractor<A: ChargeAmount>(
+        challenger: MockChallenger,
+        auth_header: Option<&str>,
+    ) -> Result<MppChargeFor<A>, MppChargeRejection> {
+        let state: Arc<dyn ChargeChallenger> = Arc::new(challenger);
+        let mut builder = http_types::Request::builder().uri("/test");
+        if let Some(auth) = auth_header {
+            builder = builder.header(header::AUTHORIZATION, auth);
+        }
+        let req = builder.body(()).unwrap();
+        let (mut parts, _body) = req.into_parts();
+        MppChargeFor::<A>::from_request_parts(&mut parts, &state).await
+    }
+
+    #[tokio::test]
+    async fn test_extractor_no_auth_returns_challenge() {
+        let result = run_extractor::<DefaultAmount>(MockChallenger { accept: true }, None).await;
+        let err = result.unwrap_err();
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+    }
+
+    #[tokio::test]
+    async fn test_extractor_valid_payment_returns_receipt() {
+        let result = run_extractor::<DefaultAmount>(
+            MockChallenger { accept: true },
+            Some("Payment eyJmYWtlIjp0cnVlfQ"),
+        )
+        .await;
+        let charge = result.unwrap();
+        assert_eq!(charge.receipt.reference, "0xabc");
+    }
+
+    #[tokio::test]
+    async fn test_extractor_invalid_payment_returns_challenge_for_retry() {
+        let result = run_extractor::<DefaultAmount>(
+            MockChallenger { accept: false },
+            Some("Payment eyJmYWtlIjp0cnVlfQ"),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+    }
+
+    #[tokio::test]
+    async fn test_extractor_wrong_scheme_returns_challenge() {
+        let result = run_extractor::<DefaultAmount>(
+            MockChallenger { accept: true },
+            Some("Bearer some-token"),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::Challenge(_)));
+    }
+
+    #[tokio::test]
+    async fn test_extractor_custom_amount() {
+        struct TenCents;
+        impl ChargeAmount for TenCents {
+            fn amount() -> &'static str {
+                "0.10"
+            }
+        }
+
+        // No auth → challenge should be generated (verifying custom amount type works)
+        let result =
+            run_extractor::<TenCents>(MockChallenger { accept: true }, None).await;
+        assert!(result.is_err());
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -659,15 +659,17 @@ mod tests {
             fn verify_payment(
                 &self,
                 _credential_str: &str,
-            ) -> std::pin::Pin<
-                Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>,
-            > {
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+            {
                 Box::pin(std::future::ready(Err("unused".into())))
             }
         }
 
         let state: Arc<dyn ChargeChallenger> = Arc::new(FailingChallenger);
-        let req = http_types::Request::builder().uri("/test").body(()).unwrap();
+        let req = http_types::Request::builder()
+            .uri("/test")
+            .body(())
+            .unwrap();
         let (mut parts, _body) = req.into_parts();
         let result = MppCharge::<OneCent>::from_request_parts(&mut parts, &state).await;
         let err = result.unwrap_err();

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -644,4 +644,48 @@ mod tests {
         let result = run_extractor::<TenCents>(MockChallenger { accept: true }, None).await;
         assert!(result.is_err());
     }
+
+    #[tokio::test]
+    async fn test_extractor_challenge_failure_returns_internal_error() {
+        struct FailingChallenger;
+        impl ChargeChallenger for FailingChallenger {
+            fn challenge(
+                &self,
+                _amount: &str,
+                _options: ChallengeOptions,
+            ) -> Result<PaymentChallenge, String> {
+                Err("config error".into())
+            }
+            fn verify_payment(
+                &self,
+                _credential_str: &str,
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>,
+            > {
+                Box::pin(std::future::ready(Err("unused".into())))
+            }
+        }
+
+        let state: Arc<dyn ChargeChallenger> = Arc::new(FailingChallenger);
+        let req = http_types::Request::builder().uri("/test").body(()).unwrap();
+        let (mut parts, _body) = req.into_parts();
+        let result = MppCharge::<OneCent>::from_request_parts(&mut parts, &state).await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::InternalError(_)));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_extractor_malformed_payment_credential_returns_verification_failed() {
+        let result = run_extractor::<OneCent>(
+            MockChallenger { accept: false },
+            Some("Payment !!not-base64!!"),
+        )
+        .await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+    }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -1,0 +1,342 @@
+//! Axum extractors and response types for payment gating.
+//!
+//! Provides [`MppCharge`], an axum extractor that handles the full
+//! 402 challenge/verify flow automatically:
+//!
+//! - No `Authorization: Payment` header → 402 with `WWW-Authenticate` challenge
+//! - Invalid credential → 402 error
+//! - Valid credential → extracts the [`Receipt`] for the handler
+//!
+//! Also provides [`IntoResponse`](axum_core::response::IntoResponse)
+//! implementations for [`PaymentChallenge`] (402 response) and
+//! [`Receipt`] (response header).
+//!
+//! # Example
+//!
+//! ```ignore
+//! use axum::{routing::get, Router, Json};
+//! use mpp::server::{Mpp, tempo, TempoConfig};
+//! use mpp::server::axum::MppCharge;
+//! use std::sync::Arc;
+//!
+//! let mpp = Mpp::create(tempo(TempoConfig {
+//!     currency: "0x20c...",
+//!     recipient: "0xabc...",
+//! })).unwrap();
+//!
+//! async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
+//!     // charge.receipt is the verified Receipt
+//!     Json(serde_json::json!({ "paid": true }))
+//! }
+//!
+//! let app = Router::new()
+//!     .route("/api/premium", get(handler))
+//!     .with_state(Arc::new(mpp));
+//! ```
+
+use std::sync::Arc;
+
+use axum_core::extract::FromRequestParts;
+use axum_core::response::IntoResponse;
+use http_types::{header, HeaderValue, StatusCode};
+
+use crate::protocol::core::headers::{
+    extract_payment_scheme, format_receipt, format_www_authenticate, parse_authorization,
+    PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
+};
+use crate::protocol::core::{PaymentChallenge, Receipt};
+use crate::protocol::traits::ChargeMethod;
+
+// ==================== IntoResponse for PaymentChallenge ====================
+
+/// A 402 Payment Required response wrapping a [`PaymentChallenge`].
+///
+/// Returned as a rejection from [`MppCharge`] when no credential is present,
+/// or can be used directly in handlers.
+///
+/// # Example
+///
+/// ```ignore
+/// use mpp::server::axum::PaymentRequired;
+///
+/// async fn handler() -> PaymentRequired {
+///     let challenge = mpp.charge("1.00").unwrap();
+///     PaymentRequired(challenge)
+/// }
+/// ```
+pub struct PaymentRequired(pub PaymentChallenge);
+
+impl IntoResponse for PaymentRequired {
+    fn into_response(self) -> axum_core::response::Response {
+        match format_www_authenticate(&self.0) {
+            Ok(www_auth) => {
+                let mut resp = (
+                    StatusCode::PAYMENT_REQUIRED,
+                    serde_json::json!({ "error": "Payment Required" }).to_string(),
+                )
+                    .into_response();
+                if let Ok(val) = HeaderValue::from_str(&www_auth) {
+                    resp.headers_mut().insert(WWW_AUTHENTICATE_HEADER, val);
+                }
+                resp.headers_mut().insert(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("application/json"),
+                );
+                resp
+            }
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to format challenge: {}", e),
+            )
+                .into_response(),
+        }
+    }
+}
+
+// ==================== MppCharge extractor ====================
+
+/// Axum extractor that gates a handler behind charge payment verification.
+///
+/// Extracts the `Authorization: Payment ...` header, verifies the credential
+/// using the [`Mpp`](super::Mpp) instance from state, and provides the
+/// verified [`Receipt`] to the handler.
+///
+/// If no credential or an invalid credential is provided, the extractor
+/// short-circuits with a 402 response containing the challenge.
+///
+/// # State Requirements
+///
+/// Requires `Arc<Mpp<M, S>>` in the router state where `M: ChargeMethod`.
+///
+/// # Example
+///
+/// ```ignore
+/// use axum::{routing::get, Router, Json};
+/// use mpp::server::axum::MppCharge;
+/// use mpp::server::{Mpp, tempo, TempoConfig};
+/// use std::sync::Arc;
+///
+/// let mpp = Mpp::create(tempo(TempoConfig {
+///     currency: "0x20c...",
+///     recipient: "0xabc...",
+/// })).unwrap();
+///
+/// async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
+///     let receipt_header = charge.receipt.to_header().unwrap_or_default();
+///     Json(serde_json::json!({ "status": "paid", "ref": charge.receipt.reference }))
+/// }
+///
+/// let app = Router::new()
+///     .route("/premium", get(handler))
+///     .with_state(Arc::new(mpp));
+/// ```
+pub struct MppCharge {
+    /// The verified payment receipt.
+    pub receipt: Receipt,
+}
+
+/// Rejection type for [`MppCharge`] extractor.
+pub enum MppChargeRejection {
+    /// No credential — return 402 with challenge.
+    Challenge(PaymentRequired),
+    /// Verification failed — return 402 with error.
+    VerificationFailed(String),
+    /// Internal error generating challenge.
+    InternalError(String),
+}
+
+impl IntoResponse for MppChargeRejection {
+    fn into_response(self) -> axum_core::response::Response {
+        match self {
+            MppChargeRejection::Challenge(pr) => pr.into_response(),
+            MppChargeRejection::VerificationFailed(msg) => {
+                let body = serde_json::json!({ "error": msg });
+                (StatusCode::PAYMENT_REQUIRED, body.to_string()).into_response()
+            }
+            MppChargeRejection::InternalError(msg) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
+            }
+        }
+    }
+}
+
+/// Helper trait for [`MppCharge`] to generate challenges from the `Mpp` state.
+///
+/// This is automatically implemented for `Mpp` types that have the `tempo`
+/// feature enabled and bound currency/recipient.
+pub trait ChargeChallenger: Send + Sync + 'static {
+    /// Generate a charge challenge for a default amount.
+    fn default_challenge(&self) -> Result<PaymentChallenge, String>;
+
+    /// Verify a credential string.
+    fn verify_payment(
+        &self,
+        credential_str: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>;
+}
+
+#[cfg(feature = "tempo")]
+impl<S: Clone + Send + Sync + 'static> ChargeChallenger
+    for super::Mpp<super::TempoChargeMethod<super::TempoProvider>, S>
+{
+    fn default_challenge(&self) -> Result<PaymentChallenge, String> {
+        self.charge("0.01").map_err(|e| e.to_string())
+    }
+
+    fn verify_payment(
+        &self,
+        credential_str: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+        let mpp = self.clone();
+        Box::pin(async move {
+            super::Mpp::verify_credential(&mpp, &credential)
+                .await
+                .map_err(|e| e.to_string())
+        })
+    }
+}
+
+impl<S, M> FromRequestParts<Arc<super::Mpp<M, S>>> for MppCharge
+where
+    M: ChargeMethod + Clone + Send + Sync + 'static,
+    S: Clone + Send + Sync + 'static,
+    super::Mpp<M, S>: ChargeChallenger,
+{
+    type Rejection = MppChargeRejection;
+
+    fn from_request_parts(
+        parts: &mut http_types::request::Parts,
+        state: &Arc<super::Mpp<M, S>>,
+    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
+        let auth_header = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(extract_payment_scheme)
+            .map(|s| s.to_string());
+
+        let state = Arc::clone(state);
+
+        async move {
+            let credential_str = match auth_header {
+                Some(c) => c,
+                None => {
+                    let challenge = state
+                        .default_challenge()
+                        .map_err(MppChargeRejection::InternalError)?;
+                    return Err(MppChargeRejection::Challenge(PaymentRequired(challenge)));
+                }
+            };
+
+            let receipt = state
+                .verify_payment(&credential_str)
+                .await
+                .map_err(MppChargeRejection::VerificationFailed)?;
+
+            Ok(MppCharge { receipt })
+        }
+    }
+}
+
+// ==================== Receipt IntoResponse helper ====================
+
+/// A successful response with a [`Receipt`] attached as a `Payment-Receipt` header.
+///
+/// Wraps an inner response and attaches the receipt header.
+///
+/// # Example
+///
+/// ```ignore
+/// use mpp::server::axum::{MppCharge, WithReceipt};
+/// use axum::Json;
+///
+/// async fn handler(charge: MppCharge) -> WithReceipt<Json<serde_json::Value>> {
+///     WithReceipt {
+///         receipt: charge.receipt,
+///         body: Json(serde_json::json!({ "fortune": "good luck" })),
+///     }
+/// }
+/// ```
+pub struct WithReceipt<T> {
+    /// The payment receipt to include in the response.
+    pub receipt: Receipt,
+    /// The inner response body.
+    pub body: T,
+}
+
+impl<T: IntoResponse> IntoResponse for WithReceipt<T> {
+    fn into_response(self) -> axum_core::response::Response {
+        let mut resp = self.body.into_response();
+        if let Ok(header_val) = format_receipt(&self.receipt) {
+            if let Ok(val) = HeaderValue::from_str(&header_val) {
+                resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
+            }
+        }
+        resp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payment_required_into_response() {
+        use crate::protocol::core::Base64UrlJson;
+
+        let challenge = PaymentChallenge::new(
+            "test-id",
+            "test-realm",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
+        );
+        let resp = PaymentRequired(challenge).into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+    }
+
+    #[test]
+    fn test_rejection_verification_failed() {
+        let rejection = MppChargeRejection::VerificationFailed("bad payment".into());
+        let resp = rejection.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+    }
+
+    #[test]
+    fn test_rejection_internal_error() {
+        let rejection = MppChargeRejection::InternalError("oops".into());
+        let resp = rejection.into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_with_receipt_attaches_header() {
+        use crate::protocol::core::{MethodName, ReceiptStatus};
+
+        let receipt = Receipt {
+            status: ReceiptStatus::Success,
+            method: MethodName::new("tempo"),
+            timestamp: "2025-01-01T00:00:00Z".into(),
+            reference: "0xabc".into(),
+        };
+
+        let resp = WithReceipt {
+            receipt,
+            body: "ok",
+        }
+        .into_response();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+    }
+}

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -56,8 +56,8 @@
 //! }
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
-//!     currency: "0x20c...",
 //!     recipient: "0xabc...",
+//!     currency: None,
 //! })).unwrap();
 //!
 //! async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {
@@ -192,8 +192,8 @@ pub struct ChallengeOptions {
 /// }
 ///
 /// let mpp = Mpp::create(tempo(TempoConfig {
-///     currency: "0x20c...",
 ///     recipient: "0xabc...",
+///     currency: None,
 /// })).unwrap();
 ///
 /// async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -13,18 +13,28 @@
 //!
 //! # Per-route pricing
 //!
-//! The default [`MppCharge`] charges `$0.01`. To set a different amount
-//! per route, define a [`ChargeAmount`] type and use [`MppChargeFor<P>`]:
+//! Define a [`ChargeConfig`] type for each price point and use
+//! [`MppCharge<C>`] as the extractor:
 //!
 //! ```ignore
-//! use mpp::server::axum::{ChargeAmount, MppChargeFor};
+//! use mpp::server::axum::{ChargeConfig, MppCharge};
 //!
-//! struct OneDollar;
-//! impl ChargeAmount for OneDollar {
-//!     fn amount() -> &'static str { "1.00" }
+//! struct OneCent;
+//! impl ChargeConfig for OneCent {
+//!     fn amount() -> &'static str { "0.01" }
 //! }
 //!
-//! async fn expensive(charge: MppChargeFor<OneDollar>) -> &'static str {
+//! struct OneDollar;
+//! impl ChargeConfig for OneDollar {
+//!     fn amount() -> &'static str { "1.00" }
+//!     fn description() -> Option<&'static str> { Some("Premium content") }
+//! }
+//!
+//! async fn cheap(charge: MppCharge<OneCent>) -> &'static str {
+//!     "basic content"
+//! }
+//!
+//! async fn expensive(charge: MppCharge<OneDollar>) -> &'static str {
 //!     "premium content"
 //! }
 //! ```
@@ -37,15 +47,20 @@
 //! ```ignore
 //! use axum::{routing::get, Router, Json};
 //! use mpp::server::{Mpp, tempo, TempoConfig};
-//! use mpp::server::axum::{MppCharge, ChargeChallenger};
+//! use mpp::server::axum::{MppCharge, ChargeConfig, ChargeChallenger};
 //! use std::sync::Arc;
+//!
+//! struct OneCent;
+//! impl ChargeConfig for OneCent {
+//!     fn amount() -> &'static str { "0.01" }
+//! }
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
 //!     currency: "0x20c...",
 //!     recipient: "0xabc...",
 //! })).unwrap();
 //!
-//! async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
+//! async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {
 //!     Json(serde_json::json!({ "paid": true }))
 //! }
 //!
@@ -65,8 +80,6 @@ use crate::protocol::core::headers::{
     PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
 };
 use crate::protocol::core::{PaymentChallenge, Receipt};
-
-// ==================== IntoResponse for PaymentChallenge ====================
 
 /// A 402 Payment Required response wrapping a [`PaymentChallenge`].
 ///
@@ -115,52 +128,50 @@ impl IntoResponse for PaymentRequired {
     }
 }
 
-// ==================== Charge amount policy ====================
-
-/// Trait for specifying a static charge amount on a per-route basis.
+/// Per-route charge configuration.
 ///
-/// Implement this on a marker type and use [`MppChargeFor<P>`] as your
-/// extractor to control the dollar amount charged per route.
+/// Implement this on a marker type to define the amount and optional
+/// description for a payment-gated route. Only [`amount()`](ChargeConfig::amount)
+/// is required; [`description()`](ChargeConfig::description) defaults to `None`.
 ///
-/// This is designed for fixed per-route pricing. For dynamic pricing
-/// (per-user, per-request, etc.), implement [`ChargeChallenger`] directly
-/// or use a custom extractor.
+/// Server-level settings like `fee_payer` and `external_id` are configured
+/// on the [`Mpp`](super::Mpp) instance, not per-route.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use mpp::server::axum::{ChargeAmount, MppChargeFor};
+/// use mpp::server::axum::{ChargeConfig, MppCharge};
 ///
-/// struct TenCents;
-/// impl ChargeAmount for TenCents {
-///     fn amount() -> &'static str { "0.10" }
+/// struct PremiumFortune;
+/// impl ChargeConfig for PremiumFortune {
+///     fn amount() -> &'static str { "1.00" }
+///     fn description() -> Option<&'static str> { Some("Premium fortune reading") }
 /// }
 ///
-/// async fn handler(charge: MppChargeFor<TenCents>) -> &'static str {
+/// async fn handler(charge: MppCharge<PremiumFortune>) -> &'static str {
 ///     "paid content"
 /// }
 /// ```
-pub trait ChargeAmount {
+pub trait ChargeConfig {
     /// The dollar amount to charge (e.g., `"0.01"`, `"1.00"`).
     fn amount() -> &'static str;
-}
 
-/// Default charge amount: $0.01.
-#[derive(Debug)]
-pub struct DefaultAmount;
-
-impl ChargeAmount for DefaultAmount {
-    fn amount() -> &'static str {
-        "0.01"
+    /// Human-readable description included in the challenge.
+    fn description() -> Option<&'static str> {
+        None
     }
 }
 
-// ==================== MppCharge extractor ====================
+/// Options passed from a [`ChargeConfig`] to [`ChargeChallenger::challenge`].
+#[derive(Debug, Default)]
+pub struct ChallengeOptions {
+    /// Human-readable description.
+    pub description: Option<&'static str>,
+}
 
-/// Axum extractor that gates a handler behind charge payment verification.
+/// Axum extractor that gates a handler behind payment verification.
 ///
-/// Uses the default charge amount of `$0.01`. For custom amounts, use
-/// [`MppChargeFor`] with a [`ChargeAmount`] implementation.
+/// The type parameter `C` determines the charge configuration via [`ChargeConfig`].
 ///
 /// # State Requirements
 ///
@@ -170,17 +181,22 @@ impl ChargeAmount for DefaultAmount {
 /// # Example
 ///
 /// ```ignore
-/// use axum::{routing::get, Router, Json};
-/// use mpp::server::axum::{MppCharge, ChargeChallenger};
+/// use mpp::server::axum::{ChargeConfig, MppCharge, ChargeChallenger};
 /// use mpp::server::{Mpp, tempo, TempoConfig};
+/// use axum::{routing::get, Router, Json};
 /// use std::sync::Arc;
+///
+/// struct OneCent;
+/// impl ChargeConfig for OneCent {
+///     fn amount() -> &'static str { "0.01" }
+/// }
 ///
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     currency: "0x20c...",
 ///     recipient: "0xabc...",
 /// })).unwrap();
 ///
-/// async fn handler(charge: MppCharge) -> Json<serde_json::Value> {
+/// async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {
 ///     Json(serde_json::json!({ "status": "paid", "ref": charge.receipt.reference }))
 /// }
 ///
@@ -188,34 +204,14 @@ impl ChargeAmount for DefaultAmount {
 ///     .route("/premium", get(handler))
 ///     .with_state(Arc::new(mpp) as Arc<dyn ChargeChallenger>);
 /// ```
-pub type MppCharge = MppChargeFor<DefaultAmount>;
-
-/// Axum extractor that gates a handler with a configurable charge amount.
-///
-/// The type parameter `A` determines the dollar amount via [`ChargeAmount`].
-///
-/// # Example
-///
-/// ```ignore
-/// use mpp::server::axum::{ChargeAmount, MppChargeFor};
-///
-/// struct OneDollar;
-/// impl ChargeAmount for OneDollar {
-///     fn amount() -> &'static str { "1.00" }
-/// }
-///
-/// async fn expensive(charge: MppChargeFor<OneDollar>) -> &'static str {
-///     "premium content"
-/// }
-/// ```
 #[derive(Debug)]
-pub struct MppChargeFor<A: ChargeAmount> {
+pub struct MppCharge<C: ChargeConfig> {
     /// The verified payment receipt.
     pub receipt: Receipt,
-    _amount: std::marker::PhantomData<A>,
+    _config: std::marker::PhantomData<C>,
 }
 
-/// Rejection type for [`MppCharge`] and [`MppChargeFor`] extractors.
+/// Rejection type for [`MppCharge`] extractors.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum MppChargeRejection {
@@ -231,18 +227,13 @@ impl IntoResponse for MppChargeRejection {
     fn into_response(self) -> axum_core::response::Response {
         match self {
             MppChargeRejection::Challenge(pr) => pr.into_response(),
-            MppChargeRejection::VerificationFailed(pr) => {
-                // Return 402 with challenge so the client can retry.
-                pr.into_response()
-            }
+            MppChargeRejection::VerificationFailed(pr) => pr.into_response(),
             MppChargeRejection::InternalError(msg) => {
                 (StatusCode::INTERNAL_SERVER_ERROR, msg).into_response()
             }
         }
     }
 }
-
-// ==================== ChargeChallenger ====================
 
 /// Trait for generating payment challenges and verifying credentials.
 ///
@@ -252,8 +243,12 @@ impl IntoResponse for MppChargeRejection {
 ///
 /// The extractors require `Arc<dyn ChargeChallenger>` in router state.
 pub trait ChargeChallenger: Send + Sync + 'static {
-    /// Generate a charge challenge for the given dollar amount.
-    fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String>;
+    /// Generate a charge challenge for the given dollar amount and options.
+    fn challenge(
+        &self,
+        amount: &str,
+        options: ChallengeOptions,
+    ) -> Result<PaymentChallenge, String>;
 
     /// Verify a credential string and return a receipt.
     fn verify_payment(
@@ -268,8 +263,19 @@ where
     P: alloy::providers::Provider<tempo_alloy::TempoNetwork> + Clone + Send + Sync + 'static,
     S: Clone + Send + Sync + 'static,
 {
-    fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String> {
-        self.charge(amount).map_err(|e| e.to_string())
+    fn challenge(
+        &self,
+        amount: &str,
+        options: ChallengeOptions,
+    ) -> Result<PaymentChallenge, String> {
+        self.charge_with_options(
+            amount,
+            super::ChargeOptions {
+                description: options.description,
+                ..Default::default()
+            },
+        )
+        .map_err(|e| e.to_string())
     }
 
     fn verify_payment(
@@ -294,10 +300,10 @@ where
     }
 }
 
-impl<S, A> FromRequestParts<S> for MppChargeFor<A>
+impl<S, C> FromRequestParts<S> for MppCharge<C>
 where
     Arc<dyn ChargeChallenger>: FromRef<S>,
-    A: ChargeAmount,
+    C: ChargeConfig,
     S: Send + Sync,
 {
     type Rejection = MppChargeRejection;
@@ -315,11 +321,15 @@ where
             .map(|s| s.to_string());
 
         async move {
+            let options = ChallengeOptions {
+                description: C::description(),
+            };
+
             let credential_str = match auth_header {
                 Some(c) => c,
                 None => {
                     let challenge = challenger
-                        .challenge(A::amount())
+                        .challenge(C::amount(), options)
                         .map_err(MppChargeRejection::InternalError)?;
                     return Err(MppChargeRejection::Challenge(PaymentRequired(challenge)));
                 }
@@ -329,7 +339,7 @@ where
                 Ok(r) => r,
                 Err(_) => {
                     let challenge = challenger
-                        .challenge(A::amount())
+                        .challenge(C::amount(), options)
                         .map_err(MppChargeRejection::InternalError)?;
                     return Err(MppChargeRejection::VerificationFailed(PaymentRequired(
                         challenge,
@@ -337,15 +347,13 @@ where
                 }
             };
 
-            Ok(MppChargeFor {
+            Ok(MppCharge {
                 receipt,
-                _amount: std::marker::PhantomData,
+                _config: std::marker::PhantomData,
             })
         }
     }
 }
-
-// ==================== Receipt IntoResponse helper ====================
 
 /// A successful response with a [`Receipt`] attached as a `Payment-Receipt` header.
 ///
@@ -354,10 +362,15 @@ where
 /// # Example
 ///
 /// ```ignore
-/// use mpp::server::axum::{MppCharge, WithReceipt};
+/// use mpp::server::axum::{ChargeConfig, MppCharge, WithReceipt};
 /// use axum::Json;
 ///
-/// async fn handler(charge: MppCharge) -> WithReceipt<Json<serde_json::Value>> {
+/// struct OneCent;
+/// impl ChargeConfig for OneCent {
+///     fn amount() -> &'static str { "0.01" }
+/// }
+///
+/// async fn handler(charge: MppCharge<OneCent>) -> WithReceipt<Json<serde_json::Value>> {
 ///     WithReceipt {
 ///         receipt: charge.receipt,
 ///         body: Json(serde_json::json!({ "fortune": "good luck" })),
@@ -388,8 +401,6 @@ mod tests {
     use super::*;
     use crate::protocol::core::Base64UrlJson;
 
-    // ==================== Test helpers ====================
-
     fn test_challenge() -> PaymentChallenge {
         PaymentChallenge::new(
             "test-id",
@@ -400,13 +411,16 @@ mod tests {
         )
     }
 
-    /// Mock [`ChargeChallenger`] for extractor tests.
     struct MockChallenger {
         accept: bool,
     }
 
     impl ChargeChallenger for MockChallenger {
-        fn challenge(&self, amount: &str) -> Result<PaymentChallenge, String> {
+        fn challenge(
+            &self,
+            amount: &str,
+            _options: ChallengeOptions,
+        ) -> Result<PaymentChallenge, String> {
             Ok(PaymentChallenge::new(
                 "mock-id",
                 "mock-realm",
@@ -437,7 +451,13 @@ mod tests {
         }
     }
 
-    // ==================== PaymentRequired tests ====================
+    #[derive(Debug)]
+    struct OneCent;
+    impl ChargeConfig for OneCent {
+        fn amount() -> &'static str {
+            "0.01"
+        }
+    }
 
     #[test]
     fn test_payment_required_into_response() {
@@ -454,8 +474,6 @@ mod tests {
             "application/json"
         );
     }
-
-    // ==================== MppChargeRejection tests ====================
 
     #[test]
     fn test_rejection_challenge_returns_402_with_header() {
@@ -480,17 +498,10 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 
-    // ==================== ChargeAmount tests ====================
-
-    #[test]
-    fn test_default_amount() {
-        assert_eq!(DefaultAmount::amount(), "0.01");
-    }
-
     #[test]
     fn test_custom_amount() {
         struct FiveDollars;
-        impl ChargeAmount for FiveDollars {
+        impl ChargeConfig for FiveDollars {
             fn amount() -> &'static str {
                 "5.00"
             }
@@ -498,7 +509,25 @@ mod tests {
         assert_eq!(FiveDollars::amount(), "5.00");
     }
 
-    // ==================== WithReceipt tests ====================
+    #[test]
+    fn test_config_defaults() {
+        assert_eq!(OneCent::description(), None);
+    }
+
+    #[test]
+    fn test_config_overrides() {
+        struct Premium;
+        impl ChargeConfig for Premium {
+            fn amount() -> &'static str {
+                "10.00"
+            }
+            fn description() -> Option<&'static str> {
+                Some("Premium access")
+            }
+        }
+        assert_eq!(Premium::amount(), "10.00");
+        assert_eq!(Premium::description(), Some("Premium access"));
+    }
 
     #[test]
     fn test_with_receipt_attaches_header() {
@@ -521,12 +550,12 @@ mod tests {
         assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
     }
 
-    // ==================== ChargeChallenger mock tests ====================
-
     #[test]
     fn test_mock_challenger_generates_challenge() {
         let challenger = MockChallenger { accept: true };
-        let challenge = challenger.challenge("0.50").unwrap();
+        let challenge = challenger
+            .challenge("0.50", ChallengeOptions::default())
+            .unwrap();
         assert_eq!(challenge.id, "mock-id");
     }
 
@@ -545,13 +574,10 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ==================== FromRequestParts integration tests ====================
-
-    /// Helper to run the extractor against a mock request.
-    async fn run_extractor<A: ChargeAmount>(
+    async fn run_extractor<C: ChargeConfig>(
         challenger: MockChallenger,
         auth_header: Option<&str>,
-    ) -> Result<MppChargeFor<A>, MppChargeRejection> {
+    ) -> Result<MppCharge<C>, MppChargeRejection> {
         let state: Arc<dyn ChargeChallenger> = Arc::new(challenger);
         let mut builder = http_types::Request::builder().uri("/test");
         if let Some(auth) = auth_header {
@@ -559,12 +585,12 @@ mod tests {
         }
         let req = builder.body(()).unwrap();
         let (mut parts, _body) = req.into_parts();
-        MppChargeFor::<A>::from_request_parts(&mut parts, &state).await
+        MppCharge::<C>::from_request_parts(&mut parts, &state).await
     }
 
     #[tokio::test]
     async fn test_extractor_no_auth_returns_challenge() {
-        let result = run_extractor::<DefaultAmount>(MockChallenger { accept: true }, None).await;
+        let result = run_extractor::<OneCent>(MockChallenger { accept: true }, None).await;
         let err = result.unwrap_err();
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
@@ -573,7 +599,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_extractor_valid_payment_returns_receipt() {
-        let result = run_extractor::<DefaultAmount>(
+        let result = run_extractor::<OneCent>(
             MockChallenger { accept: true },
             Some("Payment eyJmYWtlIjp0cnVlfQ"),
         )
@@ -584,7 +610,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_extractor_invalid_payment_returns_challenge_for_retry() {
-        let result = run_extractor::<DefaultAmount>(
+        let result = run_extractor::<OneCent>(
             MockChallenger { accept: false },
             Some("Payment eyJmYWtlIjp0cnVlfQ"),
         )
@@ -598,27 +624,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_extractor_wrong_scheme_returns_challenge() {
-        let result = run_extractor::<DefaultAmount>(
-            MockChallenger { accept: true },
-            Some("Bearer some-token"),
-        )
-        .await;
+        let result =
+            run_extractor::<OneCent>(MockChallenger { accept: true }, Some("Bearer some-token"))
+                .await;
         let err = result.unwrap_err();
         assert!(matches!(err, MppChargeRejection::Challenge(_)));
     }
 
     #[tokio::test]
     async fn test_extractor_custom_amount() {
+        #[derive(Debug)]
         struct TenCents;
-        impl ChargeAmount for TenCents {
+        impl ChargeConfig for TenCents {
             fn amount() -> &'static str {
                 "0.10"
             }
         }
 
-        // No auth → challenge should be generated (verifying custom amount type works)
-        let result =
-            run_extractor::<TenCents>(MockChallenger { accept: true }, None).await;
+        let result = run_extractor::<TenCents>(MockChallenger { accept: true }, None).await;
         assert!(result.is_err());
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -57,7 +57,6 @@
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
 //!     recipient: "0xabc...",
-//!     currency: None,
 //! })).unwrap();
 //!
 //! async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {
@@ -193,7 +192,6 @@ pub struct ChallengeOptions {
 ///
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     recipient: "0xabc...",
-///     currency: None,
 /// })).unwrap();
 ///
 /// async fn handler(charge: MppCharge<OneCent>) -> Json<serde_json::Value> {

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -12,8 +12,8 @@
 //! use mpp::server::{Mpp, tempo, TempoConfig};
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
-//!     currency: "0x20c...",
 //!     recipient: "0xabc...",
+//!     currency: None,
 //! })).unwrap();
 //!
 //! let app = Router::new()

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -13,7 +13,6 @@
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
 //!     recipient: "0xabc...",
-//!     currency: None,
 //! })).unwrap();
 //!
 //! let app = Router::new()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,8 +6,8 @@
 //! use mpp::server::{Mpp, tempo, TempoConfig};
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
-//!     currency: "0x20c0000000000000000000000000000000000000",
 //!     recipient: "0xabc...123",
+//!     currency: None, // defaults to pathUSD
 //! }))?;
 //!
 //! // Charge $0.10 — everything else has smart defaults
@@ -59,13 +59,13 @@ pub use crate::protocol::methods::tempo::session_method::{
 
 /// Configuration for the Tempo payment method.
 ///
-/// Only `currency` and `recipient` are required. Everything else has smart defaults.
+/// Only `recipient` is required. Everything else has smart defaults.
 #[cfg(feature = "tempo")]
 pub struct TempoConfig<'a> {
-    /// Token address (e.g., pathUSD).
-    pub currency: &'a str,
     /// Recipient address for payments.
     pub recipient: &'a str,
+    /// Token address. Defaults to pathUSD (`0x20c0...`).
+    pub currency: Option<&'a str>,
 }
 
 /// Builder returned by [`tempo()`] for configuring a Tempo payment method.
@@ -181,6 +181,7 @@ pub struct ChargeOptions<'a> {
 /// - **rpc_url**: `https://rpc.tempo.xyz`
 /// - **realm**: `"MPP Payment"`
 /// - **secret_key**: reads `MPP_SECRET_KEY` env var, or generates a random UUID
+/// - **currency**: pathUSD (`0x20c0000000000000000000000000000000000000`)
 /// - **decimals**: `6` (for pathUSD / standard stablecoins)
 /// - **expires**: `now + 5 minutes`
 ///
@@ -189,17 +190,17 @@ pub struct ChargeOptions<'a> {
 /// ```ignore
 /// use mpp::server::{Mpp, tempo, TempoConfig};
 ///
-/// // Minimal
+/// // Minimal — currency defaults to pathUSD
 /// let mpp = Mpp::create(tempo(TempoConfig {
-///     currency: "0x20c0000000000000000000000000000000000000",
 ///     recipient: "0xabc...123",
+///     currency: None,
 /// }))?;
 ///
 /// // With overrides
 /// let mpp = Mpp::create(
 ///     tempo(TempoConfig {
-///         currency: "0x20c0000000000000000000000000000000000000",
 ///         recipient: "0xabc...123",
+///         currency: Some("0xcustom_token_address"),
 ///     })
 ///     .rpc_url("https://rpc.moderato.tempo.xyz")
 ///     .realm("my-api.com")
@@ -210,7 +211,10 @@ pub struct ChargeOptions<'a> {
 #[cfg(feature = "tempo")]
 pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
     TempoBuilder {
-        currency: config.currency.to_string(),
+        currency: config
+            .currency
+            .unwrap_or(crate::protocol::methods::tempo::DEFAULT_CURRENCY)
+            .to_string(),
         recipient: config.recipient.to_string(),
         rpc_url: crate::protocol::methods::tempo::DEFAULT_RPC_URL.to_string(),
         realm: "MPP Payment".to_string(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -29,11 +29,13 @@
 
 mod amount;
 mod mpp;
-#[cfg(feature = "tempo")]
 pub mod sse;
 
 #[cfg(feature = "tower")]
 pub mod middleware;
+
+#[cfg(feature = "axum")]
+pub mod axum;
 
 pub use crate::protocol::traits::{ChargeMethod, ErrorCode, SessionMethod, VerificationError};
 pub use amount::{parse_dollar_amount, AmountError};

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -7,7 +7,6 @@
 //!
 //! let mpp = Mpp::create(tempo(TempoConfig {
 //!     recipient: "0xabc...123",
-//!     currency: None, // defaults to pathUSD
 //! }))?;
 //!
 //! // Charge $0.10 — everything else has smart defaults
@@ -64,8 +63,6 @@ pub use crate::protocol::methods::tempo::session_method::{
 pub struct TempoConfig<'a> {
     /// Recipient address for payments.
     pub recipient: &'a str,
-    /// Token address. Defaults to pathUSD (`0x20c0...`).
-    pub currency: Option<&'a str>,
 }
 
 /// Builder returned by [`tempo()`] for configuring a Tempo payment method.
@@ -102,6 +99,12 @@ impl TempoBuilder {
     /// Explicitly set the chain ID for challenges.
     pub fn chain_id(mut self, id: u64) -> Self {
         self.chain_id = Some(id);
+        self
+    }
+
+    /// Override the token currency (default: pathUSD `0x20c0...`).
+    pub fn currency(mut self, addr: &str) -> Self {
+        self.currency = addr.to_string();
         self
     }
 
@@ -193,15 +196,14 @@ pub struct ChargeOptions<'a> {
 /// // Minimal — currency defaults to pathUSD
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     recipient: "0xabc...123",
-///     currency: None,
 /// }))?;
 ///
 /// // With overrides
 /// let mpp = Mpp::create(
 ///     tempo(TempoConfig {
 ///         recipient: "0xabc...123",
-///         currency: Some("0xcustom_token_address"),
 ///     })
+///     .currency("0xcustom_token_address")
 ///     .rpc_url("https://rpc.moderato.tempo.xyz")
 ///     .realm("my-api.com")
 ///     .secret_key("my-secret")
@@ -211,10 +213,7 @@ pub struct ChargeOptions<'a> {
 #[cfg(feature = "tempo")]
 pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
     TempoBuilder {
-        currency: config
-            .currency
-            .unwrap_or(crate::protocol::methods::tempo::DEFAULT_CURRENCY)
-            .to_string(),
+        currency: crate::protocol::methods::tempo::DEFAULT_CURRENCY.to_string(),
         recipient: config.recipient.to_string(),
         rpc_url: crate::protocol::methods::tempo::DEFAULT_RPC_URL.to_string(),
         realm: "MPP Payment".to_string(),

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -10,7 +10,6 @@
 //!
 //! let mpp = Mpp::create(tempo(mpp::server::TempoConfig {
 //!     recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
-//!     currency: None,
 //! }))?;
 //!
 //! let challenge = mpp.charge("0.10")?;
@@ -49,7 +48,6 @@ pub struct SessionVerifyResult {
 ///
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     recipient: "0xabc...123",
-///     currency: None,
 /// }))?;
 ///
 /// // Charge $0.10 — currency, recipient, realm, secret, expires all handled
@@ -702,7 +700,6 @@ mod tests {
         Mpp::create(
             tempo(TempoConfig {
                 recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
-                currency: None,
             })
             .secret_key("test-secret"),
         )

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -9,8 +9,8 @@
 //! use mpp::server::{Mpp, tempo};
 //!
 //! let mpp = Mpp::create(tempo(mpp::server::TempoConfig {
-//!     currency: "0x20c0000000000000000000000000000000000000",
 //!     recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+//!     currency: None,
 //! }))?;
 //!
 //! let challenge = mpp.charge("0.10")?;
@@ -48,8 +48,8 @@ pub struct SessionVerifyResult {
 /// use mpp::server::{Mpp, tempo, TempoConfig};
 ///
 /// let mpp = Mpp::create(tempo(TempoConfig {
-///     currency: "0x20c0000000000000000000000000000000000000",
 ///     recipient: "0xabc...123",
+///     currency: None,
 /// }))?;
 ///
 /// // Charge $0.10 — currency, recipient, realm, secret, expires all handled
@@ -701,8 +701,8 @@ mod tests {
     fn create_test_mpp() -> Mpp<crate::server::TempoChargeMethod<crate::server::TempoProvider>> {
         Mpp::create(
             tempo(TempoConfig {
-                currency: "0x20c0000000000000000000000000000000000000",
                 recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+                currency: None,
             })
             .secret_key("test-secret"),
         )

--- a/src/server/sse.rs
+++ b/src/server/sse.rs
@@ -12,6 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "tempo")]
 use crate::protocol::methods::tempo::stream_receipt::StreamReceipt;
 
 // ---------------------------------------------------------------------------
@@ -70,6 +71,7 @@ pub enum SseEvent {
     /// Balance exhausted — client should send a new voucher.
     PaymentNeedVoucher(NeedVoucherEvent),
     /// Final receipt for the stream session.
+    #[cfg(feature = "tempo")]
     PaymentReceipt(StreamReceipt),
 }
 
@@ -96,6 +98,7 @@ pub enum SseEvent {
 /// assert!(event.starts_with("event: payment-receipt\ndata: "));
 /// assert!(event.ends_with("\n\n"));
 /// ```
+#[cfg(feature = "tempo")]
 pub fn format_receipt_event(receipt: &StreamReceipt) -> String {
     format!(
         "event: payment-receipt\ndata: {}\n\n",
@@ -149,7 +152,7 @@ pub fn format_message_event(data: &str) -> String {
 /// Handles the three event types used by mpp streaming:
 /// - `message` (default / no event field) — application data
 /// - `payment-need-voucher` — balance exhausted
-/// - `payment-receipt` — final receipt
+/// - `payment-receipt` — final receipt (requires `tempo` feature)
 ///
 /// Returns `None` if no `data:` lines are present.
 ///
@@ -188,6 +191,7 @@ pub fn parse_event(raw: &str) -> Option<SseEvent> {
         "payment-need-voucher" => serde_json::from_str::<NeedVoucherEvent>(&data)
             .ok()
             .map(SseEvent::PaymentNeedVoucher),
+        #[cfg(feature = "tempo")]
         "payment-receipt" => serde_json::from_str::<StreamReceipt>(&data)
             .ok()
             .map(SseEvent::PaymentReceipt),
@@ -242,15 +246,16 @@ pub struct ServeOptions<G> {
 ///    waits for the client to top up
 /// 4. On completion, yields a final `event: payment-receipt\n...`
 ///
-/// Returns a [`tokio::sync::mpsc::Receiver`] that yields `String` SSE events.
+/// Returns a [`Stream`](futures_core::Stream) that yields `String` SSE events.
 #[cfg(feature = "tempo")]
-pub fn serve<G>(options: ServeOptions<G>) -> tokio::sync::mpsc::Receiver<String>
+pub fn serve<G>(
+    options: ServeOptions<G>,
+) -> std::pin::Pin<Box<dyn futures_core::Stream<Item = String> + Send>>
 where
     G: futures_core::Stream<Item = String> + Send + Unpin + 'static,
 {
     use crate::protocol::methods::tempo::session_method::deduct_from_channel;
 
-    let (tx, rx) = tokio::sync::mpsc::channel(32);
     let ServeOptions {
         store,
         channel_id,
@@ -260,7 +265,7 @@ where
         poll_interval_ms,
     } = options;
 
-    tokio::spawn(async move {
+    Box::pin(async_stream::stream! {
         let mut stream = std::pin::pin!(generate);
 
         while let Some(value) = next_item(&mut stream).await {
@@ -277,9 +282,7 @@ where
                                 accepted_cumulative: ch.highest_voucher_amount.to_string(),
                                 deposit: ch.deposit.to_string(),
                             });
-                            if tx.send(event).await.is_err() {
-                                return;
-                            }
+                            yield event;
                         }
 
                         // Wait for channel update or poll interval
@@ -292,9 +295,7 @@ where
             }
 
             let event = format_message_event(&value);
-            if tx.send(event).await.is_err() {
-                return;
-            }
+            yield event;
         }
 
         // Emit final receipt
@@ -308,11 +309,9 @@ where
             );
             receipt.units = Some(ch.units);
             let event = format_receipt_event(&receipt);
-            let _ = tx.send(event).await;
+            yield event;
         }
-    });
-
-    rx
+    })
 }
 
 /// Poll the next item from a stream (avoids depending on StreamExt).
@@ -370,6 +369,7 @@ mod tests {
 
     // -- Format tests --
 
+    #[cfg(feature = "tempo")]
     #[test]
     fn test_format_receipt_event() {
         let mut receipt =
@@ -438,6 +438,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "tempo")]
     #[test]
     fn test_parse_event_receipt() {
         let data = serde_json::json!({
@@ -498,6 +499,7 @@ mod tests {
 
     // -- StreamReceipt tests --
 
+    #[cfg(feature = "tempo")]
     #[test]
     fn test_stream_receipt_new() {
         let mut receipt =
@@ -515,6 +517,7 @@ mod tests {
         assert!(!receipt.timestamp.is_empty());
     }
 
+    #[cfg(feature = "tempo")]
     #[test]
     fn test_stream_receipt_serialization() {
         let mut receipt =

--- a/src/server/sse.rs
+++ b/src/server/sse.rs
@@ -36,22 +36,13 @@ use crate::protocol::methods::tempo::stream_receipt::StreamReceipt;
 /// };
 /// assert_eq!(event.channel_id, "0xabc");
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NeedVoucherEvent {
     pub channel_id: String,
     pub required_cumulative: String,
     pub accepted_cumulative: String,
     pub deposit: String,
-}
-
-impl PartialEq for NeedVoucherEvent {
-    fn eq(&self, other: &Self) -> bool {
-        self.channel_id == other.channel_id
-            && self.required_cumulative == other.required_cumulative
-            && self.accepted_cumulative == other.accepted_cumulative
-            && self.deposit == other.deposit
-    }
 }
 
 /// Parsed SSE event (discriminated union).
@@ -152,7 +143,8 @@ pub fn format_message_event(data: &str) -> String {
 /// Handles the three event types used by mpp streaming:
 /// - `message` (default / no event field) — application data
 /// - `payment-need-voucher` — balance exhausted
-/// - `payment-receipt` — final receipt (requires `tempo` feature)
+/// - `payment-receipt` — final receipt (requires `tempo` feature;
+///   without it, receipt events are returned as `Message`)
 ///
 /// Returns `None` if no `data:` lines are present.
 ///


### PR DESCRIPTION
## Summary

Three changes to improve the SDK:

### 1. Update package description
Changed from "Machine Payment Protocol - Rust library for Web Payment Auth" to match the mppx (TypeScript sibling) format:
> Rust implementation of the "Payment" HTTP Authentication Scheme (402 Protocol).

### 2. Make SSE pluggable

**SSE module ungated from `tempo`**: The `sse` module was previously gated behind `#[cfg(feature = "tempo")]`. The generic format/parse utilities (`format_message_event`, `format_need_voucher_event`, `parse_event`, `is_event_stream`, `sse_headers`, `NeedVoucherEvent`, `SseEvent`) are now available with just the `server` feature. Only `StreamReceipt`-dependent items (`format_receipt_event`, `SseEvent::PaymentReceipt`, `serve()`, `ServeOptions`) still require `tempo`.

**`serve()` returns a Stream**: Changed from `tokio::sync::mpsc::Receiver<String>` to `Pin<Box<dyn Stream<Item = String> + Send>>`. This makes it composable with any framework (axum, actix, warp) without requiring an intermediate `async_stream` wrapper at the call site.

### 3. Add axum feature flag with first-class middleware

New `axum` feature flag (implies `server` and `http-types`) with:

- **`MppCharge`** extractor — handles the full 402 challenge/verify flow automatically, eliminating the boilerplate from handlers (see `examples/basic/src/server.rs` fortune handler for the pattern it replaces)
- **`PaymentRequired`** — `IntoResponse` for `PaymentChallenge` (402 response)
- **`WithReceipt<T>`** — attaches `Payment-Receipt` header to any response
- **`ChargeChallenger`** trait — abstracts payment verification for extractors

### 4. Fix `transferWithMemo` selector

Updated `TRANSFER_WITH_MEMO_SELECTOR` from `0x4a7a1364` to `0x95777d59` to match the correct `bytes4(keccak256("transferWithMemo(address,uint256,bytes32)"))`. The server now also accepts `transferWithMemo` when no memo was specified in the challenge, so clients that attach attribution memos are not rejected.

### Testing

- `make check` passes (fmt, clippy --all-features, test, build)
- 392 tests pass with `--all-features` (including cross-SDK golden vectors)
- Golden vectors match conformance test fixtures in `conformance/vectors/challenge-id.json`