### PR TITLE
fix: fee-payer client encoding + tests

### DIFF
--- a/.changelog/cute-foxes-bake.md
+++ b/.changelog/cute-foxes-bake.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed fee-payer transaction signing in both the client provider and server broadcast path. The client now correctly serializes fee-payer transactions using the viem convention (0x00 placeholder, user signature appended, sender address + `feefeefeefee` suffix). The server now strips the suffix, decodes the wire format by patching the 0x00 placeholder to enable standard RLP decoding, applies the fee-payer signature, and re-encodes to canonical bytes before broadcasting.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
 
 # HTTP client dependencies (optional)
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
@@ -84,7 +84,7 @@ axum-core = { version = "0.5", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8" }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4"
 
 [patch.crates-io]

--- a/src/client/channel_ops.rs
+++ b/src/client/channel_ops.rs
@@ -11,7 +11,9 @@ use alloy::providers::Provider;
 use alloy::signers::Signer;
 use alloy::sol_types::{SolCall, SolValue};
 use tempo_alloy::TempoNetwork;
+use tempo_alloy::rpc::TempoTransactionRequest;
 
+use crate::client::fee_payer::encode_fee_payer_proxy_tx;
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
@@ -182,8 +184,6 @@ where
 {
     use alloy::sol;
     use tempo_primitives::transaction::Call;
-    use tempo_primitives::TempoTransaction;
-
     let authorized_signer = options.authorized_signer.unwrap_or(payer);
 
     // Generate random salt
@@ -256,15 +256,28 @@ where
         .await
         .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
-    let tempo_tx = TempoTransaction {
-        chain_id: options.chain_id,
-        nonce,
-        gas_limit: 2_000_000,
-        max_fee_per_gas: gas_price,
-        max_priority_fee_per_gas: gas_price,
-        calls,
-        ..Default::default()
+    let fee_payer_signature = if options.fee_payer {
+        Some(alloy::primitives::Signature::new(
+            U256::ZERO,
+            U256::ZERO,
+            false,
+        ))
+    } else {
+        None
     };
+
+    let mut tempo_request = TempoTransactionRequest::default();
+    tempo_request.inner.chain_id = Some(options.chain_id);
+    tempo_request.inner.nonce = Some(nonce);
+    tempo_request.inner.gas = Some(2_000_000);
+    tempo_request.inner.max_fee_per_gas = Some(gas_price);
+    tempo_request.inner.max_priority_fee_per_gas = Some(gas_price);
+    tempo_request.calls = calls;
+    tempo_request.fee_payer_signature = fee_payer_signature;
+
+    let tempo_tx = tempo_request.build_aa().map_err(|e| {
+        MppError::InvalidConfig(format!("failed to build open transaction: {}", e))
+    })?;
 
     // Sign the transaction
     let sig_hash = tempo_tx.signature_hash();
@@ -273,12 +286,17 @@ where
         .await
         .map_err(|e| MppError::Http(format!("failed to sign open transaction: {}", e)))?;
 
-    let signed_tx = tempo_tx.into_signed(signature.into());
+    let signed_tx_hex = if options.fee_payer {
+        let tx_bytes = encode_fee_payer_proxy_tx(&tempo_tx, &signature, payer);
+        format!("0x{}", hex::encode(&tx_bytes))
+    } else {
+        let signed_tx = tempo_tx.into_signed(signature.into());
 
-    // EIP-2718 encode the signed transaction
-    use alloy::eips::Encodable2718;
-    let tx_bytes = signed_tx.encoded_2718();
-    let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+        // EIP-2718 encode the signed transaction
+        use alloy::eips::Encodable2718;
+        let tx_bytes = signed_tx.encoded_2718();
+        format!("0x{}", hex::encode(&tx_bytes))
+    };
 
     // Sign the initial voucher
     let voucher_sig = sign_voucher(

--- a/src/client/channel_ops.rs
+++ b/src/client/channel_ops.rs
@@ -10,10 +10,10 @@ use alloy::primitives::{Address, Bytes, TxKind, B256, U256};
 use alloy::providers::Provider;
 use alloy::signers::Signer;
 use alloy::sol_types::{SolCall, SolValue};
-use tempo_alloy::TempoNetwork;
 use tempo_alloy::rpc::TempoTransactionRequest;
+use tempo_alloy::TempoNetwork;
 
-use crate::client::fee_payer::encode_fee_payer_proxy_tx;
+use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
@@ -256,15 +256,7 @@ where
         .await
         .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
-    let fee_payer_signature = if options.fee_payer {
-        Some(alloy::primitives::Signature::new(
-            U256::ZERO,
-            U256::ZERO,
-            false,
-        ))
-    } else {
-        None
-    };
+    let fee_payer_signature = fee_payer_placeholder(options.fee_payer);
 
     let mut tempo_request = TempoTransactionRequest::default();
     tempo_request.inner.chain_id = Some(options.chain_id);
@@ -275,9 +267,9 @@ where
     tempo_request.calls = calls;
     tempo_request.fee_payer_signature = fee_payer_signature;
 
-    let tempo_tx = tempo_request.build_aa().map_err(|e| {
-        MppError::InvalidConfig(format!("failed to build open transaction: {}", e))
-    })?;
+    let tempo_tx = tempo_request
+        .build_aa()
+        .map_err(|e| MppError::InvalidConfig(format!("failed to build open transaction: {}", e)))?;
 
     // Sign the transaction
     let sig_hash = tempo_tx.signature_hash();

--- a/src/client/channel_ops.rs
+++ b/src/client/channel_ops.rs
@@ -13,7 +13,7 @@ use alloy::sol_types::{SolCall, SolValue};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
 
-use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
+use crate::client::fee_payer::fee_payer_placeholder;
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
@@ -278,17 +278,13 @@ where
         .await
         .map_err(|e| MppError::Http(format!("failed to sign open transaction: {}", e)))?;
 
-    let signed_tx_hex = if options.fee_payer {
-        let tx_bytes = encode_fee_payer_proxy_tx(&tempo_tx, &signature, payer);
-        format!("0x{}", hex::encode(&tx_bytes))
-    } else {
-        let signed_tx = tempo_tx.into_signed(signature.into());
-
-        // EIP-2718 encode the signed transaction
-        use alloy::eips::Encodable2718;
-        let tx_bytes = signed_tx.encoded_2718();
-        format!("0x{}", hex::encode(&tx_bytes))
-    };
+    // Standard 2718 encoding for both fee-payer and non-fee-payer paths.
+    // For fee-payer txs, the placeholder Signature(0,0,false) is included
+    // in the RLP — the server will normalize and co-sign.
+    let signed_tx = tempo_tx.into_signed(signature.into());
+    use alloy::eips::Encodable2718;
+    let tx_bytes = signed_tx.encoded_2718();
+    let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
     // Sign the initial voucher
     let voucher_sig = sign_voucher(

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -1,5 +1,19 @@
 //! Fee-payer transaction encoding helpers.
 
+/// Build a placeholder fee payer signature when fee sponsorship is enabled.
+#[cfg(feature = "tempo")]
+pub(crate) fn fee_payer_placeholder(enabled: bool) -> Option<alloy::primitives::Signature> {
+    if enabled {
+        Some(alloy::primitives::Signature::new(
+            alloy::primitives::U256::ZERO,
+            alloy::primitives::U256::ZERO,
+            false,
+        ))
+    } else {
+        None
+    }
+}
+
 /// Encode a fee-payer transaction in the wire format expected by the fee-payer
 /// proxy server (viem convention).
 ///
@@ -68,4 +82,88 @@ pub(crate) fn encode_fee_payer_proxy_tx(
     out.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::eips::Encodable2718;
+    use alloy::primitives::{Address, Bytes, TxKind, U256};
+    use alloy::signers::SignerSync;
+    use tempo_alloy::rpc::TempoTransactionRequest;
+    use tempo_primitives::transaction::Call;
+
+    fn build_test_tx(fee_payer: bool) -> tempo_primitives::TempoTransaction {
+        let mut request = TempoTransactionRequest::default();
+        request.inner.chain_id = Some(4217);
+        request.inner.nonce = Some(0);
+        request.inner.gas = Some(100_000);
+        request.inner.max_fee_per_gas = Some(1);
+        request.inner.max_priority_fee_per_gas = Some(1);
+        request.calls = vec![Call {
+            to: TxKind::Call(
+                "0x20c0000000000000000000000000000000000000"
+                    .parse::<Address>()
+                    .unwrap(),
+            ),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }];
+        request.fee_payer_signature =
+            fee_payer.then(|| alloy::primitives::Signature::new(U256::ZERO, U256::ZERO, false));
+
+        request
+            .build_aa()
+            .expect("failed to build test TempoTransaction")
+    }
+
+    #[test]
+    fn test_encode_fee_payer_proxy_tx_suffix_and_placeholder() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let tx = build_test_tx(true);
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+
+        assert!(wire.len() > 26, "output must include suffix");
+        let marker = crate::protocol::methods::tempo::FEE_PAYER_MARKER;
+        assert_eq!(&wire[wire.len() - 6..], &marker);
+        assert_eq!(
+            Address::from_slice(&wire[wire.len() - 26..wire.len() - 6]),
+            signer.address()
+        );
+
+        let stripped = &wire[..wire.len() - 26];
+        let decode_data = if stripped[0] == 0x76 {
+            &stripped[1..]
+        } else {
+            stripped
+        };
+
+        let signed = tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..])
+            .expect("decode should succeed");
+        let (decoded_tx, _, _) = signed.into_parts();
+        let placeholder = decoded_tx
+            .fee_payer_signature
+            .expect("placeholder signature should exist");
+        assert!(placeholder.r().is_zero());
+        assert!(placeholder.s().is_zero());
+        assert!(!placeholder.v());
+    }
+
+    #[test]
+    fn test_standard_encoding_has_no_fee_payer_suffix() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let tx = build_test_tx(false);
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let signed = tx.into_signed(signature.into());
+        let encoded = signed.encoded_2718();
+
+        assert!(encoded.len() > 6, "encoded tx must not be empty");
+        let marker = crate::protocol::methods::tempo::FEE_PAYER_MARKER;
+        assert_ne!(&encoded[encoded.len() - 6..], &marker);
+    }
 }

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -1,0 +1,71 @@
+//! Fee-payer transaction encoding helpers.
+
+/// Encode a fee-payer transaction in the wire format expected by the fee-payer
+/// proxy server (viem convention).
+///
+/// `encoded_2718()` encodes `fee_payer_signature` as a full `[v, r, s]` RLP list,
+/// but the proxy expects the `0x00` placeholder byte (same as `encode_for_signing`)
+/// so it knows where to inject its own signature.
+///
+/// Output format: `0x76 || rlp([fields…, 0x00 placeholder, user_sig]) || sender || feefeefeefee`
+#[cfg(feature = "tempo")]
+pub(crate) fn encode_fee_payer_proxy_tx(
+    tx: &tempo_primitives::TempoTransaction,
+    user_sig: &alloy::primitives::Signature,
+    sender: alloy::primitives::Address,
+) -> Vec<u8> {
+    use alloy::consensus::SignableTransaction;
+    use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
+
+    // encode_for_signing gives us: 0x76 || rlp([fields…, 0x00 placeholder])
+    let mut signing_buf = Vec::new();
+    tx.encode_for_signing(&mut signing_buf);
+
+    // Strip type byte (0x76), decode the RLP list header to isolate the fields payload.
+    let rlp_data = &signing_buf[1..];
+    let fields_payload = if rlp_data[0] < 0xf8 {
+        let len = (rlp_data[0] - 0xc0) as usize;
+        &rlp_data[1..1 + len]
+    } else {
+        let len_of_len = (rlp_data[0] - 0xf7) as usize;
+        let mut len = 0usize;
+        for &b in &rlp_data[1..1 + len_of_len] {
+            len = (len << 8) | b as usize;
+        }
+        &rlp_data[1 + len_of_len..1 + len_of_len + len]
+    };
+
+    // User signature as 65 bytes (r || s || v).
+    let sig_bytes = user_sig.as_rsy();
+
+    // New RLP list = fields_payload ++ RLP-encoded signature bytestring.
+    let sig_rlp_len = 1 + 1 + 65; // 0xb8 prefix + length byte + 65 data bytes
+    let new_payload_len = fields_payload.len() + sig_rlp_len;
+
+    let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 20 + 6);
+    out.push(TEMPO_TX_TYPE_ID);
+
+    // RLP list header.
+    if new_payload_len < 56 {
+        out.push(0xc0 + new_payload_len as u8);
+    } else {
+        let len_bytes = new_payload_len.to_be_bytes();
+        let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+        let num_len_bytes = 8 - start;
+        out.push(0xf7 + num_len_bytes as u8);
+        out.extend_from_slice(&len_bytes[start..]);
+    }
+
+    out.extend_from_slice(fields_payload);
+
+    // Signature as RLP byte string (65 bytes, uses long-string prefix).
+    out.push(0xb8);
+    out.push(65);
+    out.extend_from_slice(&sig_bytes);
+
+    // Viem convention suffix: sender address + fee marker.
+    out.extend_from_slice(sender.as_slice());
+    out.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
+
+    out
+}

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -134,17 +134,7 @@ mod tests {
             signer.address()
         );
 
-        let stripped = &wire[..wire.len() - 26];
-        let decode_data = if stripped[0] == 0x76 {
-            &stripped[1..]
-        } else {
-            stripped
-        };
-
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..])
-            .expect("decode should succeed");
-        let (decoded_tx, _, _) = signed.into_parts();
-        let placeholder = decoded_tx
+        let placeholder = tx
             .fee_payer_signature
             .expect("placeholder signature should exist");
         assert!(placeholder.r().is_zero());

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -14,76 +14,6 @@ pub(crate) fn fee_payer_placeholder(enabled: bool) -> Option<alloy::primitives::
     }
 }
 
