### PR TITLE
fix: make basic-client accept URL and headers as CLI args

### DIFF
--- a/.changelog/vain-hills-break.md
+++ b/.changelog/vain-hills-break.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed support for fee-payer-sponsored Tempo transactions by setting placeholder fee payer signatures in the client, appending sender address with magic bytes for server identification, and normalizing viem-encoded transactions that use `0x00` instead of `0x80` for empty fee payer signature placeholders.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,23 @@
 # mpp
 
+Rust SDK for the [**Machine Payments Protocol**](https://machinepayments.dev)
+
 [![Docs](https://img.shields.io/badge/docs-github%20pages-blue)](https://tempoxyz.github.io/mpp-rs)
+[![License](https://img.shields.io/crates/l/mpp.svg)](LICENSE)
 
-Rust SDK for the Machine Payments Protocol (MPP) — an implementation of the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/).
+## Documentation
 
-## Architecture
+Full documentation, API reference, and guides are available at **[machinepayments.dev/sdk/rust](https://machinepayments.dev/sdk/rust)**.
 
-### Core Types
+## Install
 
-| Type | Role | HTTP Header |
-|------|------|-------------|
-| `PaymentChallenge` | Server's payment request | `WWW-Authenticate: Payment ...` |
-| `ChargeRequest` | Typed request schema (inside challenge) | Base64 in `request=` param |
-| `PaymentCredential` | Client's payment proof | `Authorization: Payment ...` |
-| `Receipt` | Server's confirmation | `Payment-Receipt: ...` |
-
-### Traits
-
-| Trait | Side | Purpose |
-|-------|------|---------|
-| `ChargeMethod` | Server | Verify credentials against `ChargeRequest` |
-| `PaymentProvider` | Client | Create credentials from challenges |
-
-### Intents
-
-Two built-in intent types:
-
-- **`charge`** — One-time immediate payments (`ChargeRequest`)
-- **`session`** — Pay-as-you-go streaming payments (`SessionRequest`)
-
-Both support a `decimals` field for human-readable amounts (e.g., `"1.5"` with `decimals: 6` → `"1500000"`). The `decimals` field is input-only and stripped from wire serialization.
+```bash
+cargo add mpp
+```
 
 ## Quick Start
 
-### Server (simple API)
+### Server
 
 ```rust
 use mpp::server::{Mpp, tempo, TempoConfig};
@@ -46,29 +30,7 @@ let challenge = mpp.charge("1")?;
 let receipt = mpp.verify_credential(&credential).await?;
 ```
 
-### Server (advanced API)
-
-```rust
-use mpp::server::{Mpp, tempo_provider, TempoChargeMethod};
-
-let provider = tempo_provider("https://rpc.moderato.tempo.xyz")?;
-let method = TempoChargeMethod::new(provider);
-let payment = Mpp::new(method, "api.example.com", "my-server-secret");
-
-let challenge = payment.charge_challenge("1000000", "0x...", "0x...")?;
-let receipt = payment.verify(&credential, &request).await?;
-```
-
-### Client (extension trait)
-
-```rust
-use mpp::client::{Fetch, TempoProvider};
-
-let provider = TempoProvider::new(signer, "https://rpc.moderato.tempo.xyz")?;
-let resp = client.get(url).send_with_payment(&provider).await?;
-```
-
-### Client (middleware)
+### Client
 
 ```rust
 use mpp::client::{PaymentMiddleware, TempoProvider};
@@ -78,6 +40,9 @@ let provider = TempoProvider::new(signer, "https://rpc.moderato.tempo.xyz")?;
 let client = ClientBuilder::new(reqwest::Client::new())
     .with(PaymentMiddleware::new(provider))
     .build();
+
+// Requests now handle 402 automatically
+let resp = client.get("https://api.example.com/resource").send().await?;
 ```
 
 ## Feature Flags
@@ -91,22 +56,9 @@ let client = ClientBuilder::new(reqwest::Client::new())
 | `middleware` | reqwest-middleware support with `PaymentMiddleware` (implies `client`) |
 | `utils` | Hex/random utilities for development and testing |
 
-The `tempo` feature requires a git patch:
+## Protocol
 
-```toml
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
-```
-
-## Commands
-
-```bash
-make build      # Build with default features (tempo)
-make test       # Run tests
-make check      # Format check, clippy, test, and build
-make fix        # Auto-fix formatting and clippy warnings
-```
+Built on the ["Payment" HTTP Authentication Scheme](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/). See [payment-auth-spec](https://github.com/tempoxyz/payment-auth-spec) for the full specification.
 
 ## License
 

--- a/examples/basic/src/client.rs
+++ b/examples/basic/src/client.rs
@@ -12,6 +12,9 @@
 //! # Then in another terminal:
 //! cargo run --bin basic-client
 //!
+//! # Or target any external server:
+//! cargo run --bin basic-client -- https://mpp.sh/api/ping/paid -H "x-vercel-protection-bypass: TOKEN"
+//!
 //! # Optional: provide your own private key
 //! export PRIVATE_KEY=0x...
 //! cargo run --bin basic-client
@@ -56,13 +59,35 @@ async fn main() {
     let provider =
         TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
 
-    let base_url = std::env::var("BASE_URL")
-        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let args: Vec<String> = std::env::args().skip(1).collect();
 
-    let client = Client::new();
+    let mut url = "http://localhost:3000/api/fortune".to_string();
+    let mut extra_headers = reqwest::header::HeaderMap::new();
 
-    let url = format!("{base_url}/api/fortune");
-    println!("Fetching fortune from {url} ...");
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-H" => {
+                i += 1;
+                if let Some((key, val)) = args.get(i).and_then(|h| h.split_once(':')) {
+                    extra_headers.insert(
+                        reqwest::header::HeaderName::from_bytes(key.trim().as_bytes())
+                            .expect("invalid header name"),
+                        val.trim().parse().expect("invalid header value"),
+                    );
+                }
+            }
+            _ => url = args[i].clone(),
+        }
+        i += 1;
+    }
+
+    let client = Client::builder()
+        .default_headers(extra_headers)
+        .build()
+        .expect("failed to build client");
+
+    println!("Fetching {url} ...");
 
     let resp = client
         .get(&url)
@@ -80,10 +105,14 @@ async fn main() {
         }
     }
 
-    let body: serde_json::Value = resp.json().await.expect("failed to parse response");
+    let body = resp.text().await.expect("failed to read response body");
 
-    if let Some(fortune) = body.get("fortune").and_then(|v| v.as_str()) {
-        println!("\nFortune: {fortune}");
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+        if let Some(fortune) = json.get("fortune").and_then(|v| v.as_str()) {
+            println!("\nFortune: {fortune}");
+        } else {
+            println!("\nResponse: {json}");
+        }
     } else {
         println!("\nResponse: {body}");
     }

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -203,13 +203,28 @@ impl PaymentProvider for TempoProvider {
             .await
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
+        // When fee sponsorship is requested, set a placeholder fee_payer_signature
+        // so that encode_for_signing excludes fee_token from the signing hash.
+        // The server will replace this with the real fee payer signature.
+        let is_fee_payer = charge.fee_payer();
+        let fee_payer_signature = if is_fee_payer {
+            Some(alloy::primitives::Signature::new(
+                alloy::primitives::U256::ZERO,
+                alloy::primitives::U256::ZERO,
+                false,
+            ))
+        } else {
+            None
+        };
+
         // Build a Tempo transaction (type 0x76) for proper on-chain processing.
         let tempo_tx = TempoTransaction {
             chain_id: expected_chain_id,
             nonce,
-            gas_limit: 1_000_000,
+            gas_limit: 300_000,
             max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: gas_price,
+            max_priority_fee_per_gas: 2,
+            fee_payer_signature,
             calls: vec![Call {
                 to: TxKind::Call(currency),
                 value: alloy::primitives::U256::ZERO,
@@ -227,7 +242,18 @@ impl PaymentProvider for TempoProvider {
 
         let signed_tx = tempo_tx.into_signed(signature.into());
         let tx_bytes = signed_tx.encoded_2718();
-        let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+        let signed_tx_hex = if is_fee_payer {
+            // Append sender address + magic bytes for fee payer flow.
+            // The server uses this to identify the sender when computing
+            // the fee payer signature hash.
+            format!(
+                "0x{}{}feefeefeefee",
+                hex::encode(&tx_bytes),
+                hex::encode(address.as_slice())
+            )
+        } else {
+            format!("0x{}", hex::encode(&tx_bytes))
+        };
 
         let echo = challenge.to_echo();
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -98,7 +98,14 @@ pub struct TempoProvider {
     signer: alloy_signer_local::PrivateKeySigner,
     rpc_url: reqwest::Url,
     client_id: Option<String>,
+    gas_limit: u64,
+    max_priority_fee_per_gas: u128,
 }
+
+#[cfg(feature = "tempo")]
+const DEFAULT_GAS_LIMIT: u64 = 300_000;
+#[cfg(feature = "tempo")]
+const DEFAULT_MAX_PRIORITY_FEE_PER_GAS: u128 = 2;
 
 #[cfg(feature = "tempo")]
 impl TempoProvider {
@@ -119,12 +126,26 @@ impl TempoProvider {
             signer,
             rpc_url: url,
             client_id: None,
+            gas_limit: DEFAULT_GAS_LIMIT,
+            max_priority_fee_per_gas: DEFAULT_MAX_PRIORITY_FEE_PER_GAS,
         })
     }
 
     /// Set an optional client identifier for attribution memos.
     pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
         self.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Set the gas limit for transactions (default: 300,000).
+    pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
+        self.gas_limit = gas_limit;
+        self
+    }
+
+    /// Set the max priority fee per gas (default: 2).
+    pub fn with_max_priority_fee_per_gas(mut self, fee: u128) -> Self {
+        self.max_priority_fee_per_gas = fee;
         self
     }
 
@@ -221,9 +242,9 @@ impl PaymentProvider for TempoProvider {
         let tempo_tx = TempoTransaction {
             chain_id: expected_chain_id,
             nonce,
-            gas_limit: 300_000,
+            gas_limit: self.gas_limit,
             max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: 2,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
             fee_payer_signature,
             calls: vec![Call {
                 to: TxKind::Call(currency),
@@ -462,6 +483,29 @@ mod tests {
             .with_client_id("my-app");
 
         assert_eq!(provider.client_id.as_deref(), Some("my-app"));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_tempo_provider_gas_config() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let provider = TempoProvider::new(signer, "https://rpc.example.com")
+            .unwrap()
+            .with_gas_limit(500_000)
+            .with_max_priority_fee_per_gas(10);
+
+        assert_eq!(provider.gas_limit, 500_000);
+        assert_eq!(provider.max_priority_fee_per_gas, 10);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_tempo_provider_default_gas_config() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let provider = TempoProvider::new(signer, "https://rpc.example.com").unwrap();
+
+        assert_eq!(provider.gas_limit, DEFAULT_GAS_LIMIT);
+        assert_eq!(provider.max_priority_fee_per_gas, DEFAULT_MAX_PRIORITY_FEE_PER_GAS);
     }
 
     #[cfg(feature = "tempo")]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -397,8 +397,17 @@ where
         };
 
         // Decode the signed Tempo transaction (AASigned = tx fields + signature).
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..])
-            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
+        // Try normal decode first, then fall back to normalizing viem format
+        // (viem uses 0x00 for fee_payer_signature placeholder instead of 0x80).
+        let signed = match tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]) {
+            Ok(s) => s,
+            Err(_) => {
+                let normalized = normalize_viem_tx(tx_data);
+                tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice()).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode transaction: {}", e))
+                })?
+            }
+        };
         let tx = signed.tx();
 
         // Validate chain_id to prevent cross-chain replay attacks
@@ -528,9 +537,67 @@ where
             ));
         }
 
