### PR TITLE
fix: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Version


### PR DESCRIPTION
The Release workflow fails with a 403 when `changelogs-rs` tries to push the `changelog-release/main` branch because the default `GITHUB_TOKEN` is read-only.

Adds `contents: write` and `pull-requests: write` permissions so the action can push commits and create version PRs.