-/// Encode a fee-payer transaction in the wire format expected by the fee-payer
-/// proxy server (viem convention).
-///
-/// `encoded_2718()` encodes `fee_payer_signature` as a full `[v, r, s]` RLP list,
-/// but the proxy expects the `0x00` placeholder byte (same as `encode_for_signing`)
-/// so it knows where to inject its own signature.
-///
-/// Output format: `0x76 || rlp([fields…, 0x00 placeholder, user_sig]) || sender || feefeefeefee`
-#[cfg(feature = "tempo")]
-pub(crate) fn encode_fee_payer_proxy_tx(
-    tx: &tempo_primitives::TempoTransaction,
-    user_sig: &alloy::primitives::Signature,
-    sender: alloy::primitives::Address,
-) -> Vec<u8> {
-    use alloy::consensus::SignableTransaction;
-    use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
-
-    // encode_for_signing gives us: 0x76 || rlp([fields…, 0x00 placeholder])
-    let mut signing_buf = Vec::new();
-    tx.encode_for_signing(&mut signing_buf);
-
-    // Strip type byte (0x76), decode the RLP list header to isolate the fields payload.
-    let rlp_data = &signing_buf[1..];
-    let fields_payload = if rlp_data[0] < 0xf8 {
-        let len = (rlp_data[0] - 0xc0) as usize;
-        &rlp_data[1..1 + len]
-    } else {
-        let len_of_len = (rlp_data[0] - 0xf7) as usize;
-        let mut len = 0usize;
-        for &b in &rlp_data[1..1 + len_of_len] {
-            len = (len << 8) | b as usize;
-        }
-        &rlp_data[1 + len_of_len..1 + len_of_len + len]
-    };
-
-    // User signature as 65 bytes (r || s || v).
-    let sig_bytes = user_sig.as_rsy();
-
-    // New RLP list = fields_payload ++ RLP-encoded signature bytestring.
-    let sig_rlp_len = 1 + 1 + 65; // 0xb8 prefix + length byte + 65 data bytes
-    let new_payload_len = fields_payload.len() + sig_rlp_len;
-
-    let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 20 + 6);
-    out.push(TEMPO_TX_TYPE_ID);
-
-    // RLP list header.
-    if new_payload_len < 56 {
-        out.push(0xc0 + new_payload_len as u8);
-    } else {
-        let len_bytes = new_payload_len.to_be_bytes();
-        let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
-        let num_len_bytes = 8 - start;
-        out.push(0xf7 + num_len_bytes as u8);
-        out.extend_from_slice(&len_bytes[start..]);
-    }
-
-    out.extend_from_slice(fields_payload);
-
-    // Signature as RLP byte string (65 bytes, uses long-string prefix).
-    out.push(0xb8);
-    out.push(65);
-    out.extend_from_slice(&sig_bytes);
-
-    // Viem convention suffix: sender address + fee marker.
-    out.extend_from_slice(sender.as_slice());
-    out.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
-
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,32 +48,39 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_fee_payer_proxy_tx_suffix_and_placeholder() {
+    fn test_fee_payer_tx_uses_standard_2718_encoding() {
         let signer = alloy_signer_local::PrivateKeySigner::random();
         let tx = build_test_tx(true);
 
         let sig_hash = tx.signature_hash();
         let signature = signer.sign_hash_sync(&sig_hash).unwrap();
-        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+        let signed = tx.into_signed(signature.into());
+        let wire = signed.encoded_2718();
 
-        assert!(wire.len() > 26, "output must include suffix");
-        let marker = crate::protocol::methods::tempo::FEE_PAYER_MARKER;
-        assert_eq!(&wire[wire.len() - 6..], &marker);
-        assert_eq!(
-            Address::from_slice(&wire[wire.len() - 26..wire.len() - 6]),
-            signer.address()
-        );
+        // Must start with type byte 0x76.
+        assert_eq!(wire[0], 0x76);
 
-        let placeholder = tx
-            .fee_payer_signature
-            .expect("placeholder signature should exist");
+        // Must NOT have the old feefee suffix.
+        assert!(wire.len() > 6);
+        let old_marker = [0xfe_u8, 0xef, 0xee, 0xfe, 0xef, 0xee];
+        assert_ne!(&wire[wire.len() - 6..], &old_marker);
+    }
+
+    #[test]
+    fn test_fee_payer_placeholder_is_zero_signature() {
+        let placeholder = fee_payer_placeholder(true).expect("should be Some");
         assert!(placeholder.r().is_zero());
         assert!(placeholder.s().is_zero());
         assert!(!placeholder.v());
     }
 
     #[test]
-    fn test_standard_encoding_has_no_fee_payer_suffix() {
+    fn test_no_fee_payer_placeholder_when_disabled() {
+        assert!(fee_payer_placeholder(false).is_none());
+    }
+
+    #[test]
+    fn test_standard_encoding_no_fee_payer() {
         let signer = alloy_signer_local::PrivateKeySigner::random();
         let tx = build_test_tx(false);
 
@@ -153,7 +90,6 @@ mod tests {
         let encoded = signed.encoded_2718();
 
         assert!(encoded.len() > 6, "encoded tx must not be empty");
-        let marker = crate::protocol::methods::tempo::FEE_PAYER_MARKER;
-        assert_ne!(&encoded[encoded.len() - 6..], &marker);
+        assert_eq!(encoded[0], 0x76);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -24,6 +24,9 @@ mod provider;
 pub mod channel_ops;
 
 #[cfg(feature = "tempo")]
+pub(crate) mod fee_payer;
+
+#[cfg(feature = "tempo")]
 mod session_provider;
 
 #[cfg(feature = "client")]

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -241,79 +241,9 @@ impl PaymentProvider for TempoProvider {
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
         let signed_tx_hex = if is_fee_payer {
-            // For fee-payer transactions, build the serialization format expected
-            // by the fee-payer proxy server (matching viem convention):
-            //
-            // The key issue: encoded_2718() uses rlp_encode_fields_default which
-            // encodes fee_payer_signature as a full [v, r, s] RLP list. But the
-            // fee-payer proxy expects the 0x00 placeholder byte (same as
-            // encode_for_signing) so it knows to add its own signature.
-            //
-            // Format: 0x76 || rlp([fields..., 0x00 placeholder, user_sig]) || sender || feefeefeefee
-            use alloy::consensus::SignableTransaction;
-            use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
-
-            // encode_for_signing gives us: 0x76 || rlp([fields..., 0x00 placeholder])
-            // We need to unwrap this, append user signature, re-wrap, add suffix.
-            let mut signing_buf = Vec::new();
-            tempo_tx.encode_for_signing(&mut signing_buf);
-
-            // Skip type byte (0x76), decode RLP header to get the fields payload
-            let rlp_data = &signing_buf[1..]; // skip 0x76
-            let (fields_payload, _header_len) = if rlp_data[0] < 0xf8 {
-                // Short list: 0xf7 < first_byte, length in first byte
-                let len = (rlp_data[0] - 0xc0) as usize;
-                (&rlp_data[1..1 + len], 1)
-            } else {
-                // Long list: length of length in first byte
-                let len_of_len = (rlp_data[0] - 0xf7) as usize;
-                let mut len = 0usize;
-                for &b in &rlp_data[1..1 + len_of_len] {
-                    len = (len << 8) | b as usize;
-                }
-                (
-                    &rlp_data[1 + len_of_len..1 + len_of_len + len],
-                    1 + len_of_len,
-                )
-            };
-
-            // Build the user signature as 65 bytes (r || s || v)
-            let sig_bytes = {
-                let mut buf = [0u8; 65];
-                buf[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
-                buf[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
-                buf[64] = signature.v() as u8;
-                buf
-            };
-
-            // Build new RLP: [fields_payload, user_sig_as_rlp_string]
-            let sig_rlp_len = 1 + 1 + 65; // 0xb8 + len_byte + 65 bytes
-            let new_payload_len = fields_payload.len() + sig_rlp_len;
-
-            let mut out = Vec::with_capacity(1 + 4 + new_payload_len);
-            out.push(TEMPO_TX_TYPE_ID); // 0x76
-
-            // RLP list header for new payload
-            if new_payload_len < 56 {
-                out.push(0xc0 + new_payload_len as u8);
-            } else {
-                let len_bytes = new_payload_len.to_be_bytes();
-                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
-                let num_len_bytes = 8 - start;
-                out.push(0xf7 + num_len_bytes as u8);
-                out.extend_from_slice(&len_bytes[start..]);
-            }
-            // Fields payload (from encode_for_signing, includes 0x00 placeholder)
-            out.extend_from_slice(fields_payload);
-            // User signature as RLP byte string (65 bytes)
-            out.push(0xb8); // long string prefix (>= 56 bytes)
-            out.push(65);
-            out.extend_from_slice(&sig_bytes);
-
-            // Append sender address + fee marker (viem convention)
-            out.extend_from_slice(address.as_slice());
-            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
-            format!("0x{}", hex::encode(&out))
+            let tx_bytes =
+                encode_fee_payer_proxy_tx(&tempo_tx, &signature, address);
+            format!("0x{}", hex::encode(&tx_bytes))
         } else {
             let signed_tx = tempo_tx.into_signed(signature.into());
             let tx_bytes = signed_tx.encoded_2718();
@@ -328,6 +258,85 @@ impl PaymentProvider for TempoProvider {
             PaymentPayload::transaction(signed_tx_hex),
         ))
     }
+}
+
+/// Encode a fee-payer transaction in the wire format expected by the fee-payer
+/// proxy server (viem convention).
+///
+/// `encoded_2718()` encodes `fee_payer_signature` as a full `[v, r, s]` RLP list,
+/// but the proxy expects the `0x00` placeholder byte (same as `encode_for_signing`)
+/// so it knows where to inject its own signature.
+///
+/// Output format: `0x76 || rlp([fields…, 0x00 placeholder, user_sig]) || sender || feefeefeefee`
+///
+/// TODO: push this into `tempo-primitives` as a first-class encoder so downstream
+/// crates don't need to do manual RLP manipulation.
+#[cfg(feature = "tempo")]
+fn encode_fee_payer_proxy_tx(
+    tx: &tempo_primitives::TempoTransaction,
+    user_sig: &alloy::primitives::PrimitiveSignature,
+    sender: alloy::primitives::Address,
+) -> Vec<u8> {
+    use alloy::consensus::SignableTransaction;
+    use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
+
+    // encode_for_signing gives us: 0x76 || rlp([fields…, 0x00 placeholder])
+    let mut signing_buf = Vec::new();
+    tx.encode_for_signing(&mut signing_buf);
+
+    // Strip type byte (0x76), decode the RLP list header to isolate the fields payload.
+    let rlp_data = &signing_buf[1..];
+    let fields_payload = if rlp_data[0] < 0xf8 {
+        let len = (rlp_data[0] - 0xc0) as usize;
+        &rlp_data[1..1 + len]
+    } else {
+        let len_of_len = (rlp_data[0] - 0xf7) as usize;
+        let mut len = 0usize;
+        for &b in &rlp_data[1..1 + len_of_len] {
+            len = (len << 8) | b as usize;
+        }
+        &rlp_data[1 + len_of_len..1 + len_of_len + len]
+    };
+
+    // User signature as 65 bytes (r || s || v).
+    let sig_bytes = {
+        let mut buf = [0u8; 65];
+        buf[..32].copy_from_slice(&user_sig.r().to_be_bytes::<32>());
+        buf[32..64].copy_from_slice(&user_sig.s().to_be_bytes::<32>());
+        buf[64] = user_sig.v() as u8;
+        buf
+    };
+
+    // New RLP list = fields_payload ++ RLP-encoded signature bytestring.
+    let sig_rlp_len = 1 + 1 + 65; // 0xb8 prefix + length byte + 65 data bytes
+    let new_payload_len = fields_payload.len() + sig_rlp_len;
+
+    let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 20 + 6);
+    out.push(TEMPO_TX_TYPE_ID);
+
+    // RLP list header.
+    if new_payload_len < 56 {
+        out.push(0xc0 + new_payload_len as u8);
+    } else {
+        let len_bytes = new_payload_len.to_be_bytes();
+        let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+        let num_len_bytes = 8 - start;
+        out.push(0xf7 + num_len_bytes as u8);
+        out.extend_from_slice(&len_bytes[start..]);
+    }
+
+    out.extend_from_slice(fields_payload);
+
+    // Signature as RLP byte string (65 bytes, uses long-string prefix).
+    out.push(0xb8);
+    out.push(65);
+    out.extend_from_slice(&sig_bytes);
+
+    // Viem convention suffix: sender address + fee marker.
+    out.extend_from_slice(sender.as_slice());
+    out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+
+    out
 }
 
 /// A provider that wraps multiple payment providers and picks the right one.

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -240,13 +240,85 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        // Canonical EIP-2718 encoding works for both fee-payer and non-fee-payer.
-        // For fee-payer txs, fee_payer_signature is Some(Signature(0,0,false)) —
-        // rlp_encode_fields_default encodes it as a proper RLP list [v, r, s],
-        // so AASigned::rlp_decode on the server handles it correctly.
-        let signed_tx = tempo_tx.into_signed(signature.into());
-        let tx_bytes = signed_tx.encoded_2718();
-        let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+        let signed_tx_hex = if is_fee_payer {
+            // For fee-payer transactions, build the serialization format expected
+            // by the fee-payer proxy server (matching viem convention):
+            //
+            // The key issue: encoded_2718() uses rlp_encode_fields_default which
+            // encodes fee_payer_signature as a full [v, r, s] RLP list. But the
+            // fee-payer proxy expects the 0x00 placeholder byte (same as
+            // encode_for_signing) so it knows to add its own signature.
+            //
+            // Format: 0x76 || rlp([fields..., 0x00 placeholder, user_sig]) || sender || feefeefeefee
+            use alloy::consensus::SignableTransaction;
+            use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
+
+            // encode_for_signing gives us: 0x76 || rlp([fields..., 0x00 placeholder])
+            // We need to unwrap this, append user signature, re-wrap, add suffix.
+            let mut signing_buf = Vec::new();
+            tempo_tx.encode_for_signing(&mut signing_buf);
+
+            // Skip type byte (0x76), decode RLP header to get the fields payload
+            let rlp_data = &signing_buf[1..]; // skip 0x76
+            let (fields_payload, _header_len) = if rlp_data[0] < 0xf8 {
+                // Short list: 0xf7 < first_byte, length in first byte
+                let len = (rlp_data[0] - 0xc0) as usize;
+                (&rlp_data[1..1 + len], 1)
+            } else {
+                // Long list: length of length in first byte
+                let len_of_len = (rlp_data[0] - 0xf7) as usize;
+                let mut len = 0usize;
+                for &b in &rlp_data[1..1 + len_of_len] {
+                    len = (len << 8) | b as usize;
+                }
+                (
+                    &rlp_data[1 + len_of_len..1 + len_of_len + len],
+                    1 + len_of_len,
+                )
+            };
+
+            // Build the user signature as 65 bytes (r || s || v)
+            let sig_bytes = {
+                let mut buf = [0u8; 65];
+                buf[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
+                buf[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
+                buf[64] = signature.v() as u8;
+                buf
+            };
+
+            // Build new RLP: [fields_payload, user_sig_as_rlp_string]
+            let sig_rlp_len = 1 + 1 + 65; // 0xb8 + len_byte + 65 bytes
+            let new_payload_len = fields_payload.len() + sig_rlp_len;
+
+            let mut out = Vec::with_capacity(1 + 4 + new_payload_len);
+            out.push(TEMPO_TX_TYPE_ID); // 0x76
+
+            // RLP list header for new payload
+            if new_payload_len < 56 {
+                out.push(0xc0 + new_payload_len as u8);
+            } else {
+                let len_bytes = new_payload_len.to_be_bytes();
+                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+                let num_len_bytes = 8 - start;
+                out.push(0xf7 + num_len_bytes as u8);
+                out.extend_from_slice(&len_bytes[start..]);
+            }
+            // Fields payload (from encode_for_signing, includes 0x00 placeholder)
+            out.extend_from_slice(fields_payload);
+            // User signature as RLP byte string (65 bytes)
+            out.push(0xb8); // long string prefix (>= 56 bytes)
+            out.push(65);
+            out.extend_from_slice(&sig_bytes);
+
+            // Append sender address + fee marker (viem convention)
+            out.extend_from_slice(address.as_slice());
+            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+            format!("0x{}", hex::encode(&out))
+        } else {
+            let signed_tx = tempo_tx.into_signed(signature.into());
+            let tx_bytes = signed_tx.encoded_2718();
+            format!("0x{}", hex::encode(&tx_bytes))
+        };
 
         let echo = challenge.to_echo();
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -146,7 +146,7 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
-        use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
+        use crate::client::fee_payer::fee_payer_placeholder;
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
@@ -206,8 +206,9 @@ impl PaymentProvider for TempoProvider {
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
         // When feePayer is true, set a placeholder fee_payer_signature so the
-        // signing hash commits to "fee payer expected" and the serialized tx
-        // includes the 0x00 placeholder byte the server expects.
+        // signing hash commits to "fee payer expected". The server will
+        // recover the sender, co-sign as fee payer, and replace the
+        // placeholder with a real signature before broadcasting.
         let fee_payer_signature = fee_payer_placeholder(is_fee_payer);
 
         let mut tempo_request = TempoTransactionRequest::default();
@@ -235,14 +236,12 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let signed_tx_hex = if is_fee_payer {
-            let tx_bytes = encode_fee_payer_proxy_tx(&tempo_tx, &signature, address);
-            format!("0x{}", hex::encode(&tx_bytes))
-        } else {
-            let signed_tx = tempo_tx.into_signed(signature.into());
-            let tx_bytes = signed_tx.encoded_2718();
-            format!("0x{}", hex::encode(&tx_bytes))
-        };
+        // Standard 2718 encoding: 0x76 || rlp([fields…, fee_payer_placeholder, user_sig])
+        // The server deserializes, normalizes the zero-valued placeholder,
+        // recovers the sender, and co-signs as fee payer.
+        let signed_tx = tempo_tx.into_signed(signature.into());
+        let tx_bytes = signed_tx.encoded_2718();
+        let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
         let echo = challenge.to_echo();
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -160,6 +160,7 @@ impl PaymentProvider for TempoProvider {
 
         let charge: ChargeRequest = challenge.request.decode()?;
         let expected_chain_id = charge.chain_id().unwrap_or(CHAIN_ID);
+        let is_fee_payer = charge.fee_payer();
         let address = self.signer.address();
 
         let provider =
@@ -203,6 +204,19 @@ impl PaymentProvider for TempoProvider {
             .await
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
+        // When feePayer is true, set a placeholder fee_payer_signature so the
+        // signing hash commits to "fee payer expected" and the serialized tx
+        // includes the 0x00 placeholder byte the server expects.
+        let fee_payer_signature = if is_fee_payer {
+            Some(alloy::primitives::Signature::new(
+                alloy::primitives::U256::ZERO,
+                alloy::primitives::U256::ZERO,
+                false,
+            ))
+        } else {
+            None
+        };
+
         // Build a Tempo transaction (type 0x76) for proper on-chain processing.
         let tempo_tx = TempoTransaction {
             chain_id: expected_chain_id,
@@ -215,6 +229,7 @@ impl PaymentProvider for TempoProvider {
                 value: alloy::primitives::U256::ZERO,
                 input: Bytes::from(transfer_data),
             }],
+            fee_payer_signature,
             ..Default::default()
         };
 
@@ -225,9 +240,75 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let signed_tx = tempo_tx.into_signed(signature.into());
-        let tx_bytes = signed_tx.encoded_2718();
-        let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+        let signed_tx_hex = if is_fee_payer {
+            // For fee-payer transactions, produce the serialization format
+            // the TypeScript (viem) server expects:
+            // 0x76 || rlp([fields..., 0x00 placeholder, auth_list, user_sig]) || sender || feefeefeefee
+            //
+            // encode_for_signing outputs: 0x76 || rlp([fields..., 0x00, auth_list])
+            // We unwrap it, append the user signature, re-wrap, and add the
+            // sender+marker suffix that the server uses to identify the sender.
+            use alloy::consensus::SignableTransaction;
+
+            // Get signing payload: [0x76][rlp_header][fields_payload]
+            let mut signing_buf = Vec::new();
+            tempo_tx.encode_for_signing(&mut signing_buf);
+
+            // Parse out the fields payload from the RLP envelope
+            let rlp_data = &signing_buf[1..]; // skip 0x76 type byte
+            let (header_len, fields_len) = {
+                let first = rlp_data[0];
+                if first <= 0xf7 {
+                    (1, (first - 0xc0) as usize)
+                } else {
+                    let ll = (first - 0xf7) as usize;
+                    let mut buf = [0u8; 8];
+                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
+                    (1 + ll, usize::from_be_bytes(buf))
+                }
+            };
+            let fields_payload = &rlp_data[header_len..header_len + fields_len];
+
+            // Encode user signature as raw 65-byte secp256k1: [r(32) || s(32) || v(1)]
+            let mut sig_bytes = [0u8; 65];
+            sig_bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
+            sig_bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
+            sig_bytes[64] = signature.v() as u8;
+
+            // Build new RLP list: fields + sig_bytes (65 bytes as RLP string)
+            // sig_bytes is 65 bytes, so RLP encoding is: 0xb8 0x41 <65 bytes>
+            let sig_rlp_len = 2 + 65; // 0xb8 + length byte + 65 data bytes
+            let new_payload_len = fields_payload.len() + sig_rlp_len;
+
+            let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 26);
+            // Type byte
+            out.push(0x76);
+            // RLP list header for new payload
+            if new_payload_len <= 55 {
+                out.push(0xc0 + new_payload_len as u8);
+            } else {
+                let len_bytes = new_payload_len.to_be_bytes();
+                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+                let num_len_bytes = 8 - start;
+                out.push(0xf7 + num_len_bytes as u8);
+                out.extend_from_slice(&len_bytes[start..]);
+            }
+            // Fields payload (from encode_for_signing)
+            out.extend_from_slice(fields_payload);
+            // User signature as RLP string (65 bytes)
+            out.push(0xb8); // long string prefix
+            out.push(65); // length
+            out.extend_from_slice(&sig_bytes);
+
+            // Append sender address + fee marker (viem convention)
+            out.extend_from_slice(address.as_slice());
+            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+            format!("0x{}", hex::encode(&out))
+        } else {
+            let signed_tx = tempo_tx.into_signed(signature.into());
+            let tx_bytes = signed_tx.encoded_2718();
+            format!("0x{}", hex::encode(&tx_bytes))
+        };
 
         let echo = challenge.to_echo();
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -146,6 +146,7 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
@@ -155,8 +156,8 @@ impl PaymentProvider for TempoProvider {
         use alloy::sol_types::SolCall;
         use tempo_alloy::contracts::precompiles::tip20::ITIP20;
         use tempo_alloy::TempoNetwork;
+        use tempo_alloy::rpc::TempoTransactionRequest;
         use tempo_primitives::transaction::Call;
-        use tempo_primitives::TempoTransaction;
 
         let charge: ChargeRequest = challenge.request.decode()?;
         let expected_chain_id = charge.chain_id().unwrap_or(CHAIN_ID);
@@ -217,21 +218,23 @@ impl PaymentProvider for TempoProvider {
             None
         };
 
+        let mut tempo_request = TempoTransactionRequest::default();
+        tempo_request.inner.chain_id = Some(expected_chain_id);
+        tempo_request.inner.nonce = Some(nonce);
+        tempo_request.inner.gas = Some(1_000_000);
+        tempo_request.inner.max_fee_per_gas = Some(gas_price);
+        tempo_request.inner.max_priority_fee_per_gas = Some(gas_price);
+        tempo_request.calls = vec![Call {
+            to: TxKind::Call(currency),
+            value: alloy::primitives::U256::ZERO,
+            input: Bytes::from(transfer_data),
+        }];
+        tempo_request.fee_payer_signature = fee_payer_signature;
+
         // Build a Tempo transaction (type 0x76) for proper on-chain processing.
-        let tempo_tx = TempoTransaction {
-            chain_id: expected_chain_id,
-            nonce,
-            gas_limit: 1_000_000,
-            max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: gas_price,
-            calls: vec![Call {
-                to: TxKind::Call(currency),
-                value: alloy::primitives::U256::ZERO,
-                input: Bytes::from(transfer_data),
-            }],
-            fee_payer_signature,
-            ..Default::default()
-        };
+        let tempo_tx = tempo_request.build_aa().map_err(|e| {
+            MppError::InvalidConfig(format!("failed to build tempo transaction: {}", e))
+        })?;
 
         use alloy::signers::SignerSync;
         let sig_hash = tempo_tx.signature_hash();
@@ -258,85 +261,6 @@ impl PaymentProvider for TempoProvider {
             PaymentPayload::transaction(signed_tx_hex),
         ))
     }
-}
-
-/// Encode a fee-payer transaction in the wire format expected by the fee-payer
-/// proxy server (viem convention).
-///
-/// `encoded_2718()` encodes `fee_payer_signature` as a full `[v, r, s]` RLP list,
-/// but the proxy expects the `0x00` placeholder byte (same as `encode_for_signing`)
-/// so it knows where to inject its own signature.
-///
-/// Output format: `0x76 || rlp([fields…, 0x00 placeholder, user_sig]) || sender || feefeefeefee`
-///
-/// TODO: push this into `tempo-primitives` as a first-class encoder so downstream
-/// crates don't need to do manual RLP manipulation.
-#[cfg(feature = "tempo")]
-fn encode_fee_payer_proxy_tx(
-    tx: &tempo_primitives::TempoTransaction,
-    user_sig: &alloy::primitives::PrimitiveSignature,
-    sender: alloy::primitives::Address,
-) -> Vec<u8> {
-    use alloy::consensus::SignableTransaction;
-    use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
-
-    // encode_for_signing gives us: 0x76 || rlp([fields…, 0x00 placeholder])
-    let mut signing_buf = Vec::new();
-    tx.encode_for_signing(&mut signing_buf);
-
-    // Strip type byte (0x76), decode the RLP list header to isolate the fields payload.
-    let rlp_data = &signing_buf[1..];
-    let fields_payload = if rlp_data[0] < 0xf8 {
-        let len = (rlp_data[0] - 0xc0) as usize;
-        &rlp_data[1..1 + len]
-    } else {
-        let len_of_len = (rlp_data[0] - 0xf7) as usize;
-        let mut len = 0usize;
-        for &b in &rlp_data[1..1 + len_of_len] {
-            len = (len << 8) | b as usize;
-        }
-        &rlp_data[1 + len_of_len..1 + len_of_len + len]
-    };
-
-    // User signature as 65 bytes (r || s || v).
-    let sig_bytes = {
-        let mut buf = [0u8; 65];
-        buf[..32].copy_from_slice(&user_sig.r().to_be_bytes::<32>());
-        buf[32..64].copy_from_slice(&user_sig.s().to_be_bytes::<32>());
-        buf[64] = user_sig.v() as u8;
-        buf
-    };
-
-    // New RLP list = fields_payload ++ RLP-encoded signature bytestring.
-    let sig_rlp_len = 1 + 1 + 65; // 0xb8 prefix + length byte + 65 data bytes
-    let new_payload_len = fields_payload.len() + sig_rlp_len;
-
-    let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 20 + 6);
-    out.push(TEMPO_TX_TYPE_ID);
-
-    // RLP list header.
-    if new_payload_len < 56 {
-        out.push(0xc0 + new_payload_len as u8);
-    } else {
-        let len_bytes = new_payload_len.to_be_bytes();
-        let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
-        let num_len_bytes = 8 - start;
-        out.push(0xf7 + num_len_bytes as u8);
-        out.extend_from_slice(&len_bytes[start..]);
-    }
-
-    out.extend_from_slice(fields_payload);
-
-    // Signature as RLP byte string (65 bytes, uses long-string prefix).
-    out.push(0xb8);
-    out.push(65);
-    out.extend_from_slice(&sig_bytes);
-
-    // Viem convention suffix: sender address + fee marker.
-    out.extend_from_slice(sender.as_slice());
-    out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
-
-    out
 }
 
 /// A provider that wraps multiple payment providers and picks the right one.

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -240,75 +240,13 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let signed_tx_hex = if is_fee_payer {
-            // For fee-payer transactions, produce the serialization format
-            // the TypeScript (viem) server expects:
-            // 0x76 || rlp([fields..., 0x00 placeholder, auth_list, user_sig]) || sender || feefeefeefee
-            //
-            // encode_for_signing outputs: 0x76 || rlp([fields..., 0x00, auth_list])
-            // We unwrap it, append the user signature, re-wrap, and add the
-            // sender+marker suffix that the server uses to identify the sender.
-            use alloy::consensus::SignableTransaction;
-
-            // Get signing payload: [0x76][rlp_header][fields_payload]
-            let mut signing_buf = Vec::new();
-            tempo_tx.encode_for_signing(&mut signing_buf);
-
-            // Parse out the fields payload from the RLP envelope
-            let rlp_data = &signing_buf[1..]; // skip 0x76 type byte
-            let (header_len, fields_len) = {
-                let first = rlp_data[0];
-                if first <= 0xf7 {
-                    (1, (first - 0xc0) as usize)
-                } else {
-                    let ll = (first - 0xf7) as usize;
-                    let mut buf = [0u8; 8];
-                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
-                    (1 + ll, usize::from_be_bytes(buf))
-                }
-            };
-            let fields_payload = &rlp_data[header_len..header_len + fields_len];
-
-            // Encode user signature as raw 65-byte secp256k1: [r(32) || s(32) || v(1)]
-            let mut sig_bytes = [0u8; 65];
-            sig_bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
-            sig_bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
-            sig_bytes[64] = signature.v() as u8;
-
-            // Build new RLP list: fields + sig_bytes (65 bytes as RLP string)
-            // sig_bytes is 65 bytes, so RLP encoding is: 0xb8 0x41 <65 bytes>
-            let sig_rlp_len = 2 + 65; // 0xb8 + length byte + 65 data bytes
-            let new_payload_len = fields_payload.len() + sig_rlp_len;
-
-            let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 26);
-            // Type byte
-            out.push(0x76);
-            // RLP list header for new payload
-            if new_payload_len <= 55 {
-                out.push(0xc0 + new_payload_len as u8);
-            } else {
-                let len_bytes = new_payload_len.to_be_bytes();
-                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
-                let num_len_bytes = 8 - start;
-                out.push(0xf7 + num_len_bytes as u8);
-                out.extend_from_slice(&len_bytes[start..]);
-            }
-            // Fields payload (from encode_for_signing)
-            out.extend_from_slice(fields_payload);
-            // User signature as RLP string (65 bytes)
-            out.push(0xb8); // long string prefix
-            out.push(65); // length
-            out.extend_from_slice(&sig_bytes);
-
-            // Append sender address + fee marker (viem convention)
-            out.extend_from_slice(address.as_slice());
-            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
-            format!("0x{}", hex::encode(&out))
-        } else {
-            let signed_tx = tempo_tx.into_signed(signature.into());
-            let tx_bytes = signed_tx.encoded_2718();
-            format!("0x{}", hex::encode(&tx_bytes))
-        };
+        // Canonical EIP-2718 encoding works for both fee-payer and non-fee-payer.
+        // For fee-payer txs, fee_payer_signature is Some(Signature(0,0,false)) —
+        // rlp_encode_fields_default encodes it as a proper RLP list [v, r, s],
+        // so AASigned::rlp_decode on the server handles it correctly.
+        let signed_tx = tempo_tx.into_signed(signature.into());
+        let tx_bytes = signed_tx.encoded_2718();
+        let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
         let echo = challenge.to_echo();
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -146,7 +146,7 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
-        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
+        use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
@@ -155,8 +155,8 @@ impl PaymentProvider for TempoProvider {
         use alloy::providers::{Provider, ProviderBuilder};
         use alloy::sol_types::SolCall;
         use tempo_alloy::contracts::precompiles::tip20::ITIP20;
-        use tempo_alloy::TempoNetwork;
         use tempo_alloy::rpc::TempoTransactionRequest;
+        use tempo_alloy::TempoNetwork;
         use tempo_primitives::transaction::Call;
 
         let charge: ChargeRequest = challenge.request.decode()?;
@@ -208,15 +208,7 @@ impl PaymentProvider for TempoProvider {
         // When feePayer is true, set a placeholder fee_payer_signature so the
         // signing hash commits to "fee payer expected" and the serialized tx
         // includes the 0x00 placeholder byte the server expects.
-        let fee_payer_signature = if is_fee_payer {
-            Some(alloy::primitives::Signature::new(
-                alloy::primitives::U256::ZERO,
-                alloy::primitives::U256::ZERO,
-                false,
-            ))
-        } else {
-            None
-        };
+        let fee_payer_signature = fee_payer_placeholder(is_fee_payer);
 
         let mut tempo_request = TempoTransactionRequest::default();
         tempo_request.inner.chain_id = Some(expected_chain_id);
@@ -244,8 +236,7 @@ impl PaymentProvider for TempoProvider {
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
         let signed_tx_hex = if is_fee_payer {
-            let tx_bytes =
-                encode_fee_payer_proxy_tx(&tempo_tx, &signature, address);
+            let tx_bytes = encode_fee_payer_proxy_tx(&tempo_tx, &signature, address);
             format!("0x{}", hex::encode(&tx_bytes))
         } else {
             let signed_tx = tempo_tx.into_signed(signature.into());

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -489,23 +489,6 @@ where
         }
     }
 
-    /// Strip the viem-convention fee-payer suffix from transaction bytes.
-    ///
-    /// The suffix format is: `<20-byte sender address><6-byte fee marker>`.
-    /// Returns `(canonical_tx_bytes, Some(sender_address))` when the suffix is
-    /// present, or `(original_bytes, None)` when it is not.
-    fn strip_fee_payer_suffix(tx_bytes: &[u8]) -> (&[u8], Option<Address>) {
-        const SUFFIX_LEN: usize = 20 + 6; // sender address + marker
-        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == super::FEE_PAYER_MARKER
-        {
-            let split = tx_bytes.len() - SUFFIX_LEN;
-            let sender = Address::from_slice(&tx_bytes[split..split + 20]);
-            (&tx_bytes[..split], Some(sender))
-        } else {
-            (tx_bytes, None)
-        }
-    }
-
     async fn broadcast_transaction(
         &self,
         signed_tx: &str,
@@ -527,16 +510,9 @@ where
         })?;
         let memo = charge.memo();
 
-        // Only strip the viem fee-payer suffix when fee sponsorship is requested.
-        // This avoids false-positive suffix detection on normal transactions whose
-        // trailing bytes happen to match the marker.
-        let (tx_bytes, fee_payer_sender) = if charge.fee_payer() {
-            Self::strip_fee_payer_suffix(&raw_bytes)
-        } else {
-            (&raw_bytes[..], None)
-        };
+        let tx_bytes = &raw_bytes[..];
 
-        // Validate the payment call on canonical bytes (common to both paths).
+        // Validate the payment call.
         self.validate_transaction(
             tx_bytes,
             currency,
@@ -567,21 +543,11 @@ where
                     VerificationError::new(format!("Failed to decode fee-payer transaction: {}", e))
                 })?;
 
-            // Always recover sender cryptographically — never trust the suffix alone.
+            // Recover sender cryptographically from the user's signature.
             use alloy::consensus::transaction::SignerRecoverable;
             let sender = signed
                 .recover_signer()
                 .map_err(|e| VerificationError::new(format!("Failed to recover sender: {}", e)))?;
-
-            // If the suffix included a sender address, verify it matches.
-            if let Some(suffix_sender) = fee_payer_sender {
-                if suffix_sender != sender {
-                    return Err(VerificationError::new(format!(
-                        "Suffix sender {} does not match recovered signer {}",
-                        suffix_sender, sender
-                    )));
-                }
-            }
 
             let (mut tx, user_sig, _) = signed.into_parts();
 
@@ -931,51 +897,6 @@ mod tests {
         (signed_tx.encoded_2718(), tx)
     }
 
-    // ---- Fee-payer suffix stripping tests ----
-
-    type TestChargeMethod = ChargeMethod<
-        alloy::providers::fillers::FillProvider<
-            alloy::providers::Identity,
-            alloy::providers::RootProvider<TempoNetwork>,
-            TempoNetwork,
-        >,
-    >;
-
-    #[test]
-    fn test_strip_fee_payer_suffix_present() {
-        let mut data = vec![0x76, 0xaa, 0xbb]; // fake tx bytes
-        let sender: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
-            .parse()
-            .unwrap();
-        data.extend_from_slice(sender.as_slice());
-        data.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
-
-        let (stripped, extracted_sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
-        assert_eq!(stripped, &[0x76, 0xaa, 0xbb]);
-        assert_eq!(extracted_sender, Some(sender));
-    }
-
-    #[test]
-    fn test_strip_fee_payer_suffix_absent() {
-        let data = vec![0x76, 0xaa, 0xbb, 0xcc];
-        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
-        assert_eq!(stripped, &data[..]);
-        assert_eq!(sender, None);
-    }
-
-    #[test]
-    fn test_strip_fee_payer_suffix_too_short() {
-        // Exactly 26 bytes (suffix length) should not match because there'd be
-        // zero canonical bytes.
-        let mut data = vec![0u8; 20]; // "sender"
-        data.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
-        assert_eq!(data.len(), 26);
-
-        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
-        assert_eq!(stripped.len(), data.len()); // unchanged
-        assert_eq!(sender, None);
-    }
-
     // ---- Fee-payer round-trip signing test ----
 
     #[test]
@@ -1114,11 +1035,6 @@ mod tests {
             false, // no fee payer
         );
 
-        // No suffix should be detected
-        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
-        assert_eq!(stripped.len(), raw_bytes.len());
-        assert!(sender.is_none());
-
         // validate_transaction should work directly
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_http("https://rpc.moderato.tempo.xyz".parse().unwrap());
@@ -1138,139 +1054,4 @@ mod tests {
         );
     }
 
-    // ---- Fix #8: suffix sender ≠ recovered sender ----
-
-    #[test]
-    fn test_suffix_sender_mismatch_rejected() {
-        // Build a fee-payer tx signed by user_signer, but attach a DIFFERENT
-        // address in the viem suffix. The server must reject this.
-        let user_signer = alloy_signer_local::PrivateKeySigner::random();
-        let wrong_sender = alloy_signer_local::PrivateKeySigner::random().address();
-
-        let currency: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
-            .unwrap();
-        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
-            .parse()
-            .unwrap();
-        let amount = U256::from(1_000_000u64);
-        let memo = B256::ZERO;
-
-        let (canonical_bytes, _tx) = build_test_tx(
-            &user_signer,
-            MODERATO_CHAIN_ID,
-            currency,
-            recipient,
-            amount,
-            memo,
-            true,
-        );
-
-        // Append viem suffix with the WRONG sender address
-        let mut wire_bytes = canonical_bytes.clone();
-        wire_bytes.extend_from_slice(wrong_sender.as_slice());
-        wire_bytes.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
-
-        // Verify stripping extracts the wrong sender
-        let (stripped, extracted) = TestChargeMethod::strip_fee_payer_suffix(&wire_bytes);
-        assert_eq!(stripped, &canonical_bytes[..]);
-        assert_eq!(extracted, Some(wrong_sender));
-        assert_ne!(wrong_sender, user_signer.address());
-
-        // The decoded tx should recover user_signer.address(), which differs
-        // from wrong_sender. The server should reject.
-        let decode_data = &stripped[1..]; // skip 0x76
-        let signed =
-            tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..]).expect("should decode");
-
-        use alloy::consensus::transaction::SignerRecoverable;
-        let recovered = signed.recover_signer().expect("should recover");
-        assert_eq!(recovered, user_signer.address());
-        assert_ne!(
-            recovered, wrong_sender,
-            "suffix sender must differ from recovered signer"
-        );
-    }
-
-    // ---- Fix #9: encode_fee_payer_proxy_tx roundtrip / edge-case tests ----
-
-    #[test]
-    fn test_encode_fee_payer_proxy_tx_roundtrip() {
-        // Encode a fee-payer tx via the proxy helper, then verify:
-        // 1. Suffix is present and strippable
-        // 2. After stripping, the tx can be decoded
-        // 3. The sender can be recovered
-        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
-        use alloy::signers::SignerSync;
-
-        let signer = alloy_signer_local::PrivateKeySigner::random();
-        let currency: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
-            .unwrap();
-        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
-            .parse()
-            .unwrap();
-        let amount = U256::from(500_000u64);
-        let memo = B256::ZERO;
-
-        let (_canonical, tx) = build_test_tx(
-            &signer,
-            MODERATO_CHAIN_ID,
-            currency,
-            recipient,
-            amount,
-            memo,
-            true,
-        );
-
-        // Sign and encode via the proxy helper
-        let sig_hash = tx.signature_hash();
-        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
-        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
-
-        // Must end with sender + marker
-        let marker = &crate::protocol::methods::tempo::FEE_PAYER_MARKER;
-        assert_eq!(&wire[wire.len() - 6..], marker);
-        assert_eq!(
-            Address::from_slice(&wire[wire.len() - 26..wire.len() - 6]),
-            signer.address()
-        );
-
-        // Strip suffix and verify canonical bytes decode
-        let (stripped, extracted_sender) = TestChargeMethod::strip_fee_payer_suffix(&wire);
-        assert_eq!(extracted_sender, Some(signer.address()));
-        assert!(stripped[0] == 0x76, "must start with tempo tx type");
-    }
-
-    #[test]
-    fn test_encode_fee_payer_proxy_tx_output_starts_with_type_byte() {
-        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
-        use alloy::signers::SignerSync;
-        use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
-
-        let signer = alloy_signer_local::PrivateKeySigner::random();
-        let (_canonical, tx) = build_test_tx(
-            &signer,
-            MODERATO_CHAIN_ID,
-            "0x20c0000000000000000000000000000000000000"
-                .parse()
-                .unwrap(),
-            "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
-                .parse()
-                .unwrap(),
-            U256::from(1u64),
-            B256::ZERO,
-            true,
-        );
-
-        let sig_hash = tx.signature_hash();
-        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
-        let out = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
-
-        assert_eq!(out[0], TEMPO_TX_TYPE_ID);
-        assert!(
-            out.len() > 26 + 2,
-            "output must contain tx data beyond suffix"
-        );
-    }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -509,158 +509,6 @@ where
         }
     }
 