+        // If fee payer is requested, decode the tx, add the fee payer signature,
+        // and re-encode before broadcasting.
+        let broadcast_bytes = if charge.fee_payer() {
+            if let Some(fee_signer) = &self.fee_payer_signer {
+                use alloy::consensus::transaction::SignerRecoverable;
+                use alloy::eips::Encodable2718;
+                use alloy::signers::SignerSync;
+
+                // Strip type byte for decoding
+                let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
+                    &tx_bytes[1..]
+                } else {
+                    &tx_bytes[..]
+                };
+
+                // Decode the tx, normalizing viem format if needed
+                let mut signed =
+                    match tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]) {
+                        Ok(s) => s,
+                        Err(_) => {
+                            let normalized = normalize_viem_tx(tx_data);
+                            tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice())
+                                .map_err(|e| {
+                                    VerificationError::new(format!(
+                                        "Failed to decode transaction for fee payer: {}",
+                                        e
+                                    ))
+                                })?
+                        }
+                    };
+
+                // Recover sender address from the transaction signature
+                let sender = signed.recover_signer().map_err(|e| {
+                    VerificationError::new(format!("Failed to recover sender: {}", e))
+                })?;
+                eprintln!("[fee-payer] sender: {sender}");
+                eprintln!("[fee-payer] fee_payer_signer: {}", fee_signer.address());
+
+                // Compute fee payer signature hash and sign it
+                let fee_hash = signed.tx().fee_payer_signature_hash(sender);
+                let fee_sig = fee_signer.sign_hash_sync(&fee_hash).map_err(|e| {
+                    VerificationError::new(format!("Failed to sign fee payer: {}", e))
+                })?;
+
+                // Set the fee payer signature on the transaction
+                signed.tx_mut().fee_payer_signature = Some(fee_sig.into());
+
+                // Re-encode with the fee payer signature
+                let encoded = signed.encoded_2718();
+                eprintln!("[fee-payer] re-encoded tx: 0x{}", hex::encode(&encoded));
+                Bytes::from(encoded)
+            } else {
+                tx_bytes.clone()
+            }
+        } else {
+            tx_bytes.clone()
+        };
+
         let pending = self
             .provider
