### PR TITLE
feat: cross-SDK smoke test (mpp-rs server × mppx CLI)

### DIFF
--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -57,6 +57,7 @@ jobs:
           import { tempoLocalnet } from 'viem/chains'
           import { Actions, Addresses } from 'viem/tempo'
 
+          // well-known Hardhat dev account[0] (faucet key)
           const account = privateKeyToAccount(
             '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
           )

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Start basic-server
         run: |
-          RPC_URL=http://localhost:8545 cargo run --manifest-path examples/basic/Cargo.toml --bin basic-server &
+          RPC_URL=http://localhost:8545 CHAIN_ID=1337 cargo run --manifest-path examples/basic/Cargo.toml --bin basic-server &
           echo "Waiting for basic-server..."
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -1,0 +1,116 @@
+name: Cross-SDK Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  smoke:
+    name: mpp-rs server × mppx CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install mppx CLI
+        run: npm i -g mppx@0.2.2
+
+      - name: Start Tempo node
+        run: docker compose up -d
+
+      - name: Wait for Tempo node
+        run: |
+          echo "Waiting for Tempo node to be ready..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8545 -X POST \
+              -H 'Content-Type: application/json' \
+              -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' > /dev/null 2>&1; then
+              echo "Tempo node ready after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Tempo node failed to start"
+          docker compose logs
+          exit 1
+
+      - name: Provision AMM liquidity
+        run: |
+          cd "$(mktemp -d)"
+          npm init -y > /dev/null
+          npm i viem > /dev/null 2>&1
+          node --input-type=module <<'EOF'
+          import { createClient, http, parseUnits } from 'viem'
+          import { privateKeyToAccount } from 'viem/accounts'
+          import { tempoLocalnet } from 'viem/chains'
+          import { Actions, Addresses } from 'viem/tempo'
+
+          const account = privateKeyToAccount(
+            '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+          )
+          const client = createClient({
+            account,
+            chain: { ...tempoLocalnet, rpcUrls: { default: { http: ['http://localhost:8545'] } } },
+            transport: http('http://localhost:8545'),
+          })
+
+          for (const id of [1n, 2n, 3n]) {
+            await Actions.amm.mintSync(client, {
+              account,
+              feeToken: Addresses.pathUsd,
+              userTokenAddress: id,
+              validatorTokenAddress: Addresses.pathUsd,
+              validatorTokenAmount: parseUnits('1000', 6),
+              to: account.address,
+            })
+          }
+          console.log('AMM liquidity provisioned')
+          EOF
+
+      - name: Fund client account
+        run: |
+          curl -sf http://localhost:8545 -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{"jsonrpc":"2.0","method":"tempo_fundAddress","params":["0x70997970C51812dc3A010C7d01b50e0d17dc79C8"],"id":1}'
+
+      - name: Build basic-server
+        run: cargo build --manifest-path examples/basic/Cargo.toml --bin basic-server
+
+      - name: Start basic-server
+        run: |
+          RPC_URL=http://localhost:8545 cargo run --manifest-path examples/basic/Cargo.toml --bin basic-server &
+          echo "Waiting for basic-server..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/api/health > /dev/null 2>&1; then
+              echo "basic-server ready after ${i}s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "basic-server failed to start"
+          exit 1
+
+      - name: Smoke test — mppx pays /api/ping
+        run: mppx http://localhost:3000/api/ping --rpc-url http://localhost:8545 --silent --fail
+        env:
+          MPPX_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+
+      - name: Tempo node logs
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop Tempo node
+        if: always()
+        run: docker compose down

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -79,7 +79,7 @@ jobs:
           console.log('AMM liquidity provisioned')
           EOF
 
-      - name: Fund client account
+      - name: Fund client account # well-known Hardhat dev account[1]
         run: |
           curl -sf http://localhost:8545 -X POST \
             -H 'Content-Type: application/json' \
@@ -105,7 +105,7 @@ jobs:
       - name: Smoke test — mppx pays /api/ping
         run: mppx http://localhost:3000/api/ping --rpc-url http://localhost:8545 --silent --fail
         env:
-          MPPX_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+          MPPX_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # well-known Hardhat dev account[1]
 
       - name: Tempo node logs
         if: failure()

--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -66,8 +66,8 @@ async fn main() {
     })
     .rpc_url(&rpc_url);
 