-    /// Decode a fee-payer wire-format transaction.
-    ///
-    /// The client's `encode_for_signing` uses a `0x00` placeholder byte for
-    /// `fee_payer_signature` (meaning "fee payer will sign later"), which
-    /// differs from the canonical `AASigned` encoding (`0x80` = None, or a
-    /// full RLP-encoded signature list). Standard `AASigned::rlp_decode`
-    /// cannot handle `0x00`, so we patch the byte to `0x80` before decoding
-    /// and restore `fee_payer_signature = Some(placeholder)` afterwards.
-    fn decode_fee_payer_tx(
-        tx_bytes: &[u8],
-    ) -> Result<
-        (
-            tempo_primitives::TempoTransaction,
-            tempo_primitives::transaction::TempoSignature,
-        ),
-        VerificationError,
-    > {
-        // The raw bytes are: 0x76 || RLP-list(fields..., 0x00, auth_list, sig)
-        // We need to locate the 0x00 placeholder byte and change it to 0x80 so
-        // that rlp_decode_fields treats it as None.  The placeholder is always
-        // a single 0x00 byte (see encode_for_signing) right after the fee_token
-        // field. Rather than parsing every field to find it, we scan for the
-        // unique pattern: since 0x00 only appears as the fee_payer_signature
-        // placeholder (all other fields use 0x80 for empty optionals), we can
-        // create a mutable copy and patch it.
-        let mut patched = tx_bytes.to_vec();
-
-        // Skip type byte (0x76) for Tempo transactions
-        let data_start = if !patched.is_empty() && patched[0] == 0x76 {
-            1
-        } else {
-            0
-        };
-
-        // Parse the outer RLP list header to find where fields start
-        let rlp_data = &patched[data_start..];
-        let (header_len, _payload_len) = if !rlp_data.is_empty() {
-            let first = rlp_data[0];
-            if first <= 0xf7 {
-                (1usize, (first - 0xc0) as usize)
-            } else {
-                let ll = (first - 0xf7) as usize;
-                let mut buf = [0u8; 8];
-                if ll < rlp_data.len() {
-                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
-                }
-                (1 + ll, usize::from_be_bytes(buf))
-            }
-        } else {
-            return Err(VerificationError::new(
-                "Empty transaction bytes".to_string(),
-            ));
-        };
-
-        // Scan inside the payload for a bare 0x00 byte that is the
-        // fee_payer_signature placeholder.  The fields before it
-        // (fee_token) are encoded as either 0x80 (None) or an address.
-        // The placeholder 0x00 is distinguishable because:
-        //   - It follows the fee_token field (0x80 or 0x94 <20 bytes>)
-        //   - A bare 0x00 is not valid at any other position in the
-        //     fee_payer_signature slot (a real sig would start with a
-        //     list header >= 0xc0)
-        let payload_start = data_start + header_len;
-        let payload_end = patched.len();
-
-        // Walk through the RLP items to find the fee_payer_signature slot.
-        // Field order: chain_id, max_priority_fee, max_fee, gas_limit, calls,
-        //   access_list, nonce_key, nonce, valid_before, valid_after,
-        //   fee_token, fee_payer_signature, auth_list, [key_auth], [user_sig]
-        let mut pos = payload_start;
-        let mut field_idx = 0;
-        const FEE_PAYER_SIG_IDX: usize = 11; // 0-indexed
-
-        while pos < payload_end && field_idx < FEE_PAYER_SIG_IDX {
-            let item_len = Self::rlp_item_total_len(&patched[pos..]).ok_or_else(|| {
-                VerificationError::new(format!(
-                    "Failed to parse RLP at field {} offset {}",
-                    field_idx, pos
-                ))
-            })?;
-            pos += item_len;
-            field_idx += 1;
-        }
-
-        // pos should now point to the fee_payer_signature field
-        if pos < payload_end && patched[pos] == 0x00 {
-            patched[pos] = 0x80; // patch placeholder → None
-        }
-
-        // Now decode using standard AASigned::rlp_decode
-        let decode_data = &patched[data_start..];
-        let signed =
-            tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..]).map_err(|e| {
-                VerificationError::new(format!("Failed to decode fee-payer transaction: {}", e))
-            })?;
-
-        let (mut tx, sig, _) = signed.into_parts();
-
-        // Restore the fee_payer_signature as a placeholder
-        tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
-            U256::ZERO,
-            U256::ZERO,
-            false,
-        ));
-
-        Ok((tx, sig))
-    }
-
-    /// Get the total byte length of an RLP item (header + payload).
-    fn rlp_item_total_len(data: &[u8]) -> Option<usize> {
-        if data.is_empty() {
-            return None;
-        }
-        let first = data[0];
-        match first {
-            // Single byte (0x00..=0x7f)
-            0x00..=0x7f => Some(1),
-            // Short string (0x80..=0xb7): length = first - 0x80
-            0x80..=0xb7 => {
-                let len = (first - 0x80) as usize;
-                Some(1 + len)
-            }
-            // Long string (0xb8..=0xbf): next (first - 0xb7) bytes are the length
-            0xb8..=0xbf => {
-                let ll = (first - 0xb7) as usize;
-                if data.len() < 1 + ll {
-                    return None;
-                }
-                let mut buf = [0u8; 8];
-                buf[8 - ll..].copy_from_slice(&data[1..1 + ll]);
-                let len = usize::from_be_bytes(buf);
-                Some(1 + ll + len)
-            }
-            // Short list (0xc0..=0xf7): length = first - 0xc0
-            0xc0..=0xf7 => {
-                let len = (first - 0xc0) as usize;
-                Some(1 + len)
-            }
-            // Long list (0xf8..=0xff): next (first - 0xf7) bytes are the length
-            0xf8..=0xff => {
-                let ll = (first - 0xf7) as usize;
-                if data.len() < 1 + ll {
-                    return None;
-                }
-                let mut buf = [0u8; 8];
-                buf[8 - ll..].copy_from_slice(&data[1..1 + ll]);
-                let len = usize::from_be_bytes(buf);
-                Some(1 + ll + len)
-            }
-        }
-    }
-
     async fn broadcast_transaction(
         &self,
         signed_tx: &str,
@@ -701,30 +549,39 @@ where
         let broadcast_bytes: Bytes = if charge.fee_payer() {
             let fee_payer_signer = self.fee_payer_signer.as_ref().unwrap();
 
-            let sender = fee_payer_sender.ok_or_else(|| {
-                VerificationError::new(
-                    "feePayer requested but transaction is missing the sender address suffix"
-                        .to_string(),
-                )
-            })?;
-
-            // Decode the fee-payer wire format (handles 0x00 placeholder byte).
-            let (mut tx, user_sig) = Self::decode_fee_payer_tx(tx_bytes)?;
-
-            // Validate the payment call before signing.
-            // Re-encode as canonical bytes for validate_transaction.
-            let canonical_signed = tx.clone().into_signed(user_sig.clone());
-            let mut canonical_buf = Vec::new();
-            canonical_signed.eip2718_encode(&mut canonical_buf);
-
+            // Validate the payment call on the canonical bytes.
             self.validate_transaction(
-                &canonical_buf,
+                tx_bytes,
                 currency,
                 expected_recipient,
                 expected_amount,
                 memo.as_deref(),
                 expected_chain_id,
             )?;
+
+            // Decode the canonical transaction (fee_payer_signature is a
+            // proper RLP-encoded placeholder Signature(0,0,false)).
+            let decode_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
+                &tx_bytes[1..]
+            } else {
+                tx_bytes
+            };
+            let signed =
+                tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..]).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode fee-payer transaction: {}", e))
+                })?;
+
+            // Recover sender from the user's signature.
+            use alloy::consensus::transaction::SignerRecoverable;
+            let sender = if let Some(suffix_sender) = fee_payer_sender {
+                suffix_sender
+            } else {
+                signed.recover_signer().map_err(|e| {
+                    VerificationError::new(format!("Failed to recover sender: {}", e))
+                })?
+            };
+
+            let (mut tx, user_sig, _) = signed.into_parts();
 
             // Sign with the fee payer key.
             use alloy::signers::SignerSync;