-            .send_raw_transaction(&tx_bytes)
+            .send_raw_transaction(&broadcast_bytes)
             .await
             .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
 
@@ -647,6 +714,113 @@ where
                     .await?;
                 this.verify_hash(&format!("{:#x}", tx_hash), &request).await
             }
+        }
+    }
+}
+
+/// Normalize a viem-encoded Tempo transaction for RLP decoding compatibility.
+///
+/// viem encodes fee_payer_signature placeholder as `0x00` (RLP single byte) instead of
+/// `0x80` (EMPTY_STRING_CODE). This function replaces all standalone `0x00` bytes in
+/// the fee_payer_signature position with `0x80` so that `AASigned::rlp_decode` can
+/// parse the transaction. The transformation preserves the RLP list envelope length
+/// since both encodings are 1 byte.
+fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
+    // The RLP structure after the type byte is:
+    //   [outer_header] [chain_id] [max_pri_fee] [max_fee] [gas_limit]
+    //   [calls] [access_list] [nonce_key] [nonce]
+    //   [valid_before] [valid_after] [fee_token] [fee_payer_sig] [auth_list]
+    //   [signature_bytes]
+    //
+    // We need to find the fee_payer_sig field and replace 0x00 with 0x80.
+    // We skip RLP items one by one to find position 11 (fee_payer_sig, 0-indexed).
+    let mut data = tx_data.to_vec();
+
+    if data.len() < 3 {
+        return data;
+    }
+
+    // Parse outer list header to get start of list content
+    let (content_start, content_end) = match data[0] {
+        0xf8..=0xff => {
+            let len_of_len = (data[0] - 0xf7) as usize;
+            if data.len() < 1 + len_of_len {
+                return data;
+            }
+            let payload_len =
+                usize::from_be_bytes({
+                    let mut buf = [0u8; 8];
+                    let start = 8 - len_of_len;
+                    buf[start..].copy_from_slice(&data[1..1 + len_of_len]);
+                    buf
+                });
+            (1 + len_of_len, 1 + len_of_len + payload_len)
+        }
+        0xc0..=0xf7 => {
+            let payload_len = (data[0] - 0xc0) as usize;
+            (1, 1 + payload_len)
+        }
+        _ => return data,
+    };
+
+    // Skip RLP items to find the fee_payer_sig field (index 11)
+    let mut pos = content_start;
+    for field_idx in 0..12 {
+        if pos >= content_end {
+            return data;
+        }
+
+        let item_len = rlp_item_length(&data, pos);
+        if item_len == 0 {
+            return data;
+        }
+
+        // fee_payer_sig is field index 11
+        if field_idx == 11 && data[pos] == 0x00 {
+            data[pos] = 0x80; // Replace with EMPTY_STRING_CODE
+            return data;
+        }
+
+        pos += item_len;
+    }
+
+    data
+}
+
+/// Returns the total length (header + payload) of an RLP item at the given position.
+fn rlp_item_length(data: &[u8], pos: usize) -> usize {
+    if pos >= data.len() {
+        return 0;
+    }
+    let b = data[pos];
+    match b {
+        // Single byte (0x00..=0x7f)
+        0x00..=0x7f => 1,
+        // Short string (0x80..=0xb7): length = b - 0x80
+        0x80..=0xb7 => 1 + (b - 0x80) as usize,
+        // Long string (0xb8..=0xbf): length-of-length = b - 0xb7
+        0xb8..=0xbf => {
+            let len_of_len = (b - 0xb7) as usize;
+            if pos + 1 + len_of_len > data.len() {
+                return 0;
+            }
+            let mut buf = [0u8; 8];
+            let start = 8 - len_of_len;
+            buf[start..].copy_from_slice(&data[pos + 1..pos + 1 + len_of_len]);
+            1 + len_of_len + usize::from_be_bytes(buf)
+        }
+        // Short list (0xc0..=0xf7): length = b - 0xc0
+        0xc0..=0xf7 => 1 + (b - 0xc0) as usize,
+        // Long list (0xf8..=0xff): length-of-length = b - 0xf7
+        0xf8..=0xff => {
+            let len_of_len = (b - 0xf7) as usize;
+            if pos + 1 + len_of_len > data.len() {
+                return 0;
+            }
+            let mut buf = [0u8; 8];
+            let start = 8 - len_of_len;
+            buf[start..].copy_from_slice(&data[pos + 1..pos + 1 + len_of_len]);
+            1 + len_of_len + usize::from_be_bytes(buf)
         }
     }
 }
