### PR TITLE
feat: mandate JCS (RFC 8785) for canonical JSON serialization of request parameter

### DIFF
--- a/.changelog/gentle-cats-dance.md
+++ b/.changelog/gentle-cats-dance.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Mandated JCS (RFC 8785) for canonical JSON serialization of request parameters by replacing `serde_json::to_string` with `serde_json_canonicalizer::to_string` throughout the protocol layer.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", 
 # Core dependencies (always included)
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+serde_json_canonicalizer = "0.3"
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 hmac = "0.12"

--- a/src/protocol/core/types.rs
+++ b/src/protocol/core/types.rs
@@ -189,14 +189,14 @@ impl Base64UrlJson {
     /// Create from a JSON Value by encoding it.
     #[must_use = "this returns a new Base64UrlJson and does not modify the input"]
     pub fn from_value(value: &serde_json::Value) -> Result<Self> {
-        let json = serde_json::to_string(value)?;
+        let json = serde_json_canonicalizer::to_string(value)?;
         let raw = base64url_encode(json.as_bytes());
         Ok(Self { raw })
     }
 
     /// Create from a serializable type by encoding it.
     pub fn from_typed<T: Serialize>(value: &T) -> Result<Self> {
-        let json = serde_json::to_string(value)?;
+        let json = serde_json_canonicalizer::to_string(value)?;
         let raw = base64url_encode(json.as_bytes());
         Ok(Self { raw })
     }

--- a/src/protocol/intents/payment_request.rs
+++ b/src/protocol/intents/payment_request.rs
@@ -21,7 +21,7 @@ pub fn from<T>(request: T) -> T {
 
 /// Serialize a request into base64url JSON (no padding).
 pub fn serialize<T: Serialize>(request: &T) -> Result<String> {
-    let json = serde_json::to_string(request)?;
+    let json = serde_json_canonicalizer::to_string(request)?;
     Ok(base64url_encode(json.as_bytes()))
 }
 


### PR DESCRIPTION
## Problem

The `request` parameter is base64url-encoded JSON that feeds into the HMAC-SHA256 challenge ID computation. Without canonical serialization, different implementations may produce different JSON key orderings, resulting in different HMAC values for the same logical request.

This breaks cross-implementation interoperability: a challenge created by one implementation may not be verifiable by another if the JSON keys happen to be in a different order.

## Changes

- Adds `serde_json_canonicalizer` (RFC 8785 JCS implementation) as a dependency
- Updates `Base64UrlJson::from_value()`, `Base64UrlJson::from_typed()`, and `payment_request::serialize()` to use JCS before base64url encoding
- Ensures deterministic HMAC computation across all implementations

Spec change: https://github.com/tempoxyz/mpp-specs/pull/141