@@ -1028,7 +885,7 @@ mod tests {
     }
 
     /// Helper: build a signed Tempo transaction with optional fee-payer
-    /// placeholder and optional feefeefeefee suffix, returning hex bytes.
+    /// placeholder, returning canonical EIP-2718 bytes.
     fn build_test_tx(
         signer: &alloy_signer_local::PrivateKeySigner,
         chain_id: u64,
@@ -1038,6 +895,7 @@ mod tests {
         memo: B256,
         fee_payer: bool,
     ) -> (Vec<u8>, tempo_primitives::TempoTransaction) {
+        use alloy::eips::Encodable2718;
         use alloy::primitives::TxKind;
         use alloy::signers::SignerSync;
         use alloy::sol_types::SolCall;
@@ -1076,62 +934,8 @@ mod tests {
         let sig_hash = tx.signature_hash();
         let signature = signer.sign_hash_sync(&sig_hash).unwrap();
 
-        if fee_payer {
-            // Produce viem-convention bytes:
-            // 0x76 || rlp([fields..., 0x00, auth_list, user_sig]) || sender || feefeefeefee
-            use alloy::consensus::SignableTransaction;
-
-            let mut signing_buf = Vec::new();
-            tx.encode_for_signing(&mut signing_buf);
-
-            let rlp_data = &signing_buf[1..]; // skip 0x76
-            let (header_len, fields_len) = {
-                let first = rlp_data[0];
-                if first <= 0xf7 {
-                    (1, (first - 0xc0) as usize)
-                } else {
-                    let ll = (first - 0xf7) as usize;
-                    let mut buf = [0u8; 8];
-                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
-                    (1 + ll, usize::from_be_bytes(buf))
-                }
-            };
-            let fields_payload = &rlp_data[header_len..header_len + fields_len];
-
-            let mut sig_bytes = [0u8; 65];
-            sig_bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
-            sig_bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
-            sig_bytes[64] = signature.v() as u8;
-
-            let sig_rlp_len = 2 + 65;
-            let new_payload_len = fields_payload.len() + sig_rlp_len;
-
-            let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 26);
-            out.push(0x76);
-            if new_payload_len <= 55 {
-                out.push(0xc0 + new_payload_len as u8);
-            } else {
-                let len_bytes = new_payload_len.to_be_bytes();
-                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
-                let num_len_bytes = 8 - start;
-                out.push(0xf7 + num_len_bytes as u8);
-                out.extend_from_slice(&len_bytes[start..]);
-            }
-            out.extend_from_slice(fields_payload);
-            out.push(0xb8);
-            out.push(65);
-            out.extend_from_slice(&sig_bytes);
-
-            // Append sender + fee marker
-            out.extend_from_slice(signer.address().as_slice());
-            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
-
-            (out, tx)
-        } else {
-            use alloy::eips::Encodable2718;
-            let signed_tx = tx.clone().into_signed(signature.into());
-            (signed_tx.encoded_2718(), tx)
-        }
+        let signed_tx = tx.clone().into_signed(signature.into());
+        (signed_tx.encoded_2718(), tx)
     }
 
     // ---- Fee-payer suffix stripping tests ----
@@ -1183,9 +987,10 @@ mod tests {
 
     #[test]
     fn test_fee_payer_round_trip_signing() {
-        // Verify that a fee-payer-suffixed tx can be stripped, decoded via
-        // decode_fee_payer_tx, fee-payer-signed, re-encoded, and the fee
-        // payer recovered.
+        // Verify that a canonical fee-payer tx can be decoded via
+        // AASigned::rlp_decode, sender recovered, fee-payer-signed,
+        // re-encoded, and the fee payer recovered.
+        use alloy::consensus::transaction::SignerRecoverable;
         use alloy::signers::SignerSync;
 
         let user_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1210,14 +1015,16 @@ mod tests {
             true, // fee_payer = true
         );
 
-        // Step 1: Strip suffix
-        let (tx_bytes, sender_opt) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
-        let sender = sender_opt.expect("sender should be present");
+        // Step 1: Decode canonical bytes (skip type byte 0x76)
+        let decode_data = &raw_bytes[1..];
+        let signed = tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..])
+            .expect("should decode canonical fee-payer tx");
+
+        // Step 2: Recover sender from the user's signature
+        let sender = signed.recover_signer().expect("should recover sender");
         assert_eq!(sender, user_signer.address());
 
-        // Step 2: Decode the fee-payer wire format
-        let (mut tx, user_sig) =
-            TestChargeMethod::decode_fee_payer_tx(tx_bytes).expect("should decode fee-payer tx");
+        let (mut tx, user_sig, _) = signed.into_parts();
 
         // The placeholder should be present
         assert!(tx.fee_payer_signature.is_some(), "placeholder should exist");
@@ -1246,9 +1053,8 @@ mod tests {
     }
 
     #[test]
-    fn test_decode_fee_payer_tx_validates_payment() {
-        // Ensure decode_fee_payer_tx + re-encode produces bytes that
-        // validate_transaction can parse and verify the payment call.
+    fn test_fee_payer_tx_validates_payment() {
+        // Ensure canonical fee-payer tx bytes pass validate_transaction.
         use alloy::providers::ProviderBuilder;
 
         let user_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1271,22 +1077,12 @@ mod tests {
             true,
         );
 
-        // Strip and decode the fee-payer format
-        let (tx_bytes, _sender) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
-        let (tx, user_sig) =
-            TestChargeMethod::decode_fee_payer_tx(tx_bytes).expect("should decode");
-
-        // Re-encode as canonical bytes
-        let canonical_signed = tx.into_signed(user_sig);
-        let mut canonical_buf = Vec::new();
-        canonical_signed.eip2718_encode(&mut canonical_buf);
-
-        // validate_transaction should succeed on canonical bytes
+        // validate_transaction should work directly on canonical bytes
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .connect_http("https://rpc.moderato.tempo.xyz".parse().unwrap());
         let method = ChargeMethod::new(provider);
         let result = method.validate_transaction(
-            &canonical_buf,
+            &raw_bytes,
             currency,
             recipient,
             amount,
@@ -1295,7 +1091,7 @@ mod tests {
         );
         assert!(
             result.is_ok(),
-            "should validate after decode + re-encode: {:?}",
+            "fee-payer tx should validate directly: {:?}",
             result.err()
         );
     }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -489,10 +489,6 @@ where
         }
     }
 
-    /// The feefeefeefee suffix marker used by viem-based clients to pass the
-    /// sender address to the fee-payer proxy.
-    const FEE_MARKER: [u8; 6] = [0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee];
-
     /// Strip the viem-convention fee-payer suffix from transaction bytes.
     ///
     /// The suffix format is: `<20-byte sender address><6-byte fee marker>`.
@@ -500,7 +496,7 @@ where
     /// present, or `(original_bytes, None)` when it is not.
     fn strip_fee_payer_suffix(tx_bytes: &[u8]) -> (&[u8], Option<Address>) {
         const SUFFIX_LEN: usize = 20 + 6; // sender address + marker
-        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == Self::FEE_MARKER {
+        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == super::FEE_PAYER_MARKER {
             let split = tx_bytes.len() - SUFFIX_LEN;
             let sender = Address::from_slice(&tx_bytes[split..split + 20]);
             (&tx_bytes[..split], Some(sender))
@@ -519,13 +515,6 @@ where
             .parse::<Bytes>()
             .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {}", e)))?;
 
-        // Strip viem fee-payer suffix before any processing so that
-        // validate_transaction and RLP decoding see canonical bytes.
-        let (tx_bytes, fee_payer_sender) = Self::strip_fee_payer_suffix(&raw_bytes);
-
-        // Pre-broadcast validation: verify transaction contains expected payment call.
-        // For fee-payer transactions, decode via the custom fee-payer format first,
-        // then re-encode to canonical bytes for validate_transaction.
         let expected_recipient = charge.recipient_address().map_err(|e| {
             VerificationError::new(format!("Invalid recipient address in request: {}", e))
         })?;
@@ -537,27 +526,33 @@ where
         })?;
         let memo = charge.memo();
 
-        // Fail fast if fee payer is requested but no signer is configured.
-        if charge.fee_payer() && self.fee_payer_signer.is_none() {
-            return Err(VerificationError::new(
-                "feePayer requested but fee sponsorship is not configured on this server"
-                    .to_string(),
-            ));
-        }
+        // Only strip the viem fee-payer suffix when fee sponsorship is requested.
+        // This avoids false-positive suffix detection on normal transactions whose
+        // trailing bytes happen to match the marker.
+        let (tx_bytes, fee_payer_sender) = if charge.fee_payer() {
+            Self::strip_fee_payer_suffix(&raw_bytes)
+        } else {
+            (&raw_bytes[..], None)
+        };
+
+        // Validate the payment call on canonical bytes (common to both paths).
+        self.validate_transaction(
+            tx_bytes,
+            currency,
+            expected_recipient,
+            expected_amount,
+            memo.as_deref(),
+            expected_chain_id,
+        )?;
 
         // Build the final transaction bytes to broadcast.
         let broadcast_bytes: Bytes = if charge.fee_payer() {
-            let fee_payer_signer = self.fee_payer_signer.as_ref().unwrap();
-
-            // Validate the payment call on the canonical bytes.
-            self.validate_transaction(
-                tx_bytes,
-                currency,
-                expected_recipient,
-                expected_amount,
-                memo.as_deref(),
-                expected_chain_id,
-            )?;
+            let fee_payer_signer = self.fee_payer_signer.as_ref().ok_or_else(|| {
+                VerificationError::new(
+                    "feePayer requested but fee sponsorship is not configured on this server"
+                        .to_string(),
+                )
+            })?;
 
             // Decode the canonical transaction (fee_payer_signature is a
             // proper RLP-encoded placeholder Signature(0,0,false)).
@@ -571,15 +566,21 @@ where
                     VerificationError::new(format!("Failed to decode fee-payer transaction: {}", e))
                 })?;
 
-            // Recover sender from the user's signature.
+            // Always recover sender cryptographically — never trust the suffix alone.
             use alloy::consensus::transaction::SignerRecoverable;
-            let sender = if let Some(suffix_sender) = fee_payer_sender {
-                suffix_sender
-            } else {
-                signed.recover_signer().map_err(|e| {
-                    VerificationError::new(format!("Failed to recover sender: {}", e))
-                })?
-            };
+            let sender = signed.recover_signer().map_err(|e| {
+                VerificationError::new(format!("Failed to recover sender: {}", e))
+            })?;
+
+            // If the suffix included a sender address, verify it matches.
+            if let Some(suffix_sender) = fee_payer_sender {
+                if suffix_sender != sender {
+                    return Err(VerificationError::new(format!(
+                        "Suffix sender {} does not match recovered signer {}",
+                        suffix_sender, sender
+                    )));
+                }
+            }
 
             let (mut tx, user_sig, _) = signed.into_parts();
 
@@ -597,15 +598,6 @@ where
             fully_signed.eip2718_encode(&mut buf);
             Bytes::from(buf)
         } else {
-            // Non-fee-payer path: validate and broadcast directly.
-            self.validate_transaction(
-                tx_bytes,
-                currency,
-                expected_recipient,
-                expected_amount,
-                memo.as_deref(),
-                expected_chain_id,
-            )?;
             Bytes::copy_from_slice(tx_bytes)
         };
 