@@ -801,5 +975,68 @@ mod tests {
         assert!(error
             .to_string()
             .contains("fee sponsorship is not configured"));
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_replaces_zero_fee_payer_sig() {
+        // A viem-encoded tx with 0x00 at the fee_payer_sig position (field index 11)
+        // This is a real transaction from mppx client
+        let viem_tx = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             00\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        let normalized = normalize_viem_tx(&viem_tx);
+
+        // The fee_payer_sig byte (0x00) should now be 0x80
+        // Verify we can decode the normalized tx
+        let result = tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice());
+        assert!(result.is_ok(), "Failed to decode normalized viem tx: {:?}", result.err());
+
+        let signed = result.unwrap();
+        assert_eq!(signed.tx().chain_id, MODERATO_CHAIN_ID);
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_preserves_normal_tx() {
+        // A normally-encoded tx with 0x80 (empty string) at fee_payer_sig position
+        // should be unchanged
+        let normal_tx = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             80\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        let normalized = normalize_viem_tx(&normal_tx);
+        assert_eq!(normal_tx, normalized, "Normal tx should not be modified");
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -572,8 +572,6 @@ where
                 let sender = signed.recover_signer().map_err(|e| {
                     VerificationError::new(format!("Failed to recover sender: {}", e))
                 })?;
-                eprintln!("[fee-payer] sender: {sender}");
-                eprintln!("[fee-payer] fee_payer_signer: {}", fee_signer.address());
 
                 // Compute fee payer signature hash and sign it
                 let fee_hash = signed.tx().fee_payer_signature_hash(sender);
@@ -586,7 +584,6 @@ where
 
                 // Re-encode with the fee payer signature
                 let encoded = signed.encoded_2718();
-                eprintln!("[fee-payer] re-encoded tx: 0x{}", hex::encode(&encoded));
                 Bytes::from(encoded)
             } else {
                 tx_bytes.clone()
@@ -721,70 +718,87 @@ where
 /// Normalize a viem-encoded Tempo transaction for RLP decoding compatibility.
 ///
 /// viem encodes fee_payer_signature placeholder as `0x00` (RLP single byte) instead of
-/// `0x80` (EMPTY_STRING_CODE). This function replaces all standalone `0x00` bytes in
-/// the fee_payer_signature position with `0x80` so that `AASigned::rlp_decode` can
-/// parse the transaction. The transformation preserves the RLP list envelope length
-/// since both encodings are 1 byte.
+/// an RLP-encoded list `[v=0, r=0, s=0]` that `AASigned::rlp_decode` expects. This
+/// function replaces the `0x00` byte at the fee_payer_signature position (field index 11)
+/// with a properly-encoded placeholder signature list `c3808080` (RLP list [0x80, 0x80, 0x80]).
+///
+/// This ensures `fee_payer_signature` decodes as `Some(Signature::zero())` rather than
+/// `None`, which is critical because `signature_hash()` uses `fee_payer_signature.is_some()`
+/// to determine whether to skip the fee_token field in the signing hash.
 fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
-    // The RLP structure after the type byte is:
-    //   [outer_header] [chain_id] [max_pri_fee] [max_fee] [gas_limit]
-    //   [calls] [access_list] [nonce_key] [nonce]
-    //   [valid_before] [valid_after] [fee_token] [fee_payer_sig] [auth_list]
-    //   [signature_bytes]
-    //
-    // We need to find the fee_payer_sig field and replace 0x00 with 0x80.
-    // We skip RLP items one by one to find position 11 (fee_payer_sig, 0-indexed).
-    let mut data = tx_data.to_vec();
-
-    if data.len() < 3 {
-        return data;
+    if tx_data.len() < 3 {
+        return tx_data.to_vec();
     }
 
     // Parse outer list header to get start of list content
-    let (content_start, content_end) = match data[0] {
+    let (content_start, content_end, _header_len) = match tx_data[0] {
         0xf8..=0xff => {
-            let len_of_len = (data[0] - 0xf7) as usize;
-            if data.len() < 1 + len_of_len {
-                return data;
+            let len_of_len = (tx_data[0] - 0xf7) as usize;
+            if tx_data.len() < 1 + len_of_len {
+                return tx_data.to_vec();
             }
-            let payload_len =
-                usize::from_be_bytes({
-                    let mut buf = [0u8; 8];
-                    let start = 8 - len_of_len;
-                    buf[start..].copy_from_slice(&data[1..1 + len_of_len]);
-                    buf
-                });
-            (1 + len_of_len, 1 + len_of_len + payload_len)
+            let payload_len = usize::from_be_bytes({
+                let mut buf = [0u8; 8];
+                let start = 8 - len_of_len;
+                buf[start..].copy_from_slice(&tx_data[1..1 + len_of_len]);
+                buf
+            });
+            (1 + len_of_len, 1 + len_of_len + payload_len, 1 + len_of_len)
         }
         0xc0..=0xf7 => {
-            let payload_len = (data[0] - 0xc0) as usize;
-            (1, 1 + payload_len)
+            let payload_len = (tx_data[0] - 0xc0) as usize;
+            (1, 1 + payload_len, 1)
         }
-        _ => return data,
+        _ => return tx_data.to_vec(),
     };
 
     // Skip RLP items to find the fee_payer_sig field (index 11)
     let mut pos = content_start;
     for field_idx in 0..12 {
         if pos >= content_end {
-            return data;
+            return tx_data.to_vec();
         }
 
-        let item_len = rlp_item_length(&data, pos);
+        let item_len = rlp_item_length(tx_data, pos);
         if item_len == 0 {
-            return data;
+            return tx_data.to_vec();
         }
 
         // fee_payer_sig is field index 11
-        if field_idx == 11 && data[pos] == 0x00 {
-            data[pos] = 0x80; // Replace with EMPTY_STRING_CODE
-            return data;
+        if field_idx == 11 && tx_data[pos] == 0x00 {
+            // Replace 0x00 (1 byte) with c3808080 (4 bytes = RLP list [v=0, r=0, s=0])
+            // This requires adjusting the outer list header payload length by +3.
+            let placeholder_sig: &[u8] = &[0xc3, 0x80, 0x80, 0x80];
+            let old_payload_len = content_end - content_start;
+            let new_payload_len = old_payload_len + 3; // replacing 1 byte with 4 bytes
+
+            let mut result = Vec::with_capacity(tx_data.len() + 3);
+
+            // Re-encode the outer list header with the new payload length
+            if new_payload_len <= 55 {
+                result.push(0xc0 + new_payload_len as u8);
+            } else if new_payload_len <= 0xff {
+                result.push(0xf8);
+                result.push(new_payload_len as u8);
+            } else {
+                result.push(0xf9);
+                result.extend_from_slice(&(new_payload_len as u16).to_be_bytes());
+            }
+
+            // Copy content before the fee_payer_sig field
+            result.extend_from_slice(&tx_data[content_start..pos]);
+            // Insert the placeholder signature
+            result.extend_from_slice(placeholder_sig);
+            // Copy content after the 0x00 byte
+            result.extend_from_slice(&tx_data[pos + 1..]);
+
+            return result;
         }
 
         pos += item_len;
     }
 
-    data
+    tx_data.to_vec()
 }
 
 /// Returns the total length (header + payload) of an RLP item at the given position.
@@ -1003,13 +1017,18 @@ mod tests {
 
         let normalized = normalize_viem_tx(&viem_tx);
 
-        // The fee_payer_sig byte (0x00) should now be 0x80
+        // The 0x00 fee_payer_sig should now be c3808080 (RLP list [v=0, r=0, s=0])
+        // The normalized data should be 3 bytes longer (replacing 1 byte with 4 bytes)
+        assert_eq!(normalized.len(), viem_tx.len() + 3);
+
         // Verify we can decode the normalized tx
         let result = tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice());
         assert!(result.is_ok(), "Failed to decode normalized viem tx: {:?}", result.err());
 
         let signed = result.unwrap();
         assert_eq!(signed.tx().chain_id, MODERATO_CHAIN_ID);
+        // fee_payer_signature should be Some (placeholder)
+        assert!(signed.tx().fee_payer_signature.is_some());
     }
 
     #[test]
@@ -1038,5 +1057,168 @@ mod tests {
 
         let normalized = normalize_viem_tx(&normal_tx);
         assert_eq!(normal_tx, normalized, "Normal tx should not be modified");
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_short_input() {
+        // Inputs shorter than 3 bytes should be returned unchanged
+        assert_eq!(normalize_viem_tx(&[]), Vec::<u8>::new());
+        assert_eq!(normalize_viem_tx(&[0xc0]), vec![0xc0u8]);
+        assert_eq!(normalize_viem_tx(&[0xc1, 0x80]), vec![0xc1u8, 0x80]);
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_no_fee_payer_field() {
+        // A list with fewer than 12 fields should be returned unchanged
+        // Short list: c5 = list of 5 bytes, then 5 single-byte items
+        let short_list = vec![0xc5, 0x01, 0x02, 0x03, 0x04, 0x05];
+        let normalized = normalize_viem_tx(&short_list);
+        assert_eq!(short_list, normalized);
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_non_zero_fee_payer_sig() {
+        // When fee_payer_sig is a real signature (not 0x00), don't touch it.
+        // Build a viem tx but with 0x01 at the fee_payer_sig position instead of 0x00
+        let viem_tx_with_real_sig = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             01\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        let normalized = normalize_viem_tx(&viem_tx_with_real_sig);
+        // 0x01 is not 0x00, so no replacement should happen
+        assert_eq!(viem_tx_with_real_sig, normalized, "Non-zero fee_payer_sig should not be modified");
+    }
+
+    #[test]
+    fn test_rlp_item_length_single_byte() {
+        // Single bytes 0x00..0x7f have length 1
+        assert_eq!(rlp_item_length(&[0x00], 0), 1);
+        assert_eq!(rlp_item_length(&[0x7f], 0), 1);
+        assert_eq!(rlp_item_length(&[0x42], 0), 1);
+    }
+
+    #[test]
+    fn test_rlp_item_length_short_string() {
+        // 0x80 = empty string, length 1
+        assert_eq!(rlp_item_length(&[0x80], 0), 1);
+        // 0x83 = 3-byte string, total length 4
+        assert_eq!(rlp_item_length(&[0x83, 0x01, 0x02, 0x03], 0), 4);
+    }
+
+    #[test]
+    fn test_rlp_item_length_short_list() {
+        // 0xc0 = empty list, length 1
+        assert_eq!(rlp_item_length(&[0xc0], 0), 1);
+        // 0xc3 = list of 3 bytes, total length 4
+        assert_eq!(rlp_item_length(&[0xc3, 0x80, 0x80, 0x80], 0), 4);
+    }
+
+    #[test]
+    fn test_rlp_item_length_out_of_bounds() {
+        assert_eq!(rlp_item_length(&[], 0), 0);
+        assert_eq!(rlp_item_length(&[0x80], 5), 0);
+    }
+
+    #[test]
+    fn test_rlp_item_length_long_string() {
+        // 0xb8 0x38 = string of 56 bytes (len_of_len=1), total = 1 + 1 + 56 = 58
+        let mut data = vec![0xb8, 0x38];
+        data.extend_from_slice(&[0xaa; 56]);
+        assert_eq!(rlp_item_length(&data, 0), 58);
+    }
+
+    #[test]
+    fn test_rlp_item_length_long_list() {
+        // 0xf8 0x38 = list of 56 bytes (len_of_len=1), total = 1 + 1 + 56 = 58
+        let mut data = vec![0xf8, 0x38];
+        data.extend_from_slice(&[0x80; 56]);
+        assert_eq!(rlp_item_length(&data, 0), 58);
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_idempotent() {
+        // Normalizing an already-normalized tx should not change it further
+        let viem_tx = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             00\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        let first = normalize_viem_tx(&viem_tx);
+        let second = normalize_viem_tx(&first);
+        assert_eq!(first, second, "Normalizing twice should be idempotent");
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_signature_hash_consistency() {
+        // The critical invariant: after normalization, fee_payer_signature is Some,
+        // which means signature_hash() will exclude fee_token from the hash.
+        // This is required for correct sender recovery.
+        let viem_tx = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             00\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        let normalized = normalize_viem_tx(&viem_tx);
+        let signed = tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice()).unwrap();
+
+        // The signature_hash depends on fee_payer_signature.is_some()
+        // With Some(zero), it skips fee_token → correct signing hash for sender recovery
+        let hash_with_some = signed.tx().signature_hash();
+
+        // Build the same tx but with fee_payer_signature = None to show they differ
+        let mut tx_none = signed.tx().clone();
+        tx_none.fee_payer_signature = None;
+        let hash_with_none = tx_none.signature_hash();
+
+        assert_ne!(
+            hash_with_some, hash_with_none,
+            "signature_hash must differ between Some(zero) and None fee_payer_signature"
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -389,25 +389,7 @@ where
             ));
         }
 
-        // Skip type byte (0x76) for Tempo transactions
-        let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
-            &tx_bytes[1..]
-        } else {
-            tx_bytes
-        };
-
-        // Decode the signed Tempo transaction (AASigned = tx fields + signature).
-        // Try normal decode first, then fall back to normalizing viem format
-        // (viem uses 0x00 for fee_payer_signature placeholder instead of 0x80).
-        let signed = match tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]) {
-            Ok(s) => s,
-            Err(_) => {
-                let normalized = normalize_viem_tx(tx_data);
-                tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice()).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode transaction: {}", e))
-                })?
-            }
-        };
+        let signed = decode_tempo_signed_tx(tx_bytes)?;
         let tx = signed.tx();
 
         // Validate chain_id to prevent cross-chain replay attacks
@@ -503,6 +485,7 @@ where
         signed_tx: &str,
         charge: &ChargeRequest,
         expected_chain_id: u64,
+        credential_source: Option<&str>,
     ) -> Result<B256, VerificationError> {
         let tx_bytes = signed_tx
             .parse::<Bytes>()
@@ -545,33 +528,36 @@ where
                 use alloy::eips::Encodable2718;
                 use alloy::signers::SignerSync;
 
-                // Strip type byte for decoding
-                let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
-                    &tx_bytes[1..]
-                } else {
-                    &tx_bytes[..]
-                };
+                let mut signed = decode_tempo_signed_tx(&tx_bytes)?;
 