-    if rpc_url.contains("localhost") || rpc_url.contains("127.0.0.1") {
-        builder = builder.chain_id(1337);
+    if let Ok(id) = std::env::var("CHAIN_ID") {
+        builder = builder.chain_id(id.parse().expect("CHAIN_ID must be a number"));
     }
 
     let payment = Mpp::create(builder).expect("failed to create payment handler");

--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -61,21 +61,23 @@ async fn main() {
         .expect("faucet funding failed");
     println!("Server account funded");
 
-    let payment = Mpp::create(
-        tempo(TempoConfig {
-            recipient: &recipient,
-        })
-        .rpc_url(&rpc_url)
-        .fee_payer(true)
-        .fee_payer_signer(signer),
-    )
-    .expect("failed to create payment handler");
+    let mut builder = tempo(TempoConfig {
+        recipient: &recipient,
+    })
+    .rpc_url(&rpc_url);
+
+    if rpc_url.contains("localhost") || rpc_url.contains("127.0.0.1") {
+        builder = builder.chain_id(1337);
+    }
+
+    let payment = Mpp::create(builder).expect("failed to create payment handler");
 
     let state = Arc::new(payment);
 
     let app = Router::new()
         .route("/api/health", get(health))
         .route("/api/fortune", get(fortune))
+        .route("/api/ping", get(ping))
         .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
@@ -88,6 +90,54 @@ async fn main() {
 
 async fn health() -> impl IntoResponse {
     Json(serde_json::json!({ "status": "ok" }))
+}
+
+async fn ping(
+    State(payment): State<Arc<Payment>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Some(auth) = headers.get(header::AUTHORIZATION) {
+        if let Ok(auth_str) = auth.to_str() {
+            if let Ok(credential) = parse_authorization(auth_str) {
+                match payment.verify_credential(&credential).await {
+                    Ok(receipt) => {
+                        let receipt_header = receipt.to_header().unwrap_or_default();
+                        return (
+                            StatusCode::OK,
+                            [("payment-receipt", receipt_header)],
+                            Json(serde_json::json!({ "pong": true })),
+                        )
+                            .into_response();
+                    }
+                    Err(e) => {
+                        let body = serde_json::json!({ "error": e.to_string() });
+                        return (StatusCode::PAYMENT_REQUIRED, Json(body)).into_response();
+                    }
+                }
+            }
+        }
+    }
+
+    match payment.charge("0.01") {
+        Ok(challenge) => match format_www_authenticate(&challenge) {
+            Ok(www_auth) => (
+                StatusCode::PAYMENT_REQUIRED,
+                [(header::WWW_AUTHENTICATE, www_auth)],
+                Json(serde_json::json!({ "error": "Payment Required" })),
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response(),
+        },
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
 }
 
 async fn fortune(


### PR DESCRIPTION
## Summary

Adds a cross-SDK smoke test that validates **mpp-rs** (Rust) server interoperability with the **mppx** (TypeScript) CLI client, running against a Tempo localnet in GitHub Actions CI.

## Changes

### 1. New `/api/ping` endpoint (`examples/basic/src/server.rs`)
- Charges $0.01 and returns `{"pong": true}` with a payment receipt
- Follows the same pattern as the existing `/api/fortune` handler

### 2. New CI workflow (`.github/workflows/smoke-cross-sdk.yml`)
- Triggers on push/PR to main and daily at 06:00 UTC
- Starts a Tempo dev node via `docker-compose.yml`
- Builds and starts the Rust `basic-server` example
- Installs `mppx@0.2.2` and executes a paid request end-to-end
- Uses dev account[1] private key (`MPPX_PRIVATE_KEY` env var)
- Follows the same CI patterns as the existing `ci.yml` integration test job