@@ -955,7 +947,7 @@ mod tests {
             .parse()
             .unwrap();
         data.extend_from_slice(sender.as_slice());
-        data.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+        data.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
 
         let (stripped, extracted_sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
         assert_eq!(stripped, &[0x76, 0xaa, 0xbb]);
@@ -975,7 +967,7 @@ mod tests {
         // Exactly 26 bytes (suffix length) should not match because there'd be
         // zero canonical bytes.
         let mut data = vec![0u8; 20]; // "sender"
-        data.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+        data.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
         assert_eq!(data.len(), 26);
 
         let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
@@ -1143,5 +1135,135 @@ mod tests {
             "non-fee-payer tx should validate: {:?}",
             result.err()
         );
+    }
+
+    // ---- Fix #8: suffix sender ≠ recovered sender ----
+
+    #[test]
+    fn test_suffix_sender_mismatch_rejected() {
+        // Build a fee-payer tx signed by user_signer, but attach a DIFFERENT
+        // address in the viem suffix. The server must reject this.
+        let user_signer = alloy_signer_local::PrivateKeySigner::random();
+        let wrong_sender = alloy_signer_local::PrivateKeySigner::random().address();
+
+        let currency: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000u64);
+        let memo = B256::ZERO;
+
+        let (canonical_bytes, _tx) = build_test_tx(
+            &user_signer,
+            MODERATO_CHAIN_ID,
+            currency,
+            recipient,
+            amount,
+            memo,
+            true,
+        );
+
+        // Append viem suffix with the WRONG sender address
+        let mut wire_bytes = canonical_bytes.clone();
+        wire_bytes.extend_from_slice(wrong_sender.as_slice());
+        wire_bytes.extend_from_slice(&crate::protocol::methods::tempo::FEE_PAYER_MARKER);
+
+        // Verify stripping extracts the wrong sender
+        let (stripped, extracted) = TestChargeMethod::strip_fee_payer_suffix(&wire_bytes);
+        assert_eq!(stripped, &canonical_bytes[..]);
+        assert_eq!(extracted, Some(wrong_sender));
+        assert_ne!(wrong_sender, user_signer.address());
+
+        // The decoded tx should recover user_signer.address(), which differs
+        // from wrong_sender. The server should reject.
+        let decode_data = &stripped[1..]; // skip 0x76
+        let signed = tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..])
+            .expect("should decode");
+
+        use alloy::consensus::transaction::SignerRecoverable;
+        let recovered = signed.recover_signer().expect("should recover");
+        assert_eq!(recovered, user_signer.address());
+        assert_ne!(recovered, wrong_sender, "suffix sender must differ from recovered signer");
+    }
+
+    // ---- Fix #9: encode_fee_payer_proxy_tx roundtrip / edge-case tests ----
+
+    #[test]
+    fn test_encode_fee_payer_proxy_tx_roundtrip() {
+        // Encode a fee-payer tx via the proxy helper, then verify:
+        // 1. Suffix is present and strippable
+        // 2. After stripping, the tx can be decoded
+        // 3. The sender can be recovered
+        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
+        use alloy::signers::SignerSync;
+
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let currency: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        let amount = U256::from(500_000u64);
+        let memo = B256::ZERO;
+
+        let (_canonical, tx) = build_test_tx(
+            &signer,
+            MODERATO_CHAIN_ID,
+            currency,
+            recipient,
+            amount,
+            memo,
+            true,
+        );
+
+        // Sign and encode via the proxy helper
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+
+        // Must end with sender + marker
+        let marker = &crate::protocol::methods::tempo::FEE_PAYER_MARKER;
+        assert_eq!(&wire[wire.len() - 6..], marker);
+        assert_eq!(
+            Address::from_slice(&wire[wire.len() - 26..wire.len() - 6]),
+            signer.address()
+        );
+
+        // Strip suffix and verify canonical bytes decode
+        let (stripped, extracted_sender) = TestChargeMethod::strip_fee_payer_suffix(&wire);
+        assert_eq!(extracted_sender, Some(signer.address()));
+        assert!(stripped[0] == 0x76, "must start with tempo tx type");
+    }
+
+    #[test]
+    fn test_encode_fee_payer_proxy_tx_output_starts_with_type_byte() {
+        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
+        use alloy::signers::SignerSync;
+        use tempo_primitives::transaction::TEMPO_TX_TYPE_ID;
+
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let (_canonical, tx) = build_test_tx(
+            &signer,
+            MODERATO_CHAIN_ID,
+            "0x20c0000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+            "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+                .parse()
+                .unwrap(),
+            U256::from(1u64),
+            B256::ZERO,
+            true,
+        );
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let out = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+
+        assert_eq!(out[0], TEMPO_TX_TYPE_ID);
+        assert!(out.len() > 26 + 2, "output must contain tx data beyond suffix");
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -496,7 +496,8 @@ where
     /// present, or `(original_bytes, None)` when it is not.
     fn strip_fee_payer_suffix(tx_bytes: &[u8]) -> (&[u8], Option<Address>) {
         const SUFFIX_LEN: usize = 20 + 6; // sender address + marker
-        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == super::FEE_PAYER_MARKER {
+        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == super::FEE_PAYER_MARKER
+        {
             let split = tx_bytes.len() - SUFFIX_LEN;
             let sender = Address::from_slice(&tx_bytes[split..split + 20]);
             (&tx_bytes[..split], Some(sender))
@@ -568,9 +569,9 @@ where
 
             // Always recover sender cryptographically — never trust the suffix alone.
             use alloy::consensus::transaction::SignerRecoverable;
-            let sender = signed.recover_signer().map_err(|e| {
-                VerificationError::new(format!("Failed to recover sender: {}", e))
-            })?;
+            let sender = signed
+                .recover_signer()
+                .map_err(|e| VerificationError::new(format!("Failed to recover sender: {}", e)))?;
 
             // If the suffix included a sender address, verify it matches.
             if let Some(suffix_sender) = fee_payer_sender {
@@ -1179,13 +1180,16 @@ mod tests {
         // The decoded tx should recover user_signer.address(), which differs
         // from wrong_sender. The server should reject.
         let decode_data = &stripped[1..]; // skip 0x76
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..])
-            .expect("should decode");
+        let signed =
+            tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..]).expect("should decode");
 
         use alloy::consensus::transaction::SignerRecoverable;
         let recovered = signed.recover_signer().expect("should recover");
         assert_eq!(recovered, user_signer.address());
-        assert_ne!(recovered, wrong_sender, "suffix sender must differ from recovered signer");
+        assert_ne!(
+            recovered, wrong_sender,
+            "suffix sender must differ from recovered signer"
+        );
     }
 
     // ---- Fix #9: encode_fee_payer_proxy_tx roundtrip / edge-case tests ----
@@ -1264,6 +1268,9 @@ mod tests {
         let out = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
 
         assert_eq!(out[0], TEMPO_TX_TYPE_ID);
-        assert!(out.len() > 26 + 2, "output must contain tx data beyond suffix");
+        assert!(
+            out.len() > 26 + 2,
+            "output must contain tx data beyond suffix"
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -489,17 +489,195 @@ where
         }
     }
 
+    /// The feefeefeefee suffix marker used by viem-based clients to pass the
+    /// sender address to the fee-payer proxy.
+    const FEE_MARKER: [u8; 6] = [0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee];
+
+    /// Strip the viem-convention fee-payer suffix from transaction bytes.
+    ///
+    /// The suffix format is: `<20-byte sender address><6-byte fee marker>`.
+    /// Returns `(canonical_tx_bytes, Some(sender_address))` when the suffix is
+    /// present, or `(original_bytes, None)` when it is not.
+    fn strip_fee_payer_suffix(tx_bytes: &[u8]) -> (&[u8], Option<Address>) {
+        const SUFFIX_LEN: usize = 20 + 6; // sender address + marker
+        if tx_bytes.len() > SUFFIX_LEN && tx_bytes[tx_bytes.len() - 6..] == Self::FEE_MARKER {
+            let split = tx_bytes.len() - SUFFIX_LEN;
+            let sender = Address::from_slice(&tx_bytes[split..split + 20]);
+            (&tx_bytes[..split], Some(sender))
+        } else {
+            (tx_bytes, None)
+        }
+    }
+
+    /// Decode a fee-payer wire-format transaction.
+    ///
+    /// The client's `encode_for_signing` uses a `0x00` placeholder byte for
+    /// `fee_payer_signature` (meaning "fee payer will sign later"), which
+    /// differs from the canonical `AASigned` encoding (`0x80` = None, or a
+    /// full RLP-encoded signature list). Standard `AASigned::rlp_decode`
+    /// cannot handle `0x00`, so we patch the byte to `0x80` before decoding
+    /// and restore `fee_payer_signature = Some(placeholder)` afterwards.
+    fn decode_fee_payer_tx(
+        tx_bytes: &[u8],
+    ) -> Result<
+        (
+            tempo_primitives::TempoTransaction,
+            tempo_primitives::transaction::TempoSignature,
+        ),
+        VerificationError,
+    > {
+        // The raw bytes are: 0x76 || RLP-list(fields..., 0x00, auth_list, sig)
+        // We need to locate the 0x00 placeholder byte and change it to 0x80 so
+        // that rlp_decode_fields treats it as None.  The placeholder is always
+        // a single 0x00 byte (see encode_for_signing) right after the fee_token
+        // field. Rather than parsing every field to find it, we scan for the
+        // unique pattern: since 0x00 only appears as the fee_payer_signature
+        // placeholder (all other fields use 0x80 for empty optionals), we can
+        // create a mutable copy and patch it.
+        let mut patched = tx_bytes.to_vec();
+
+        // Skip type byte (0x76) for Tempo transactions
+        let data_start = if !patched.is_empty() && patched[0] == 0x76 {
+            1
+        } else {
+            0
+        };
+
+        // Parse the outer RLP list header to find where fields start
+        let rlp_data = &patched[data_start..];
+        let (header_len, _payload_len) = if !rlp_data.is_empty() {
+            let first = rlp_data[0];
+            if first <= 0xf7 {
+                (1usize, (first - 0xc0) as usize)
+            } else {
+                let ll = (first - 0xf7) as usize;
+                let mut buf = [0u8; 8];
+                if ll < rlp_data.len() {
+                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
+                }
+                (1 + ll, usize::from_be_bytes(buf))
+            }
+        } else {
+            return Err(VerificationError::new(
+                "Empty transaction bytes".to_string(),
+            ));
+        };
+
+        // Scan inside the payload for a bare 0x00 byte that is the
+        // fee_payer_signature placeholder.  The fields before it
+        // (fee_token) are encoded as either 0x80 (None) or an address.
+        // The placeholder 0x00 is distinguishable because:
+        //   - It follows the fee_token field (0x80 or 0x94 <20 bytes>)
+        //   - A bare 0x00 is not valid at any other position in the
+        //     fee_payer_signature slot (a real sig would start with a
+        //     list header >= 0xc0)
+        let payload_start = data_start + header_len;
+        let payload_end = patched.len();
+
+        // Walk through the RLP items to find the fee_payer_signature slot.
+        // Field order: chain_id, max_priority_fee, max_fee, gas_limit, calls,
+        //   access_list, nonce_key, nonce, valid_before, valid_after,
+        //   fee_token, fee_payer_signature, auth_list, [key_auth], [user_sig]
+        let mut pos = payload_start;
+        let mut field_idx = 0;
+        const FEE_PAYER_SIG_IDX: usize = 11; // 0-indexed
+
+        while pos < payload_end && field_idx < FEE_PAYER_SIG_IDX {
+            let item_len = Self::rlp_item_total_len(&patched[pos..]).ok_or_else(|| {
+                VerificationError::new(format!(
+                    "Failed to parse RLP at field {} offset {}",
+                    field_idx, pos
+                ))
+            })?;
+            pos += item_len;
+            field_idx += 1;
+        }
+
+        // pos should now point to the fee_payer_signature field
+        if pos < payload_end && patched[pos] == 0x00 {
+            patched[pos] = 0x80; // patch placeholder → None
+        }
+
+        // Now decode using standard AASigned::rlp_decode
+        let decode_data = &patched[data_start..];
+        let signed =
+            tempo_primitives::AASigned::rlp_decode(&mut &decode_data[..]).map_err(|e| {
+                VerificationError::new(format!("Failed to decode fee-payer transaction: {}", e))
+            })?;
+
+        let (mut tx, sig, _) = signed.into_parts();
+
+        // Restore the fee_payer_signature as a placeholder
+        tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
+            U256::ZERO,
+            U256::ZERO,
+            false,
+        ));
+
+        Ok((tx, sig))
+    }
+
+    /// Get the total byte length of an RLP item (header + payload).
+    fn rlp_item_total_len(data: &[u8]) -> Option<usize> {
+        if data.is_empty() {
+            return None;
+        }
+        let first = data[0];
+        match first {
+            // Single byte (0x00..=0x7f)
+            0x00..=0x7f => Some(1),
+            // Short string (0x80..=0xb7): length = first - 0x80
+            0x80..=0xb7 => {
+                let len = (first - 0x80) as usize;
+                Some(1 + len)
+            }
+            // Long string (0xb8..=0xbf): next (first - 0xb7) bytes are the length
+            0xb8..=0xbf => {
+                let ll = (first - 0xb7) as usize;
+                if data.len() < 1 + ll {
+                    return None;
+                }
+                let mut buf = [0u8; 8];
+                buf[8 - ll..].copy_from_slice(&data[1..1 + ll]);
+                let len = usize::from_be_bytes(buf);
+                Some(1 + ll + len)
+            }
+            // Short list (0xc0..=0xf7): length = first - 0xc0
+            0xc0..=0xf7 => {
+                let len = (first - 0xc0) as usize;
+                Some(1 + len)
+            }
+            // Long list (0xf8..=0xff): next (first - 0xf7) bytes are the length
+            0xf8..=0xff => {
+                let ll = (first - 0xf7) as usize;
+                if data.len() < 1 + ll {
+                    return None;
+                }
+                let mut buf = [0u8; 8];
+                buf[8 - ll..].copy_from_slice(&data[1..1 + ll]);
+                let len = usize::from_be_bytes(buf);
+                Some(1 + ll + len)
+            }
+        }
+    }
+
     async fn broadcast_transaction(
         &self,
         signed_tx: &str,
         charge: &ChargeRequest,
         expected_chain_id: u64,
     ) -> Result<B256, VerificationError> {
-        let tx_bytes = signed_tx
+        let raw_bytes = signed_tx
             .parse::<Bytes>()
             .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {}", e)))?;
 
-        // Pre-broadcast validation: verify transaction contains expected payment call
+        // Strip viem fee-payer suffix before any processing so that
+        // validate_transaction and RLP decoding see canonical bytes.
+        let (tx_bytes, fee_payer_sender) = Self::strip_fee_payer_suffix(&raw_bytes);
+
+        // Pre-broadcast validation: verify transaction contains expected payment call.
+        // For fee-payer transactions, decode via the custom fee-payer format first,
+        // then re-encode to canonical bytes for validate_transaction.
         let expected_recipient = charge.recipient_address().map_err(|e| {
             VerificationError::new(format!("Invalid recipient address in request: {}", e))
         })?;
@@ -511,15 +689,6 @@ where
         })?;
         let memo = charge.memo();
 