-                // Decode the tx, normalizing viem format if needed
-                let mut signed =
-                    match tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]) {
-                        Ok(s) => s,
-                        Err(_) => {
-                            let normalized = normalize_viem_tx(tx_data);
-                            tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice())
-                                .map_err(|e| {
-                                    VerificationError::new(format!(
-                                        "Failed to decode transaction for fee payer: {}",
-                                        e
-                                    ))
-                                })?
-                        }
-                    };
+                // Verify the tx has a placeholder fee_payer_signature (not already signed)
+                if let Some(ref fps) = signed.tx().fee_payer_signature {
+                    let is_placeholder = fps.r().is_zero() && fps.s().is_zero();
+                    if !is_placeholder {
+                        return Err(VerificationError::new(
+                            "Transaction already has a non-placeholder fee_payer_signature"
+                                .to_string(),
+                        ));
+                    }
+                }
 
                 // Recover sender address from the transaction signature
                 let sender = signed.recover_signer().map_err(|e| {
                     VerificationError::new(format!("Failed to recover sender: {}", e))
                 })?;
+
+                // Cross-check recovered sender against credential source DID to prevent
+                // spoofing via the magic trailer or mismatched credentials.
+                if let Some(source) = credential_source {
+                    let expected_suffix =
+                        format!(":{}", sender).to_lowercase();
+                    if !source.to_lowercase().ends_with(&expected_suffix) {
+                        return Err(VerificationError::new(format!(
+                            "Credential source mismatch: recovered sender {} does not match source {}",
+                            sender, source
+                        )));
+                    }
+                }
 
                 // Compute fee payer signature hash and sign it
                 let fee_hash = signed.tx().fee_payer_signature_hash(sender);
