### PR TITLE
Encode fee payer envelope for tempo clients

### DIFF
--- a/.changelog/kind-waves-walk.md
+++ b/.changelog/kind-waves-walk.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added fee-payer envelope encoding support for Tempo clients. Introduced a new `fee_payer` module with helpers to build placeholder fee-payer signatures and encode fee-payer proxy transactions (prefixed with magic byte `0x78`). Updated `TempoProvider::pay` to use `TempoTransactionRequest` for transaction building and conditionally encode the fee-payer envelope when fee sponsorship is enabled.

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -1,25 +1,20 @@
 //! Fee-payer transaction encoding helpers.
 
-/// Build a placeholder fee payer signature when fee sponsorship is enabled.
-#[cfg(feature = "tempo")]
-pub(crate) fn fee_payer_placeholder(enabled: bool) -> Option<alloy::primitives::Signature> {
-    if enabled {
-        Some(alloy::primitives::Signature::new(
-            alloy::primitives::U256::ZERO,
-            alloy::primitives::U256::ZERO,
-            false,
-        ))
-    } else {
-        None
-    }
-}
-
 /// Encode a fee-payer envelope for the server to co-sign and broadcast.
 ///
 /// Returns bytes prefixed with the fee payer magic byte (0x78). The
 /// payload mirrors the sender signing envelope but substitutes the
 /// sender address in the fee payer slot so the server can recover the
 /// sender and sign the fee payer hash.
+///
+/// NOTE: This duplicates the RLP field layout from
+/// `TempoTransaction::fee_payer_signature_hash` in `tempo_primitives`,
+/// because that method only returns a `B256` hash — it does not expose
+/// the raw pre-image bytes. We need the full wire envelope (pre-image +
+/// user signature) so the server can decode and co-sign.
+/// The `test_fee_payer_envelope_hash_matches_canonical` test guards
+/// against field-order drift between this function and the canonical
+/// implementation.
 #[cfg(feature = "tempo")]
 pub(crate) fn encode_fee_payer_proxy_tx(
     tx: &tempo_primitives::TempoTransaction,
@@ -82,12 +77,20 @@ pub(crate) fn encode_fee_payer_proxy_tx(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::eips::Encodable2718;
     use alloy::primitives::{Address, Bytes, TxKind, U256};
     use alloy::signers::SignerSync;
     use tempo_alloy::rpc::TempoTransactionRequest;
     use tempo_primitives::transaction::Call;
 
     fn build_test_tx(fee_payer: bool) -> tempo_primitives::TempoTransaction {
+        build_test_tx_with_fee_token(fee_payer, None)
+    }
+
+    fn build_test_tx_with_fee_token(
+        fee_payer: bool,
+        fee_token: Option<Address>,
+    ) -> tempo_primitives::TempoTransaction {
         let mut request = TempoTransactionRequest::default();
         request.inner.chain_id = Some(4217);
         request.inner.nonce = Some(0);
@@ -105,6 +108,7 @@ mod tests {
         }];
         request.fee_payer_signature =
             fee_payer.then(|| alloy::primitives::Signature::new(U256::ZERO, U256::ZERO, false));
+        request.fee_token = fee_token;
 
         request
             .build_aa()
@@ -122,6 +126,89 @@ mod tests {
 
         assert_eq!(wire[0], 0x78, "must start with fee payer envelope byte");
         assert!(wire.len() > 10, "envelope bytes must not be empty");
+    }
+
+    #[test]
+    fn test_fee_payer_envelope_hash_matches_canonical() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let tx = build_test_tx(true);
+        let canonical_hash = tx.fee_payer_signature_hash(signer.address());
+
+        // Rebuild the pre-image using the same field layout as
+        // encode_fee_payer_proxy_tx (but without the trailing user sig)
+        // and verify it hashes to the canonical fee_payer_signature_hash.
+        use alloy::rlp::{BufMut, Encodable, Header, EMPTY_STRING_CODE};
+        let mut payload = Vec::new();
+        tx.chain_id.encode(&mut payload);
+        tx.max_priority_fee_per_gas.encode(&mut payload);
+        tx.max_fee_per_gas.encode(&mut payload);
+        tx.gas_limit.encode(&mut payload);
+        tx.calls.encode(&mut payload);
+        tx.access_list.encode(&mut payload);
+        tx.nonce_key.encode(&mut payload);
+        tx.nonce.encode(&mut payload);
+        if let Some(v) = tx.valid_before { v.encode(&mut payload); } else { payload.put_u8(EMPTY_STRING_CODE); }
+        if let Some(v) = tx.valid_after { v.encode(&mut payload); } else { payload.put_u8(EMPTY_STRING_CODE); }
+        if let Some(v) = tx.fee_token { v.encode(&mut payload); } else { payload.put_u8(EMPTY_STRING_CODE); }
+        signer.address().encode(&mut payload);
+        tx.tempo_authorization_list.encode(&mut payload);
+        if let Some(ref k) = tx.key_authorization { k.encode(&mut payload); }
+
+        let header = Header { list: true, payload_length: payload.len() };
+        let mut preimage = Vec::with_capacity(1 + header.length_with_payload());
+        preimage.put_u8(0x78);
+        header.encode(&mut preimage);
+        preimage.extend_from_slice(&payload);
+
+        let our_hash = alloy::primitives::keccak256(&preimage);
+        assert_eq!(
+            our_hash, canonical_hash,
+            "fee payer envelope pre-image must hash to the same value as \
+             TempoTransaction::fee_payer_signature_hash"
+        );
+    }
+
+    #[test]
+    fn test_fee_payer_envelope_with_fee_token() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let tx = build_test_tx_with_fee_token(true, Some(fee_token));
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+
+        assert_eq!(wire[0], 0x78);
+
+        // Different fee tokens must produce different envelopes (fee payer
+        // commits to the fee token).
+        let tx_no_token = build_test_tx_with_fee_token(true, None);
+        let sig_hash2 = tx_no_token.signature_hash();
+        let signature2 = signer.sign_hash_sync(&sig_hash2).unwrap();
+        let wire2 = encode_fee_payer_proxy_tx(&tx_no_token, &signature2, signer.address());
+
+        assert_ne!(wire, wire2, "fee token must affect the envelope encoding");
+    }
+
+    #[test]
+    fn test_fee_token_changes_canonical_hash() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+
+        let tx_with = build_test_tx_with_fee_token(true, Some(fee_token));
+        let tx_without = build_test_tx_with_fee_token(true, None);
+
+        let hash_with = tx_with.fee_payer_signature_hash(signer.address());
+        let hash_without = tx_without.fee_payer_signature_hash(signer.address());
+
+        assert_ne!(
+            hash_with, hash_without,
+            "fee payer must commit to fee_token — different tokens must produce different hashes"
+        );
     }
 
     #[test]