-        self.validate_transaction(
-            &tx_bytes,
-            currency,
-            expected_recipient,
-            expected_amount,
-            memo.as_deref(),
-            expected_chain_id,
-        )?;
-
         // Fail fast if fee payer is requested but no signer is configured.
         if charge.fee_payer() && self.fee_payer_signer.is_none() {
             return Err(VerificationError::new(
@@ -528,9 +697,64 @@ where
             ));
         }
 
+        // Build the final transaction bytes to broadcast.
+        let broadcast_bytes: Bytes = if charge.fee_payer() {
+            let fee_payer_signer = self.fee_payer_signer.as_ref().unwrap();
+
+            let sender = fee_payer_sender.ok_or_else(|| {
+                VerificationError::new(
+                    "feePayer requested but transaction is missing the sender address suffix"
+                        .to_string(),
+                )
+            })?;
+
+            // Decode the fee-payer wire format (handles 0x00 placeholder byte).
+            let (mut tx, user_sig) = Self::decode_fee_payer_tx(tx_bytes)?;
+
+            // Validate the payment call before signing.
+            // Re-encode as canonical bytes for validate_transaction.
+            let canonical_signed = tx.clone().into_signed(user_sig.clone());
+            let mut canonical_buf = Vec::new();
+            canonical_signed.eip2718_encode(&mut canonical_buf);
+
+            self.validate_transaction(
+                &canonical_buf,
+                currency,
+                expected_recipient,
+                expected_amount,
+                memo.as_deref(),
+                expected_chain_id,
+            )?;
+
+            // Sign with the fee payer key.
+            use alloy::signers::SignerSync;
+            let fee_hash = tx.fee_payer_signature_hash(sender);
+            let fee_sig = fee_payer_signer
+                .sign_hash_sync(&fee_hash)
+                .map_err(|e| VerificationError::new(format!("Fee payer signing failed: {}", e)))?;
+            tx.fee_payer_signature = Some(fee_sig);
+
+            // Re-encode as canonical 2718 bytes (type 0x76 + RLP).
+            let fully_signed = tx.into_signed(user_sig);
+            let mut buf = Vec::new();
+            fully_signed.eip2718_encode(&mut buf);
+            Bytes::from(buf)
+        } else {
+            // Non-fee-payer path: validate and broadcast directly.
+            self.validate_transaction(
+                tx_bytes,
+                currency,
+                expected_recipient,
+                expected_amount,
+                memo.as_deref(),
+                expected_chain_id,
+            )?;
+            Bytes::copy_from_slice(tx_bytes)
+        };
+
         let pending = self
             .provider