@@ -580,7 +566,7 @@ where
                 })?;
 
                 // Set the fee payer signature on the transaction
-                signed.tx_mut().fee_payer_signature = Some(fee_sig.into());
+                signed.tx_mut().fee_payer_signature = Some(fee_sig);
 
                 // Re-encode with the fee payer signature
                 let encoded = signed.encoded_2718();
@@ -707,10 +693,36 @@ where
                         charge_payload.signed_tx().unwrap(),
                         &request,
                         expected_chain_id,
+                        credential.source.as_deref(),
                     )
                     .await?;
                 this.verify_hash(&format!("{:#x}", tx_hash), &request).await
             }
+        }
+    }
+}
+
+/// Strip the Tempo type byte (0x76) prefix and decode a signed Tempo transaction,
+/// with automatic viem format normalization fallback.
+///
+/// viem encodes `fee_payer_signature` placeholder as `0x00` instead of `0x80`,
+/// which fails `AASigned::rlp_decode`. This function tries the normal decode first,
+/// then falls back to [`normalize_viem_tx`] before retrying.
+fn decode_tempo_signed_tx(
+    tx_bytes: &[u8],
+) -> Result<tempo_primitives::AASigned, VerificationError> {
+    let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
+        &tx_bytes[1..]
+    } else {
+        tx_bytes
+    };
+
+    match tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]) {
+        Ok(s) => Ok(s),
+        Err(_) => {
+            let normalized = normalize_viem_tx(tx_data);
+            tempo_primitives::AASigned::rlp_decode(&mut normalized.as_slice())
+                .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))
         }
     }
 }
