### PR TITLE
test: strengthen cross-SDK smoke test with 402 assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features -- -D warnings
       - name: Run Tempo Lints
@@ -39,6 +40,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo update -p native-tls
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo test --features tempo,server,client,axum,middleware,tower,utils
       - run: cargo hack check --each-feature --no-dev-deps --skip integration
@@ -51,6 +53,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo update -p native-tls
 
       - name: Start Tempo node
         run: docker compose up -d

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -103,8 +103,20 @@ jobs:
           echo "basic-server failed to start"
           exit 1
 
+      - name: Assert /api/ping returns 402 without payment
+        run: |
+          status=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/ping)
+          if [ "$status" != "402" ]; then
+            echo "Expected 402 but got $status"
+            exit 1
+          fi
+          echo "Confirmed: /api/ping returns 402 without payment credentials"
+
       - name: Smoke test — mppx pays /api/ping
-        run: mppx http://localhost:3000/api/ping --rpc-url http://localhost:8545 --silent --fail
+        run: |
+          response=$(mppx http://localhost:3000/api/ping --rpc-url http://localhost:8545 --silent --fail)
+          echo "$response"
+          echo "$response" | grep -q '"pong"' || { echo "Response missing pong field"; exit 1; }
         env:
           MPPX_PRIVATE_KEY: "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d" # well-known Hardhat dev account[1]
 

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo update -p native-tls
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -45,7 +45,7 @@ const DEFAULT_REALM: &str = "MPP Payment";
 ///
 /// Checks platform-specific env vars in order (see [`REALM_ENV_VARS`]),
 /// falling back to `"MPP Payment"`.
-fn detect_realm() -> String {
+pub(crate) fn detect_realm() -> String {
     for name in REALM_ENV_VARS {
         if let Ok(value) = std::env::var(name) {
             if !value.is_empty() {


### PR DESCRIPTION
Adds two assertions to the cross-SDK smoke test:

1. **Negative test**: Confirms `/api/ping` returns 402 without payment credentials (curl without Authorization header). This ensures the endpoint is actually gated.

2. **Response body validation**: Checks that the mppx response contains the `pong` field, confirming the server returned the expected payload after successful payment.

The existing mppx `--fail` flag already exits 22 on HTTP errors and the CLI exits 1 on payment rejection, so the payment flow itself was already validated. These additions make the assertions explicit and guard against regressions where the endpoint might accidentally become free.