-            .send_raw_transaction(&tx_bytes)
+            .send_raw_transaction(&broadcast_bytes)
             .await
             .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
 
@@ -801,5 +1025,327 @@ mod tests {
         assert!(error
             .to_string()
             .contains("fee sponsorship is not configured"));
+    }
+
+    /// Helper: build a signed Tempo transaction with optional fee-payer
+    /// placeholder and optional feefeefeefee suffix, returning hex bytes.
+    fn build_test_tx(
+        signer: &alloy_signer_local::PrivateKeySigner,
+        chain_id: u64,
+        currency: Address,
+        recipient: Address,
+        amount: U256,
+        memo: B256,
+        fee_payer: bool,
+    ) -> (Vec<u8>, tempo_primitives::TempoTransaction) {
+        use alloy::primitives::TxKind;
+        use alloy::signers::SignerSync;
+        use alloy::sol_types::SolCall;
+        use tempo_alloy::contracts::precompiles::tip20::ITIP20;
+        use tempo_primitives::transaction::Call;
+        use tempo_primitives::TempoTransaction;
+
+        let transfer_data =
+            ITIP20::transferWithMemoCall::new((recipient, amount, memo)).abi_encode();
+
+        let fee_payer_signature = if fee_payer {
+            Some(alloy::primitives::Signature::new(
+                U256::ZERO,
+                U256::ZERO,
+                false,
+            ))
+        } else {
+            None
+        };
+
+        let tx = TempoTransaction {
+            chain_id,
+            nonce: 0,
+            gas_limit: 1_000_000,
+            max_fee_per_gas: 100,
+            max_priority_fee_per_gas: 100,
+            calls: vec![Call {
+                to: TxKind::Call(currency),
+                value: U256::ZERO,
+                input: alloy::primitives::Bytes::from(transfer_data),
+            }],
+            fee_payer_signature,
+            ..Default::default()
+        };
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+
+        if fee_payer {
+            // Produce viem-convention bytes:
+            // 0x76 || rlp([fields..., 0x00, auth_list, user_sig]) || sender || feefeefeefee
+            use alloy::consensus::SignableTransaction;
+
+            let mut signing_buf = Vec::new();
+            tx.encode_for_signing(&mut signing_buf);
+
+            let rlp_data = &signing_buf[1..]; // skip 0x76
+            let (header_len, fields_len) = {
+                let first = rlp_data[0];
+                if first <= 0xf7 {
+                    (1, (first - 0xc0) as usize)
+                } else {
+                    let ll = (first - 0xf7) as usize;
+                    let mut buf = [0u8; 8];
+                    buf[8 - ll..].copy_from_slice(&rlp_data[1..1 + ll]);
+                    (1 + ll, usize::from_be_bytes(buf))
+                }
+            };
+            let fields_payload = &rlp_data[header_len..header_len + fields_len];
+
+            let mut sig_bytes = [0u8; 65];
+            sig_bytes[..32].copy_from_slice(&signature.r().to_be_bytes::<32>());
+            sig_bytes[32..64].copy_from_slice(&signature.s().to_be_bytes::<32>());
+            sig_bytes[64] = signature.v() as u8;
+
+            let sig_rlp_len = 2 + 65;
+            let new_payload_len = fields_payload.len() + sig_rlp_len;
+
+            let mut out = Vec::with_capacity(1 + 4 + new_payload_len + 26);
+            out.push(0x76);
+            if new_payload_len <= 55 {
+                out.push(0xc0 + new_payload_len as u8);
+            } else {
+                let len_bytes = new_payload_len.to_be_bytes();
+                let start = len_bytes.iter().position(|&b| b != 0).unwrap_or(7);
+                let num_len_bytes = 8 - start;
+                out.push(0xf7 + num_len_bytes as u8);
+                out.extend_from_slice(&len_bytes[start..]);
+            }
+            out.extend_from_slice(fields_payload);
+            out.push(0xb8);
+            out.push(65);
+            out.extend_from_slice(&sig_bytes);
+
+            // Append sender + fee marker
+            out.extend_from_slice(signer.address().as_slice());
+            out.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+
+            (out, tx)
+        } else {
+            use alloy::eips::Encodable2718;
+            let signed_tx = tx.clone().into_signed(signature.into());
+            (signed_tx.encoded_2718(), tx)
+        }
+    }
+
+    // ---- Fee-payer suffix stripping tests ----
+
+    type TestChargeMethod = ChargeMethod<
+        alloy::providers::fillers::FillProvider<
+            alloy::providers::Identity,
+            alloy::providers::RootProvider<TempoNetwork>,
+            TempoNetwork,
+        >,
+    >;
+
+    #[test]
+    fn test_strip_fee_payer_suffix_present() {
+        let mut data = vec![0x76, 0xaa, 0xbb]; // fake tx bytes
+        let sender: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        data.extend_from_slice(sender.as_slice());
+        data.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+
+        let (stripped, extracted_sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
+        assert_eq!(stripped, &[0x76, 0xaa, 0xbb]);
+        assert_eq!(extracted_sender, Some(sender));
+    }
+
+    #[test]
+    fn test_strip_fee_payer_suffix_absent() {
+        let data = vec![0x76, 0xaa, 0xbb, 0xcc];
+        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
+        assert_eq!(stripped, &data[..]);
+        assert_eq!(sender, None);
+    }
+
+    #[test]
+    fn test_strip_fee_payer_suffix_too_short() {
+        // Exactly 26 bytes (suffix length) should not match because there'd be
+        // zero canonical bytes.
+        let mut data = vec![0u8; 20]; // "sender"
+        data.extend_from_slice(&[0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee]);
+        assert_eq!(data.len(), 26);
+
+        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&data);
+        assert_eq!(stripped.len(), data.len()); // unchanged
+        assert_eq!(sender, None);
+    }
+
+    // ---- Fee-payer round-trip signing test ----
+
+    #[test]
+    fn test_fee_payer_round_trip_signing() {
+        // Verify that a fee-payer-suffixed tx can be stripped, decoded via
+        // decode_fee_payer_tx, fee-payer-signed, re-encoded, and the fee
+        // payer recovered.
+        use alloy::signers::SignerSync;
+
+        let user_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+
+        let currency: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000u64);
+        let memo = B256::ZERO;
+
+        let (raw_bytes, _original_tx) = build_test_tx(
+            &user_signer,
+            MODERATO_CHAIN_ID,
+            currency,
+            recipient,
+            amount,
+            memo,
+            true, // fee_payer = true
+        );
+
+        // Step 1: Strip suffix
+        let (tx_bytes, sender_opt) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
+        let sender = sender_opt.expect("sender should be present");
+        assert_eq!(sender, user_signer.address());
+
+        // Step 2: Decode the fee-payer wire format
+        let (mut tx, user_sig) =
+            TestChargeMethod::decode_fee_payer_tx(tx_bytes).expect("should decode fee-payer tx");
+
+        // The placeholder should be present
+        assert!(tx.fee_payer_signature.is_some(), "placeholder should exist");
+        let placeholder = tx.fee_payer_signature.as_ref().unwrap();
+        assert!(placeholder.r().is_zero() && placeholder.s().is_zero());
+
+        // Step 3: Fee payer signs
+        let fee_hash = tx.fee_payer_signature_hash(sender);
+        let fee_sig = fee_payer_signer.sign_hash_sync(&fee_hash).unwrap();
+        tx.fee_payer_signature = Some(fee_sig);
+
+        // Step 4: Re-encode
+        let fully_signed = tx.clone().into_signed(user_sig);
+        let mut buf = Vec::new();
+        fully_signed.eip2718_encode(&mut buf);
+
+        // Step 5: Verify the fee payer can be recovered
+        let recovered = tx
+            .recover_fee_payer(sender)
+            .expect("fee payer recovery should succeed");
+        assert_eq!(
+            recovered,
+            fee_payer_signer.address(),
+            "recovered fee payer should match"
+        );
+    }
+
+    #[test]
+    fn test_decode_fee_payer_tx_validates_payment() {
+        // Ensure decode_fee_payer_tx + re-encode produces bytes that
+        // validate_transaction can parse and verify the payment call.
+        use alloy::providers::ProviderBuilder;
+
+        let user_signer = alloy_signer_local::PrivateKeySigner::random();
+        let currency: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000u64);
+        let memo = B256::ZERO;
+
+        let (raw_bytes, _tx) = build_test_tx(
+            &user_signer,
+            MODERATO_CHAIN_ID,
+            currency,
+            recipient,
+            amount,
+            memo,
+            true,
+        );
+
+        // Strip and decode the fee-payer format
+        let (tx_bytes, _sender) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
+        let (tx, user_sig) =
+            TestChargeMethod::decode_fee_payer_tx(tx_bytes).expect("should decode");
+
+        // Re-encode as canonical bytes
+        let canonical_signed = tx.into_signed(user_sig);
+        let mut canonical_buf = Vec::new();
+        canonical_signed.eip2718_encode(&mut canonical_buf);
+
+        // validate_transaction should succeed on canonical bytes
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("https://rpc.moderato.tempo.xyz".parse().unwrap());
+        let method = ChargeMethod::new(provider);
+        let result = method.validate_transaction(
+            &canonical_buf,
+            currency,
+            recipient,
+            amount,
+            Some(&format!("{:#x}", memo)),
+            MODERATO_CHAIN_ID,
+        );
+        assert!(
+            result.is_ok(),
+            "should validate after decode + re-encode: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_non_fee_payer_tx_unaffected() {
+        // A normal (non-fee-payer) tx should pass through without changes.
+        use alloy::providers::ProviderBuilder;
+
+        let user_signer = alloy_signer_local::PrivateKeySigner::random();
+        let currency: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let recipient: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f3bB77"
+            .parse()
+            .unwrap();
+        let amount = U256::from(1_000_000u64);
+        let memo = B256::ZERO;
+
+        let (raw_bytes, _tx) = build_test_tx(
+            &user_signer,
+            MODERATO_CHAIN_ID,
+            currency,
+            recipient,
+            amount,
+            memo,
+            false, // no fee payer
+        );
+
+        // No suffix should be detected
+        let (stripped, sender) = TestChargeMethod::strip_fee_payer_suffix(&raw_bytes);
+        assert_eq!(stripped.len(), raw_bytes.len());
+        assert!(sender.is_none());
+
+        // validate_transaction should work directly
+        let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_http("https://rpc.moderato.tempo.xyz".parse().unwrap());
+        let method = ChargeMethod::new(provider);
+        let result = method.validate_transaction(
+            &raw_bytes,
+            currency,
+            recipient,
+            amount,
+            Some(&format!("{:#x}", memo)),
+            MODERATO_CHAIN_ID,
+        );
+        assert!(
+            result.is_ok(),
+            "non-fee-payer tx should validate: {:?}",
+            result.err()
+        );
     }
 }

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -150,6 +150,10 @@ pub const INTENT_CHARGE: &str = "charge";
 /// Session intent name.
 pub const INTENT_SESSION: &str = "session";
 