@@ -731,7 +743,7 @@ fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
     }
 
     // Parse outer list header to get start of list content
-    let (content_start, content_end, _header_len) = match tx_data[0] {
+    let (content_start, content_end) = match tx_data[0] {
         0xf8..=0xff => {
             let len_of_len = (tx_data[0] - 0xf7) as usize;
             if tx_data.len() < 1 + len_of_len {
@@ -743,11 +755,20 @@ fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
                 buf[start..].copy_from_slice(&tx_data[1..1 + len_of_len]);
                 buf
             });
-            (1 + len_of_len, 1 + len_of_len + payload_len, 1 + len_of_len)
+            let cs = 1 + len_of_len;
+            let ce = match cs.checked_add(payload_len) {
+                Some(end) if end <= tx_data.len() => end,
+                _ => return tx_data.to_vec(),
+            };
+            (cs, ce)
         }
         0xc0..=0xf7 => {
             let payload_len = (tx_data[0] - 0xc0) as usize;
-            (1, 1 + payload_len, 1)
+            let ce = 1 + payload_len;
+            if ce > tx_data.len() {
+                return tx_data.to_vec();
+            }
+            (1, ce)
         }
         _ => return tx_data.to_vec(),
     };
@@ -765,7 +786,7 @@ fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
         }
 
         // fee_payer_sig is field index 11