--- a/src/client/fee_payer.rs
+++ b/src/client/fee_payer.rs
@@ -1,0 +1,140 @@
+//! Fee-payer transaction encoding helpers.
+
+/// Build a placeholder fee payer signature when fee sponsorship is enabled.
+#[cfg(feature = "tempo")]
+pub(crate) fn fee_payer_placeholder(enabled: bool) -> Option<alloy::primitives::Signature> {
+    if enabled {
+        Some(alloy::primitives::Signature::new(
+            alloy::primitives::U256::ZERO,
+            alloy::primitives::U256::ZERO,
+            false,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Encode a fee-payer envelope for the server to co-sign and broadcast.
+///
+/// Returns bytes prefixed with the fee payer magic byte (0x78). The
+/// payload mirrors the sender signing envelope but substitutes the
+/// sender address in the fee payer slot so the server can recover the
+/// sender and sign the fee payer hash.
+#[cfg(feature = "tempo")]
+pub(crate) fn encode_fee_payer_proxy_tx(
+    tx: &tempo_primitives::TempoTransaction,
+    user_sig: &alloy::primitives::Signature,
+    sender: alloy::primitives::Address,
+) -> Vec<u8> {
+    use alloy::rlp::{BufMut, Encodable, Header, EMPTY_STRING_CODE};
+
+    const FEE_PAYER_SIGNATURE_MAGIC_BYTE: u8 = 0x78;
+
+    let tempo_sig: tempo_primitives::TempoSignature = (*user_sig).into();
+
+    let mut payload = Vec::new();
+    tx.chain_id.encode(&mut payload);
+    tx.max_priority_fee_per_gas.encode(&mut payload);
+    tx.max_fee_per_gas.encode(&mut payload);
+    tx.gas_limit.encode(&mut payload);
+    tx.calls.encode(&mut payload);
+    tx.access_list.encode(&mut payload);
+    tx.nonce_key.encode(&mut payload);
+    tx.nonce.encode(&mut payload);
+
+    if let Some(valid_before) = tx.valid_before {
+        valid_before.encode(&mut payload);
+    } else {
+        payload.put_u8(EMPTY_STRING_CODE);
+    }
+
+    if let Some(valid_after) = tx.valid_after {
+        valid_after.encode(&mut payload);
+    } else {
+        payload.put_u8(EMPTY_STRING_CODE);
+    }
+
+    if let Some(fee_token) = tx.fee_token {
+        fee_token.encode(&mut payload);
+    } else {
+        payload.put_u8(EMPTY_STRING_CODE);
+    }
+
+    sender.encode(&mut payload);
+    tx.tempo_authorization_list.encode(&mut payload);
+    if let Some(key_auth) = &tx.key_authorization {
+        key_auth.encode(&mut payload);
+    }
+    tempo_sig.encode(&mut payload);
+
+    let header = Header {
+        list: true,
+        payload_length: payload.len(),
+    };
+
+    let mut out = Vec::with_capacity(1 + header.length_with_payload());
+    out.put_u8(FEE_PAYER_SIGNATURE_MAGIC_BYTE);
+    header.encode(&mut out);
+    out.extend_from_slice(&payload);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Address, Bytes, TxKind, U256};
+    use alloy::signers::SignerSync;
+    use tempo_alloy::rpc::TempoTransactionRequest;
+    use tempo_primitives::transaction::Call;
+
+    fn build_test_tx(fee_payer: bool) -> tempo_primitives::TempoTransaction {
+        let mut request = TempoTransactionRequest::default();
+        request.inner.chain_id = Some(4217);
+        request.inner.nonce = Some(0);
+        request.inner.gas = Some(100_000);
+        request.inner.max_fee_per_gas = Some(1);
+        request.inner.max_priority_fee_per_gas = Some(1);
+        request.calls = vec![Call {
+            to: TxKind::Call(
+                "0x20c0000000000000000000000000000000000000"
+                    .parse::<Address>()
+                    .unwrap(),
+            ),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }];
+        request.fee_payer_signature =
+            fee_payer.then(|| alloy::primitives::Signature::new(U256::ZERO, U256::ZERO, false));
+
+        request
+            .build_aa()
+            .expect("failed to build test TempoTransaction")
+    }
+
+    #[test]
+    fn test_encode_fee_payer_proxy_tx_canonical_output() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let tx = build_test_tx(true);
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let wire = encode_fee_payer_proxy_tx(&tx, &signature, signer.address());
+
+        assert_eq!(wire[0], 0x78, "must start with fee payer envelope byte");
+        assert!(wire.len() > 10, "envelope bytes must not be empty");
+    }
+
+    #[test]
+    fn test_standard_encoding_has_no_fee_payer_suffix() {
+        let signer = alloy_signer_local::PrivateKeySigner::random();
+        let tx = build_test_tx(false);
+
+        let sig_hash = tx.signature_hash();
+        let signature = signer.sign_hash_sync(&sig_hash).unwrap();
+        let signed = tx.into_signed(signature.into());
+        let encoded = signed.encoded_2718();
+
+        assert!(encoded.len() > 6, "encoded tx must not be empty");
+        assert_eq!(encoded[0], 0x76, "must start with tempo tx type byte");
+    }
+}

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -21,6 +21,9 @@ mod error;
 mod provider;
 
 #[cfg(feature = "tempo")]
+mod fee_payer;
+
+#[cfg(feature = "tempo")]
 pub mod channel_ops;
 
 #[cfg(feature = "tempo")]

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -146,6 +146,7 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
@@ -154,12 +155,13 @@ impl PaymentProvider for TempoProvider {
         use alloy::providers::{Provider, ProviderBuilder};
         use alloy::sol_types::SolCall;
         use tempo_alloy::contracts::precompiles::tip20::ITIP20;
+        use tempo_alloy::rpc::TempoTransactionRequest;
         use tempo_alloy::TempoNetwork;
         use tempo_primitives::transaction::Call;
-        use tempo_primitives::TempoTransaction;
 
         let charge: ChargeRequest = challenge.request.decode()?;
         let expected_chain_id = charge.chain_id().unwrap_or(CHAIN_ID);
+        let is_fee_payer = charge.fee_payer();
         let address = self.signer.address();
 
         let provider =
@@ -203,20 +205,24 @@ impl PaymentProvider for TempoProvider {
             .await
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
-        // Build a Tempo transaction (type 0x76) for proper on-chain processing.
-        let tempo_tx = TempoTransaction {
-            chain_id: expected_chain_id,
-            nonce,
-            gas_limit: 1_000_000,
-            max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: gas_price,
-            calls: vec![Call {
-                to: TxKind::Call(currency),
-                value: alloy::primitives::U256::ZERO,
-                input: Bytes::from(transfer_data),
-            }],
-            ..Default::default()
-        };
+        let fee_payer_signature = fee_payer_placeholder(is_fee_payer);
+
+        let mut tempo_request = TempoTransactionRequest::default();
+        tempo_request.inner.chain_id = Some(expected_chain_id);
+        tempo_request.inner.nonce = Some(nonce);
+        tempo_request.inner.gas = Some(1_000_000);
+        tempo_request.inner.max_fee_per_gas = Some(gas_price);
+        tempo_request.inner.max_priority_fee_per_gas = Some(gas_price);
+        tempo_request.calls = vec![Call {
+            to: TxKind::Call(currency),
+            value: alloy::primitives::U256::ZERO,
+            input: Bytes::from(transfer_data),
+        }];
+        tempo_request.fee_payer_signature = fee_payer_signature;
+
+        let tempo_tx = tempo_request.build_aa().map_err(|e| {
+            MppError::InvalidConfig(format!("failed to build tempo transaction: {}", e))
+        })?;
 
         use alloy::signers::SignerSync;
         let sig_hash = tempo_tx.signature_hash();
@@ -225,8 +231,11 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let signed_tx = tempo_tx.into_signed(signature.into());
-        let tx_bytes = signed_tx.encoded_2718();
+        let tx_bytes = if is_fee_payer {
+            encode_fee_payer_proxy_tx(&tempo_tx, &signature, address)
+        } else {
+            tempo_tx.into_signed(signature.into()).encoded_2718()
+        };
         let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
         let echo = challenge.to_echo();

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -146,7 +146,7 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
-        use crate::client::fee_payer::{encode_fee_payer_proxy_tx, fee_payer_placeholder};
+        use crate::client::fee_payer::encode_fee_payer_proxy_tx;
         use crate::protocol::core::PaymentPayload;
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
@@ -205,8 +205,6 @@ impl PaymentProvider for TempoProvider {
             .await
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
-        let fee_payer_signature = fee_payer_placeholder(is_fee_payer);
-
         let mut tempo_request = TempoTransactionRequest::default();
         tempo_request.inner.chain_id = Some(expected_chain_id);
         tempo_request.inner.nonce = Some(nonce);
@@ -218,7 +216,13 @@ impl PaymentProvider for TempoProvider {
             value: alloy::primitives::U256::ZERO,
             input: Bytes::from(transfer_data),
         }];
-        tempo_request.fee_payer_signature = fee_payer_signature;
+        tempo_request.fee_payer_signature = is_fee_payer.then(||
+            alloy::primitives::Signature::new(
+                alloy::primitives::U256::ZERO,
+                alloy::primitives::U256::ZERO,
+                false,
+            )
+        );
 
         let tempo_tx = tempo_request.build_aa().map_err(|e| {
             MppError::InvalidConfig(format!("failed to build tempo transaction: {}", e))

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -773,3 +773,56 @@ async fn test_client_balance_decreases_after_payment() {
     handle.abort();
     let _ = handle.await;
 }
+
+/// E2E charge round-trip WITHOUT fee payer — the client broadcasts a
+/// standard 0x76 transaction directly. Ensures the non-fee-payer path
+/// through `TempoProvider::pay` works end-to-end.
+#[tokio::test]
+async fn test_e2e_charge_no_fee_payer() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("no-fee-payer-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("request with payment failed");
+
+    assert_eq!(resp.status(), 200, "expected 200 after successful payment");
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
+    assert_eq!(receipt.method.as_str(), "tempo");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "paid content");
+
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- emit a 0x78 fee payer envelope for fee-sponsored tempo transactions
- add fee payer placeholder helpers for tempo client requests
- route tempo client payment serialization through the new envelope path when feePayer is true

## Testing
- make build