+/// Fee-payer suffix marker used by viem-based clients to pass the sender
+/// address alongside fee-payer transactions.
+pub const FEE_PAYER_MARKER: [u8; 6] = [0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee];
+
 /// Create a Tempo charge challenge with minimal parameters.
 ///
 /// This is the simplest way to create a payment challenge for the Tempo network.

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -150,10 +150,6 @@ pub const INTENT_CHARGE: &str = "charge";
 /// Session intent name.
 pub const INTENT_SESSION: &str = "session";
 
-/// Fee-payer suffix marker used by viem-based clients to pass the sender
-/// address alongside fee-payer transactions.
-pub const FEE_PAYER_MARKER: [u8; 6] = [0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee];
-
 /// Create a Tempo charge challenge with minimal parameters.
 ///
 /// This is the simplest way to create a payment challenge for the Tempo network.

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -781,7 +781,8 @@ async fn test_fee_payer_sponsorship_charges_fee_payer() {
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
 
     let client_before = tip20_balance(&provider_http, client_signer.address()).await;
-    let fee_payer_before = tip20_balance(&provider_http, server_signer.address()).await;
+    let fee_payer_address = server_signer.address();
+    let fee_payer_before = tip20_balance(&provider_http, fee_payer_address).await;
 
     let mpp = Mpp::create(
         tempo(TempoConfig {
@@ -790,7 +791,7 @@ async fn test_fee_payer_sponsorship_charges_fee_payer() {
         .rpc_url(&rpc)
         .chain_id(chain_id)
         .fee_payer(true)
-        .fee_payer_signer(server_signer)
+        .fee_payer_signer(server_signer.clone())
         .secret_key("fee-payer-balance-test"),
     )
     .expect("failed to create Mpp");
@@ -807,7 +808,7 @@ async fn test_fee_payer_sponsorship_charges_fee_payer() {
     assert_eq!(resp.status(), 200);
 
     let client_after = tip20_balance(&provider_http, client_signer.address()).await;
-    let fee_payer_after = tip20_balance(&provider_http, server_signer.address()).await;
+    let fee_payer_after = tip20_balance(&provider_http, fee_payer_address).await;
 
     let charge_amount = U256::from(10_000u64);
     assert_eq!(client_before - client_after, charge_amount);
@@ -866,7 +867,7 @@ async fn test_non_fee_payer_pays_gas() {
     let charge_amount = U256::from(10_000u64);
     let delta = client_before - client_after;
 
-    if gas_price > U256::ZERO {
+    if gas_price > 0 {
         assert!(
             delta > charge_amount,
             "client should pay gas without sponsorship"

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -203,6 +203,23 @@ async fn fund_account(rpc: &str, to: Address) {
     .await;
 }
 
+/// Read a TIP-20 balance for PATH_USD.
+async fn tip20_balance<P: Provider<TempoNetwork>>(provider: &P, address: Address) -> U256 {
+    let balance_call = ITIP20::balanceOfCall::new((address,)).abi_encode();
+    let result = provider
+        .call(
+            alloy::rpc::types::TransactionRequest::default()
+                .to(PATH_USD)
+                .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
+                    balance_call,
+                )))
+                .into(),
+        )
+        .await
+        .expect("balanceOf call failed");
+    U256::from_be_slice(&result)
+}
+
 // ==================== ChargeConfig types ====================
 
 struct OneCent;
@@ -707,21 +724,7 @@ async fn test_client_balance_decreases_after_payment() {
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
 
     // Check balance before payment.
-    let balance_call = ITIP20::balanceOfCall::new((client_signer.address(),)).abi_encode();
-    let balance_before: U256 = {
-        let result = provider_http
-            .call(
-                alloy::rpc::types::TransactionRequest::default()
-                    .to(PATH_USD)
-                    .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
-                        balance_call.clone(),
-                    )))
-                    .into(),
-            )
-            .await
-            .expect("balanceOf call failed");
-        U256::from_be_slice(&result)
-    };
+    let balance_before = tip20_balance(&provider_http, client_signer.address()).await;
 
     let mpp = Mpp::create(
         tempo(TempoConfig {
@@ -748,20 +751,7 @@ async fn test_client_balance_decreases_after_payment() {
     assert_eq!(resp.status(), 200);
 
     // Check balance after payment.
-    let balance_after: U256 = {
-        let result = provider_http
-            .call(
-                alloy::rpc::types::TransactionRequest::default()
-                    .to(PATH_USD)
-                    .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
-                        balance_call,
-                    )))
-                    .into(),
-            )
-            .await
-            .expect("balanceOf call failed");
-        U256::from_be_slice(&result)
-    };
+    let balance_after = tip20_balance(&provider_http, client_signer.address()).await;
 
     let charge_amount = U256::from(10_000u64); // $0.01 with 6 decimals
     let actual_decrease = balance_before - balance_after;
@@ -769,6 +759,121 @@ async fn test_client_balance_decreases_after_payment() {
         actual_decrease >= charge_amount,
         "client balance should decrease by at least the charge amount ({charge_amount}), but decreased by {actual_decrease}"
     );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Fee payer sponsorship should charge the fee payer for gas while the client
+/// only transfers the payment amount.
+#[tokio::test]
+async fn test_fee_payer_sponsorship_charges_fee_payer() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+
+    let client_before = tip20_balance(&provider_http, client_signer.address()).await;
+    let fee_payer_before = tip20_balance(&provider_http, server_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer)
+        .secret_key("fee-payer-balance-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider =
+        TempoProvider::new(client_signer.clone(), &rpc).expect("failed to create TempoProvider");
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("payment failed");
+    assert_eq!(resp.status(), 200);
+
+    let client_after = tip20_balance(&provider_http, client_signer.address()).await;
+    let fee_payer_after = tip20_balance(&provider_http, server_signer.address()).await;
+
+    let charge_amount = U256::from(10_000u64);
+    assert_eq!(client_before - client_after, charge_amount);
+    assert!(
+        fee_payer_after < fee_payer_before,
+        "fee payer balance should decrease to cover gas"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Without sponsorship, the client should pay the charge amount plus gas.
+#[tokio::test]
+async fn test_non_fee_payer_pays_gas() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+
+    let client_before = tip20_balance(&provider_http, client_signer.address()).await;
+    let gas_price = provider_http
+        .get_gas_price()
+        .await
+        .expect("failed to get gas price");
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("non-fee-payer-balance-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider =
+        TempoProvider::new(client_signer.clone(), &rpc).expect("failed to create TempoProvider");
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("payment failed");
+    assert_eq!(resp.status(), 200);
+
+    let client_after = tip20_balance(&provider_http, client_signer.address()).await;
+    let charge_amount = U256::from(10_000u64);
+    let delta = client_before - client_after;
+
+    if gas_price > U256::ZERO {
+        assert!(
+            delta > charge_amount,
+            "client should pay gas without sponsorship"
+        );
+    } else {
+        assert_eq!(delta, charge_amount);
+    }
 
     handle.abort();
     let _ = handle.await;


### PR DESCRIPTION
## Summary
- implement fee-payer proxy encoding on the Rust client (charge + session open), including placeholder signature + sender/suffix format
- build Tempo transactions via TempoTransactionRequest::build_aa for consistent field construction
- add fee-payer encoding unit tests and integration coverage for fee-payer vs non-fee-payer balance effects

## Details
- client fee-payer proxy encoder lives in src/client/fee_payer.rs and is used by charge + session paths
- session open path now emits fee-payer proxy wire format when feePayer is true
- integration tests assert sponsor pays gas while client only pays the charge amount, and non-fee-payer clients pay charge + gas

## Testing
- cargo test --features tempo
- TEMPO_RPC_URL=http://localhost:8545 cargo test --features integration --test integration_charge