-        if field_idx == 11 && tx_data[pos] == 0x00 {
+        if field_idx == 11 && item_len == 1 && tx_data[pos] == 0x00 {
             // Replace 0x00 (1 byte) with c3808080 (4 bytes = RLP list [v=0, r=0, s=0])
             // This requires adjusting the outer list header payload length by +3.
             let placeholder_sig: &[u8] = &[0xc3, 0x80, 0x80, 0x80];
@@ -775,15 +796,7 @@ fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
             let mut result = Vec::with_capacity(tx_data.len() + 3);
 
             // Re-encode the outer list header with the new payload length
-            if new_payload_len <= 55 {
-                result.push(0xc0 + new_payload_len as u8);
-            } else if new_payload_len <= 0xff {
-                result.push(0xf8);
-                result.push(new_payload_len as u8);
-            } else {
-                result.push(0xf9);
-                result.extend_from_slice(&(new_payload_len as u16).to_be_bytes());
-            }
+            encode_rlp_list_header(&mut result, new_payload_len);
 
             // Copy content before the fee_payer_sig field
             result.extend_from_slice(&tx_data[content_start..pos]);
@@ -801,7 +814,22 @@ fn normalize_viem_tx(tx_data: &[u8]) -> Vec<u8> {
     tx_data.to_vec()
 }
 
+/// Encode an RLP list header for the given payload length.
+fn encode_rlp_list_header(buf: &mut Vec<u8>, payload_len: usize) {
+    if payload_len <= 55 {
+        buf.push(0xc0 + payload_len as u8);
+    } else {
+        // Compute minimal big-endian bytes for the length
+        let len_bytes = payload_len.to_be_bytes();
+        let first_nonzero = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+        let len_of_len = len_bytes.len() - first_nonzero;
+        buf.push(0xf7 + len_of_len as u8);
+        buf.extend_from_slice(&len_bytes[first_nonzero..]);
+    }
+}
+
 /// Returns the total length (header + payload) of an RLP item at the given position.
+/// Returns 0 if the data is malformed or extends beyond the buffer.
 fn rlp_item_length(data: &[u8], pos: usize) -> usize {
     if pos >= data.len() {
         return 0;
@@ -811,7 +839,14 @@ fn rlp_item_length(data: &[u8], pos: usize) -> usize {
         // Single byte (0x00..=0x7f)
         0x00..=0x7f => 1,
         // Short string (0x80..=0xb7): length = b - 0x80
-        0x80..=0xb7 => 1 + (b - 0x80) as usize,
+        0x80..=0xb7 => {
+            let payload_len = (b - 0x80) as usize;
+            let total = 1 + payload_len;
+            if pos.checked_add(total).is_none_or(|end| end > data.len()) {
+                return 0;
+            }
+            total
+        }
         // Long string (0xb8..=0xbf): length-of-length = b - 0xb7
         0xb8..=0xbf => {
             let len_of_len = (b - 0xb7) as usize;
@@ -821,10 +856,24 @@ fn rlp_item_length(data: &[u8], pos: usize) -> usize {
             let mut buf = [0u8; 8];
             let start = 8 - len_of_len;
             buf[start..].copy_from_slice(&data[pos + 1..pos + 1 + len_of_len]);
-            1 + len_of_len + usize::from_be_bytes(buf)
+            let payload_len = usize::from_be_bytes(buf);
+            let header_len = 1 + len_of_len;
+            match header_len.checked_add(payload_len) {
+                Some(total) if pos.checked_add(total).is_some_and(|end| end <= data.len()) => {
+                    total
+                }
+                _ => 0,
+            }
         }
         // Short list (0xc0..=0xf7): length = b - 0xc0
-        0xc0..=0xf7 => 1 + (b - 0xc0) as usize,
+        0xc0..=0xf7 => {
+            let payload_len = (b - 0xc0) as usize;
+            let total = 1 + payload_len;
+            if pos.checked_add(total).is_none_or(|end| end > data.len()) {
+                return 0;
+            }
+            total
+        }
         // Long list (0xf8..=0xff): length-of-length = b - 0xf7
         0xf8..=0xff => {
             let len_of_len = (b - 0xf7) as usize;
@@ -834,7 +883,14 @@ fn rlp_item_length(data: &[u8], pos: usize) -> usize {
             let mut buf = [0u8; 8];
             let start = 8 - len_of_len;
             buf[start..].copy_from_slice(&data[pos + 1..pos + 1 + len_of_len]);
-            1 + len_of_len + usize::from_be_bytes(buf)
+            let payload_len = usize::from_be_bytes(buf);
+            let header_len = 1 + len_of_len;
+            match header_len.checked_add(payload_len) {
+                Some(total) if pos.checked_add(total).is_some_and(|end| end <= data.len()) => {
+                    total
+                }
+                _ => 0,
+            }
         }
     }
 }
@@ -1177,6 +1233,62 @@ mod tests {
         let first = normalize_viem_tx(&viem_tx);
         let second = normalize_viem_tx(&first);
         assert_eq!(first, second, "Normalizing twice should be idempotent");
+    }
+
+    #[test]
+    fn test_rlp_item_length_truncated_data() {
+        // Short string header claims 3 bytes but only 2 available → 0
+        assert_eq!(rlp_item_length(&[0x83, 0x01, 0x02], 0), 0);
+        // Long string header claims 56 bytes but data is truncated
+        assert_eq!(rlp_item_length(&[0xb8, 0x38, 0xaa], 0), 0);
+        // Short list header claims 10 bytes but only 3 available
+        assert_eq!(rlp_item_length(&[0xca, 0x80, 0x80], 0), 0);
+    }
+
+    #[test]
+    fn test_normalize_viem_tx_truncated_header() {
+        // Long list header (0xf8) but not enough bytes for length
+        let truncated = vec![0xf8];
+        assert_eq!(normalize_viem_tx(&truncated), truncated);
+
+        // Long list header with length claiming more than available data
+        let bad_len = vec![0xf8, 0xff, 0x01, 0x02];
+        assert_eq!(normalize_viem_tx(&bad_len), bad_len);
+    }
+
+    #[test]
+    fn test_decode_tempo_signed_tx_with_type_byte() {
+        // Build a viem tx with the 0x76 type byte prefix
+        let viem_tx = hex::decode(
+            "f8d882a5bf0285059682f00282f299\
+             f87ef87c9420c000000000000000000000000000000000000080\
+             b86495777d59\
+             0000000000000000000000005f270b1a3f160f7dbd21f8840bba82c61f62a029\
+             00000000000000000000000000000000000000000000000000000000000f4240\
+             ef1ed71201546a07b8cebd18e742dc\
+             0000000000000000000075943864ff95b1\
+             c0\
+             80\
+             06\
+             80\
+             80\
+             80\
+             00\
+             c0\
+             b841f94e83c7cae5d97c235de1de04a48cdad0d3a552921b730e5300fd3ce3f6a7f8\
+             1409df263a6f761984537176e7dd30bab5aacdd7a4179f5fdc69d29252bcd5581c"
+        ).unwrap();
+
+        // With 0x76 prefix
+        let mut with_prefix = vec![0x76];
+        with_prefix.extend_from_slice(&viem_tx);
+
+        let result = decode_tempo_signed_tx(&with_prefix);
+        assert!(result.is_ok(), "Should decode viem tx with 0x76 prefix: {:?}", result.err());
+
+        // Without prefix (also works)
+        let result = decode_tempo_signed_tx(&viem_tx);
+        assert!(result.is_ok(), "Should decode viem tx without prefix: {:?}", result.err());
     }
 
     #[test]


### PR DESCRIPTION
Makes the basic example client work like a mini curl for testing interop:

```bash
# Default (local server)
cargo run --bin basic-client

# External server with custom headers
cargo run --bin basic-client -- https://mpp.sh/api/ping/paid -H "x-vercel-protection-bypass: TOKEN"
```

### Verified interop

| Scenario | Status |
|---|---|
| Rust client → Rust server | ✅ |
| TS client (mppx) → Rust server | ✅ |
| Rust client → TS server (mpp.sh) | ✅ |

No library changes needed — only the example client binary.