### PR TITLE
feat: implement full fee payer support

### DIFF
--- a/.changelog/vain-clouds-crawl.md
+++ b/.changelog/vain-clouds-crawl.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added fee payer (0x78 envelope) support to the Tempo payment provider. The client now encodes fee payer transactions in the 0x78 format using expiring nonces, and the server co-signs them by recovering the sender, setting the fee token, and re-encoding as a standard 0x76 transaction with both signatures.

--- a/.changelog/vain-clouds-crawl.md
+++ b/.changelog/vain-clouds-crawl.md
@@ -2,4 +2,4 @@
 mpp: minor
 ---
 
-Added fee payer (0x78 envelope) support to the Tempo payment provider. The client now encodes fee payer transactions in the 0x78 format using expiring nonces, and the server co-signs them by recovering the sender, setting the fee token, and re-encoding as a standard 0x76 transaction with both signatures.
+Added fee payer support to the Tempo payment provider. The client now builds 0x76 transactions with expiring nonces and a placeholder fee payer signature, and the server co-signs them by recovering the sender, setting the fee token, and re-encoding as a standard 0x76 transaction with both signatures.

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -92,6 +92,18 @@ pub trait PaymentProvider: Clone + Send + Sync {
 ///     .send_with_payment(&provider)
 ///     .await?;
 /// ```
+/// Nonce key for expiring nonce transactions (fee payer mode).
+#[cfg(feature = "tempo")]
+const EXPIRING_NONCE_KEY: alloy::primitives::U256 = alloy::primitives::U256::MAX;
+
+/// Validity window (in seconds) for fee payer transactions.
+#[cfg(feature = "tempo")]
+const FEE_PAYER_VALID_BEFORE_SECS: u64 = 25;
+
+/// Type byte for the fee payer envelope format.
+#[cfg(feature = "tempo")]
+const FEE_PAYER_TX_TYPE: u8 = 0x78;
+
 #[cfg(feature = "tempo")]
 #[derive(Clone)]
 pub struct TempoProvider {
@@ -199,9 +211,15 @@ impl PaymentProvider for TempoProvider {
         let (nonce_key, nonce, valid_before) = if fee_payer {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
+                .map_err(|e| MppError::Http(format!("system clock error: {}", e)))?
                 .as_secs();
-            (U256::MAX, 0u64, Some(now + 25))
+            // Expiring nonce transactions require nonce=0. Replay protection
+            // comes from the valid_before window + tx hash, not the nonce value.
+            (
+                EXPIRING_NONCE_KEY,
+                0u64,
+                Some(now + FEE_PAYER_VALID_BEFORE_SECS),
+            )
         } else {
             let n = provider
                 .get_transaction_count(address)
@@ -408,12 +426,8 @@ fn encode_fee_payer_envelope(
     signature: tempo_primitives::transaction::TempoSignature,
 ) -> Vec<u8> {
     use alloy::primitives::bytes::BufMut;
-    use alloy::rlp::Encodable;
+    use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
 
-    const FEE_PAYER_MAGIC: u8 = 0x78;
-    const EMPTY_STRING_CODE: u8 = 0x80;
-
-    // Encode all fields into a temporary buffer to compute payload length
     let mut fields = Vec::new();
 
     tx.chain_id.encode(&mut fields);
@@ -425,13 +439,11 @@ fn encode_fee_payer_envelope(
     tx.nonce_key.encode(&mut fields);
     tx.nonce.encode(&mut fields);
 
-    // validBefore
     if let Some(vb) = tx.valid_before {
         vb.encode(&mut fields);
     } else {
         fields.put_u8(EMPTY_STRING_CODE);
     }
-    // validAfter
     if let Some(va) = tx.valid_after {
         va.encode(&mut fields);
     } else {
@@ -441,23 +453,19 @@ fn encode_fee_payer_envelope(
     fields.put_u8(EMPTY_STRING_CODE);
     // Sender address in the fee_payer_signature slot
     sender.encode(&mut fields);
-    // authorizationList
     tx.tempo_authorization_list.encode(&mut fields);
-    // keyAuthorization (optional)
     if let Some(key_auth) = &tx.key_authorization {
         key_auth.encode(&mut fields);
     }
-    // Client signature
     signature.encode(&mut fields);
 
-    // Build final: 0x78 || RLP header || fields
     let rlp_header = alloy::rlp::Header {
         list: true,
         payload_length: fields.len(),
     };
 
     let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
-    out.put_u8(FEE_PAYER_MAGIC);
+    out.put_u8(FEE_PAYER_TX_TYPE);
     rlp_header.encode(&mut out);
     out.extend_from_slice(&fields);
 

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -100,10 +100,6 @@ const EXPIRING_NONCE_KEY: alloy::primitives::U256 = alloy::primitives::U256::MAX
 #[cfg(feature = "tempo")]
 const FEE_PAYER_VALID_BEFORE_SECS: u64 = 25;
 
-/// Type byte for the fee payer envelope format.
-#[cfg(feature = "tempo")]
-const FEE_PAYER_TX_TYPE: u8 = 0x78;
-
 #[cfg(feature = "tempo")]
 #[derive(Clone)]
 pub struct TempoProvider {
@@ -233,12 +229,14 @@ impl PaymentProvider for TempoProvider {
             .await
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
-        // Build a Tempo transaction (type 0x76) for proper on-chain processing.
+        // Build a Tempo transaction (type 0x76).
         // When fee_payer is true:
         //   - fee_token is None (server chooses at co-sign time)
         //   - fee_payer_signature is a placeholder (triggers skip_fee_token in signing hash)
         //   - nonce_key = U256::MAX (expiring nonce)
         //   - valid_before is set to now + 25s
+        // The server decodes this standard 0x76 tx, recovers the sender via
+        // ecrecover, then co-signs and broadcasts.
         let tempo_tx = TempoTransaction {
             chain_id: expected_chain_id,
             nonce,
@@ -272,15 +270,8 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let tx_bytes = if fee_payer {
-            // Serialize as 0x78 fee payer envelope:
-            // The server expects this format so it can co-sign before broadcasting.
-            // Format: 0x78 || RLP([...tx_fields_with_sender_addr, client_signature])
-            encode_fee_payer_envelope(&tempo_tx, address, signature.into())
-        } else {
-            let signed_tx = tempo_tx.into_signed(signature.into());
-            signed_tx.encoded_2718()
-        };
+        let signed_tx = tempo_tx.into_signed(signature.into());
+        let tx_bytes = signed_tx.encoded_2718();
         let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
         let echo = challenge.to_echo();
@@ -402,74 +393,6 @@ impl Clone for Box<dyn DynPaymentProvider> {
     fn clone(&self) -> Self {
         self.clone_box()
     }
-}
-
-/// Encode a fee payer envelope (0x78 format).
-///
-/// This produces the serialized bytes that the mppx server expects when
-/// `feePayer: true`. The format is:
-///
-/// ```text
-/// 0x78 || RLP([chainId, maxPriorityFeePerGas, maxFeePerGas, gas, calls,
-///              accessList, nonceKey, nonce, validBefore, validAfter,
-///              feeToken, senderAddress, authorizationList, signature])
-/// ```
-///
-/// Key differences from the standard 0x76 format:
-/// - Type prefix is 0x78 instead of 0x76
-/// - The fee_payer_signature slot contains the sender address (not a placeholder)
-/// - The fee_token is empty (server chooses at co-sign time)
-#[cfg(feature = "tempo")]
-fn encode_fee_payer_envelope(
-    tx: &tempo_primitives::TempoTransaction,
-    sender: alloy::primitives::Address,
-    signature: tempo_primitives::transaction::TempoSignature,
-) -> Vec<u8> {
-    use alloy::primitives::bytes::BufMut;
-    use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
-
-    let mut fields = Vec::new();
-
-    tx.chain_id.encode(&mut fields);
-    tx.max_priority_fee_per_gas.encode(&mut fields);
-    tx.max_fee_per_gas.encode(&mut fields);
-    tx.gas_limit.encode(&mut fields);
-    tx.calls.encode(&mut fields);
-    tx.access_list.encode(&mut fields);
-    tx.nonce_key.encode(&mut fields);
-    tx.nonce.encode(&mut fields);
-
-    if let Some(vb) = tx.valid_before {
-        vb.encode(&mut fields);
-    } else {
-        fields.put_u8(EMPTY_STRING_CODE);
-    }
-    if let Some(va) = tx.valid_after {
-        va.encode(&mut fields);
-    } else {
-        fields.put_u8(EMPTY_STRING_CODE);
-    }
-    // feeToken — always empty in fee payer envelope
-    fields.put_u8(EMPTY_STRING_CODE);
-    // Sender address in the fee_payer_signature slot
-    sender.encode(&mut fields);
-    tx.tempo_authorization_list.encode(&mut fields);
-    if let Some(key_auth) = &tx.key_authorization {
-        key_auth.encode(&mut fields);
-    }
-    signature.encode(&mut fields);
-
-    let rlp_header = alloy::rlp::Header {
-        list: true,
-        payload_length: fields.len(),
-    };
-
-    let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
-    out.put_u8(FEE_PAYER_TX_TYPE);
-    rlp_header.encode(&mut out);
-    out.extend_from_slice(&fields);
-
-    out
 }
 
 #[cfg(test)]

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -150,7 +150,7 @@ impl PaymentProvider for TempoProvider {
         use crate::protocol::intents::ChargeRequest;
         use crate::protocol::methods::tempo::{TempoChargeExt, CHAIN_ID};
         use alloy::eips::Encodable2718;
-        use alloy::primitives::{Bytes, TxKind, B256};
+        use alloy::primitives::{Bytes, TxKind, B256, U256};
         use alloy::providers::{Provider, ProviderBuilder};
         use alloy::sol_types::SolCall;
         use tempo_alloy::contracts::precompiles::tip20::ITIP20;
@@ -161,6 +161,7 @@ impl PaymentProvider for TempoProvider {
         let charge: ChargeRequest = challenge.request.decode()?;
         let expected_chain_id = charge.chain_id().unwrap_or(CHAIN_ID);
         let address = self.signer.address();
+        let fee_payer = charge.fee_payer();
 
         let provider =
             ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(self.rpc_url.clone());
@@ -193,10 +194,21 @@ impl PaymentProvider for TempoProvider {
         let transfer_data =
             ITIP20::transferWithMemoCall::new((recipient, amount, memo)).abi_encode();
 
-        let nonce = provider
-            .get_transaction_count(address)
-            .await
-            .map_err(|e| MppError::Http(format!("failed to get nonce: {}", e)))?;
+        // Fee payer mode: use expiring nonces to avoid nonce collisions
+        // when the server broadcasts on the client's behalf.
+        let (nonce_key, nonce, valid_before) = if fee_payer {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            (U256::MAX, 0u64, Some(now + 25))
+        } else {
+            let n = provider
+                .get_transaction_count(address)
+                .await
+                .map_err(|e| MppError::Http(format!("failed to get nonce: {}", e)))?;
+            (U256::ZERO, n, None)
+        };
 
         let gas_price = provider
             .get_gas_price()
@@ -204,15 +216,32 @@ impl PaymentProvider for TempoProvider {
             .map_err(|e| MppError::Http(format!("failed to get gas price: {}", e)))?;
 
         // Build a Tempo transaction (type 0x76) for proper on-chain processing.
+        // When fee_payer is true:
+        //   - fee_token is None (server chooses at co-sign time)
+        //   - fee_payer_signature is a placeholder (triggers skip_fee_token in signing hash)
+        //   - nonce_key = U256::MAX (expiring nonce)
+        //   - valid_before is set to now + 25s
         let tempo_tx = TempoTransaction {
             chain_id: expected_chain_id,
             nonce,
+            nonce_key,
             gas_limit: 1_000_000,
             max_fee_per_gas: gas_price,
             max_priority_fee_per_gas: gas_price,
+            fee_token: None,
+            fee_payer_signature: if fee_payer {
+                Some(alloy::primitives::Signature::new(
+                    U256::ZERO,
+                    U256::ZERO,
+                    false,
+                ))
+            } else {
+                None
+            },
+            valid_before,
             calls: vec![Call {
                 to: TxKind::Call(currency),
-                value: alloy::primitives::U256::ZERO,
+                value: U256::ZERO,
                 input: Bytes::from(transfer_data),
             }],
             ..Default::default()
@@ -225,8 +254,15 @@ impl PaymentProvider for TempoProvider {
             .sign_hash_sync(&sig_hash)
             .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
-        let signed_tx = tempo_tx.into_signed(signature.into());
-        let tx_bytes = signed_tx.encoded_2718();
+        let tx_bytes = if fee_payer {
+            // Serialize as 0x78 fee payer envelope:
+            // The server expects this format so it can co-sign before broadcasting.
+            // Format: 0x78 || RLP([...tx_fields_with_sender_addr, client_signature])
+            encode_fee_payer_envelope(&tempo_tx, address, signature.into())
+        } else {
+            let signed_tx = tempo_tx.into_signed(signature.into());
+            signed_tx.encoded_2718()
+        };
         let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
 
         let echo = challenge.to_echo();
@@ -348,6 +384,84 @@ impl Clone for Box<dyn DynPaymentProvider> {
     fn clone(&self) -> Self {
         self.clone_box()
     }
+}
+
+/// Encode a fee payer envelope (0x78 format).
+///
+/// This produces the serialized bytes that the mppx server expects when
+/// `feePayer: true`. The format is:
+///
+/// ```text
+/// 0x78 || RLP([chainId, maxPriorityFeePerGas, maxFeePerGas, gas, calls,
+///              accessList, nonceKey, nonce, validBefore, validAfter,
+///              feeToken, senderAddress, authorizationList, signature])
+/// ```
+///
+/// Key differences from the standard 0x76 format:
+/// - Type prefix is 0x78 instead of 0x76
+/// - The fee_payer_signature slot contains the sender address (not a placeholder)
+/// - The fee_token is empty (server chooses at co-sign time)
+#[cfg(feature = "tempo")]
+fn encode_fee_payer_envelope(
+    tx: &tempo_primitives::TempoTransaction,
+    sender: alloy::primitives::Address,
+    signature: tempo_primitives::transaction::TempoSignature,
+) -> Vec<u8> {
+    use alloy::primitives::bytes::BufMut;
+    use alloy::rlp::Encodable;
+
+    const FEE_PAYER_MAGIC: u8 = 0x78;
+    const EMPTY_STRING_CODE: u8 = 0x80;
+
+    // Encode all fields into a temporary buffer to compute payload length
+    let mut fields = Vec::new();
+
+    tx.chain_id.encode(&mut fields);
+    tx.max_priority_fee_per_gas.encode(&mut fields);
+    tx.max_fee_per_gas.encode(&mut fields);
+    tx.gas_limit.encode(&mut fields);
+    tx.calls.encode(&mut fields);
+    tx.access_list.encode(&mut fields);
+    tx.nonce_key.encode(&mut fields);
+    tx.nonce.encode(&mut fields);
+
+    // validBefore
+    if let Some(vb) = tx.valid_before {
+        vb.encode(&mut fields);
+    } else {
+        fields.put_u8(EMPTY_STRING_CODE);
+    }
+    // validAfter
+    if let Some(va) = tx.valid_after {
+        va.encode(&mut fields);
+    } else {
+        fields.put_u8(EMPTY_STRING_CODE);
+    }
+    // feeToken — always empty in fee payer envelope
+    fields.put_u8(EMPTY_STRING_CODE);
+    // Sender address in the fee_payer_signature slot
+    sender.encode(&mut fields);
+    // authorizationList
+    tx.tempo_authorization_list.encode(&mut fields);
+    // keyAuthorization (optional)
+    if let Some(key_auth) = &tx.key_authorization {
+        key_auth.encode(&mut fields);
+    }
+    // Client signature
+    signature.encode(&mut fields);
+
+    // Build final: 0x78 || RLP header || fields
+    let rlp_header = alloy::rlp::Header {
+        list: true,
+        payload_length: fields.len(),
+    };
+
+    let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
+    out.put_u8(FEE_PAYER_MAGIC);
+    rlp_header.encode(&mut out);
+    out.extend_from_slice(&fields);
+
+    out
 }
 
 #[cfg(test)]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -389,12 +389,13 @@ where
             ));
         }
 
-        // Skip type byte (0x76) for Tempo transactions
-        let tx_data = if !tx_bytes.is_empty() && tx_bytes[0] == 0x76 {
-            &tx_bytes[1..]
-        } else {
-            tx_bytes
-        };
+        // Skip type byte (0x76 or 0x78) for Tempo transactions
+        let tx_data =
+            if !tx_bytes.is_empty() && (tx_bytes[0] == 0x76 || tx_bytes[0] == 0x78) {
+                &tx_bytes[1..]
+            } else {
+                tx_bytes
+            };
 
         // Decode the signed Tempo transaction (AASigned = tx fields + signature).
         let signed = tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..])
@@ -520,17 +521,23 @@ where
             expected_chain_id,
         )?;
 
-        // Fail fast if fee payer is requested but no signer is configured.
-        if charge.fee_payer() && self.fee_payer_signer.is_none() {
-            return Err(VerificationError::new(
-                "feePayer requested but fee sponsorship is not configured on this server"
-                    .to_string(),
-            ));
-        }
+        // Fee payer co-signing: decode the client tx, set fee_token, co-sign, re-encode
+        let final_tx_bytes = if charge.fee_payer() {
+            let fee_payer_signer = self.fee_payer_signer.as_ref().ok_or_else(|| {
+                VerificationError::new(
+                    "feePayer requested but fee sponsorship is not configured on this server"
+                        .to_string(),
+                )
+            })?;
+
+            self.cosign_fee_payer_transaction(&tx_bytes, fee_payer_signer, currency)?
+        } else {
+            tx_bytes.to_vec()
+        };
 
         let pending = self
             .provider
-            .send_raw_transaction(&tx_bytes)
+            .send_raw_transaction(&final_tx_bytes)
             .await
             .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
 
@@ -547,6 +554,66 @@ where
         }
 
         Ok(receipt.transaction_hash())
+    }
+
+    /// Co-sign a fee payer transaction.
+    ///
+    /// Handles both 0x78 (fee payer envelope) and 0x76 (standard) formats.
+    /// Decodes the client-signed transaction, recovers the sender, sets the fee_token,
+    /// computes the fee payer signature hash (0x78 domain), signs it, and re-encodes
+    /// as a standard 0x76 transaction with both signatures.
+    fn cosign_fee_payer_transaction(
+        &self,
+        tx_bytes: &[u8],
+        fee_payer_signer: &alloy_signer_local::PrivateKeySigner,
+        fee_token: Address,
+    ) -> Result<Vec<u8>, VerificationError> {
+        use alloy::consensus::transaction::SignerRecoverable;
+        use alloy::eips::Encodable2718;
+        use alloy::signers::SignerSync;
+
+        if tx_bytes.is_empty() {
+            return Err(VerificationError::new("Empty transaction bytes"));
+        }
+
+        // Both 0x78 (fee payer envelope) and 0x76 (standard) formats use the
+        // same RLP field layout. The AASigned decoder handles both — the
+        // fee_payer_signature slot may contain a sender address (0x78 format)
+        // or a placeholder (0x76 format), both of which decode successfully.
+        let type_byte = tx_bytes[0];
+        let rlp_data = if type_byte == 0x76 || type_byte == 0x78 {
+            &tx_bytes[1..]
+        } else {
+            tx_bytes
+        };
+
+        // Decode the signed transaction (AASigned = tx fields + sender signature)
+        let signed = tempo_primitives::AASigned::rlp_decode(&mut &rlp_data[..])
+            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
+
+        // Recover the sender address from the client's signature
+        let sender = signed
+            .recover_signer()
+            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {}", e)))?;
+
+        let client_signature = signed.signature().clone();
+        let mut tx = signed.into_parts().0;
+
+        // Set the fee token (server chooses which token to pay gas with)
+        tx.fee_token = Some(fee_token);
+
+        // Compute the fee payer signature hash (0x78 domain) and sign
+        let fp_hash = tx.fee_payer_signature_hash(sender);
+        let fp_sig = fee_payer_signer
+            .sign_hash_sync(&fp_hash)
+            .map_err(|e| VerificationError::new(format!("Failed to co-sign transaction: {}", e)))?;
+
+        // Set the real fee payer signature (replacing the placeholder)
+        tx.fee_payer_signature = Some(fp_sig);
+
+        // Re-encode as standard 0x76 transaction with both signatures
+        let signed_tx = tx.into_signed(client_signature);
+        Ok(signed_tx.encoded_2718())
     }
 }
 

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -692,10 +692,25 @@ where
                 "Fee payer envelope must use expiring nonce key (U256::MAX)",
             ));
         }
-        if valid_before.is_none() {
-            return Err(VerificationError::new(
-                "Fee payer envelope must include valid_before",
-            ));
+        match valid_before {
+            None => {
+                return Err(VerificationError::new(
+                    "Fee payer envelope must include valid_before",
+                ));
+            }
+            Some(vb) => {
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_err(|e| {
+                        VerificationError::new(format!("System clock error: {e}"))
+                    })?
+                    .as_secs();
+                if vb <= now {
+                    return Err(VerificationError::new(format!(
+                        "Fee payer envelope expired: valid_before ({vb}) is not in the future (now={now})"
+                    )));
+                }
+            }
         }
 
         // Rebuild the transaction with fee_token set
@@ -980,5 +995,338 @@ mod tests {
         assert!(error
             .to_string()
             .contains("fee sponsorship is not configured"));
+    }
+
+    // ==================== Fee payer co-sign unit tests ====================
+
+    /// Helper: build a 0x78 fee payer envelope using encode_fee_payer_envelope
+    /// from provider.rs (replicated here since it's private to that module).
+    fn build_fee_payer_envelope(
+        tx: &tempo_primitives::TempoTransaction,
+        sender: Address,
+        signature: tempo_primitives::transaction::TempoSignature,
+    ) -> Vec<u8> {
+        use alloy::primitives::bytes::BufMut;
+        use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
+
+        let mut fields = Vec::new();
+
+        tx.chain_id.encode(&mut fields);
+        tx.max_priority_fee_per_gas.encode(&mut fields);
+        tx.max_fee_per_gas.encode(&mut fields);
+        tx.gas_limit.encode(&mut fields);
+        tx.calls.encode(&mut fields);
+        tx.access_list.encode(&mut fields);
+        tx.nonce_key.encode(&mut fields);
+        tx.nonce.encode(&mut fields);
+
+        if let Some(vb) = tx.valid_before {
+            vb.encode(&mut fields);
+        } else {
+            fields.put_u8(EMPTY_STRING_CODE);
+        }
+        if let Some(va) = tx.valid_after {
+            va.encode(&mut fields);
+        } else {
+            fields.put_u8(EMPTY_STRING_CODE);
+        }
+        // feeToken — always empty in fee payer envelope
+        fields.put_u8(EMPTY_STRING_CODE);
+        // Sender address in the fee_payer_signature slot
+        sender.encode(&mut fields);
+        tx.tempo_authorization_list.encode(&mut fields);
+        if let Some(key_auth) = &tx.key_authorization {
+            key_auth.encode(&mut fields);
+        }
+        signature.encode(&mut fields);
+
+        let rlp_header = alloy::rlp::Header {
+            list: true,
+            payload_length: fields.len(),
+        };
+
+        let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
+        out.put_u8(0x78);
+        rlp_header.encode(&mut out);
+        out.extend_from_slice(&fields);
+
+        out
+    }
+
+    /// Helper: build a valid TempoTransaction for fee payer tests.
+    fn make_fee_payer_tx(valid_before_secs_from_now: u64) -> tempo_primitives::TempoTransaction {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        tempo_primitives::TempoTransaction {
+            chain_id: CHAIN_ID,
+            nonce: 0,
+            nonce_key: U256::MAX,
+            gas_limit: 1_000_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000_000,
+            fee_token: None,
+            fee_payer_signature: Some(alloy::primitives::Signature::new(
+                U256::ZERO,
+                U256::ZERO,
+                false,
+            )),
+            valid_before: Some(now + valid_before_secs_from_now),
+            valid_after: None,
+            calls: vec![tempo_primitives::transaction::Call {
+                to: TxKind::Call(Address::repeat_byte(0x20)),
+                value: U256::ZERO,
+                input: Bytes::from(vec![0xa9, 0x05, 0x9c, 0xbb]), // transfer selector
+            }],
+            access_list: Default::default(),
+            tempo_authorization_list: vec![],
+            key_authorization: None,
+        }
+    }
+
+    /// Helper: sign a tx and build a 0x78 envelope.
+    fn sign_and_encode_fee_payer_envelope(
+        tx: &tempo_primitives::TempoTransaction,
+        signer: &alloy_signer_local::PrivateKeySigner,
+    ) -> Vec<u8> {
+        use alloy::signers::SignerSync;
+
+        let sig_hash = tx.signature_hash();
+        let sig = signer.sign_hash_sync(&sig_hash).unwrap();
+        build_fee_payer_envelope(tx, signer.address(), sig.into())
+    }
+
+    /// Round-trip: encode_fee_payer_envelope → cosign_fee_payer_transaction
+    /// succeeds and produces a valid 0x76 transaction.
+    #[test]
+    fn test_fee_payer_envelope_round_trip() {
+        use alloy::eips::Decodable2718;
+
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let tx = make_fee_payer_tx(60);
+        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+
+        // Verify it starts with 0x78
+        assert_eq!(envelope[0], 0x78);
+
+        // Create a dummy ChargeMethod to call cosign_fee_payer_transaction.
+        // We need a Provider<TempoNetwork>, but cosign doesn't use it — use
+        // a mock HTTP provider that we never call.
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &envelope,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let co_signed = result.expect("cosign should succeed for valid 0x78 envelope");
+
+        // Result should be a valid 0x76 transaction
+        assert_eq!(
+            co_signed[0],
+            tempo_primitives::transaction::TEMPO_TX_TYPE_ID,
+            "co-signed output should be 0x76"
+        );
+
+        // It should be decodable by AASigned
+        let signed = tempo_primitives::AASigned::decode_2718(&mut &co_signed[..])
+            .expect("co-signed tx should be decodable as AASigned");
+
+        let decoded_tx = signed.tx();
+        assert_eq!(decoded_tx.chain_id, CHAIN_ID);
+        assert_eq!(decoded_tx.nonce_key, U256::MAX);
+        assert_eq!(decoded_tx.fee_token, Some(fee_token.into()));
+        assert!(decoded_tx.fee_payer_signature.is_some());
+        assert!(decoded_tx.valid_before.is_some());
+    }
+
+    /// cosign_fee_payer_transaction rejects a standard 0x76 transaction.
+    #[test]
+    fn test_cosign_rejects_0x76_input() {
+        use alloy::eips::Encodable2718;
+        use alloy::signers::SignerSync;
+
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let tx = make_fee_payer_tx(60);
+        let sig_hash = tx.signature_hash();
+        let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
+        let signed = tx.into_signed(sig.into());
+        let encoded_0x76 = signed.encoded_2718();
+
+        assert_eq!(encoded_0x76[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
+
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &encoded_0x76,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject 0x76 input");
+        assert!(
+            err.to_string().contains("Expected fee payer envelope (0x78)"),
+            "error should mention 0x78, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects envelopes with wrong nonce_key.
+    #[test]
+    fn test_cosign_rejects_wrong_nonce_key() {
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.nonce_key = U256::ZERO; // Wrong — should be U256::MAX
+
+        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &envelope,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject wrong nonce_key");
+        assert!(
+            err.to_string().contains("expiring nonce key"),
+            "error should mention expiring nonce key, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects envelopes without valid_before.
+    #[test]
+    fn test_cosign_rejects_missing_valid_before() {
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.valid_before = None; // Missing
+
+        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &envelope,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject missing valid_before");
+        assert!(
+            err.to_string().contains("must include valid_before"),
+            "error should mention valid_before, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects envelopes with expired valid_before.
+    #[test]
+    fn test_cosign_rejects_expired_valid_before() {
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        // Build a tx with valid_before in the past
+        let past = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            - 10;
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.valid_before = Some(past);
+
+        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &envelope,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject expired valid_before");
+        assert!(
+            err.to_string().contains("expired"),
+            "error should mention expiration, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects empty input.
+    #[test]
+    fn test_cosign_rejects_empty_input() {
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let provider = alloy::providers::ProviderBuilder::new_with_network::<
+            tempo_alloy::TempoNetwork,
+        >()
+        .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &[],
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject empty input");
+        assert!(
+            err.to_string().contains("Empty transaction bytes"),
+            "error should mention empty, got: {err}"
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -701,9 +701,7 @@ where
             Some(vb) => {
                 let now = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|e| {
-                        VerificationError::new(format!("System clock error: {e}"))
-                    })?
+                    .map_err(|e| VerificationError::new(format!("System clock error: {e}")))?
                     .as_secs();
                 if vb <= now {
                     return Err(VerificationError::new(format!(
@@ -1119,10 +1117,9 @@ mod tests {
         // Create a dummy ChargeMethod to call cosign_fee_payer_transaction.
         // We need a Provider<TempoNetwork>, but cosign doesn't use it — use
         // a mock HTTP provider that we never call.
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
@@ -1171,12 +1168,14 @@ mod tests {
         let signed = tx.into_signed(sig.into());
         let encoded_0x76 = signed.encoded_2718();
 
-        assert_eq!(encoded_0x76[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
+        assert_eq!(
+            encoded_0x76[0],
+            tempo_primitives::transaction::TEMPO_TX_TYPE_ID
+        );
 
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
@@ -1188,7 +1187,8 @@ mod tests {
 
         let err = result.expect_err("should reject 0x76 input");
         assert!(
-            err.to_string().contains("Expected fee payer envelope (0x78)"),
+            err.to_string()
+                .contains("Expected fee payer envelope (0x78)"),
             "error should mention 0x78, got: {err}"
         );
     }
@@ -1207,10 +1207,9 @@ mod tests {
 
         let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
 
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
@@ -1241,10 +1240,9 @@ mod tests {
 
         let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
 
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
@@ -1282,10 +1280,9 @@ mod tests {
 
         let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
 
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
@@ -1310,10 +1307,9 @@ mod tests {
             .parse()
             .unwrap();
 
-        let provider = alloy::providers::ProviderBuilder::new_with_network::<
-            tempo_alloy::TempoNetwork,
-        >()
-        .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
 
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -389,11 +389,9 @@ where
             ));
         }
 
-        // Skip type byte (0x76 or 0x78) for Tempo transactions
+        // Skip type byte (0x76) for Tempo transactions
         let tx_data = if !tx_bytes.is_empty()
-            && (tx_bytes[0] == tempo_primitives::transaction::TEMPO_TX_TYPE_ID
-                || tx_bytes[0]
-                    == tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE)
+            && tx_bytes[0] == tempo_primitives::transaction::TEMPO_TX_TYPE_ID
         {
             &tx_bytes[1..]
         } else {
@@ -514,10 +512,8 @@ where
         })?;
         let memo = charge.memo();
 
-        // Fee payer co-signing must happen before validation because the 0x78
-        // envelope contains a sender address in the fee_payer_signature slot,
-        // which AASigned::rlp_decode cannot parse. Co-signing converts it to a
-        // standard 0x76 transaction that validate_transaction can decode.
+        // Fee payer co-signing replaces the placeholder fee_payer_signature
+        // with a real co-signature and sets the fee_token.
         let final_tx_bytes = if charge.fee_payer() {
             let fee_payer_signer = self.fee_payer_signer.as_ref().ok_or_else(|| {
                 VerificationError::new(
@@ -563,19 +559,18 @@ where
 
     /// Co-sign a fee payer transaction.
     ///
-    /// Requires a 0x78 fee payer envelope from the client. The 0x78 format
-    /// places the sender address in the fee_payer_signature slot, which
-    /// standard `AASigned::rlp_decode` cannot parse. This method manually
-    /// decodes the RLP, extracts the sender address, then rebuilds and
-    /// co-signs as a standard 0x76 transaction.
+    /// Accepts a standard 0x76 Tempo transaction with a placeholder
+    /// fee_payer_signature. Recovers the sender address via ecrecover,
+    /// validates fee-payer invariants, then co-signs and returns a
+    /// complete 0x76 transaction ready for broadcast.
     fn cosign_fee_payer_transaction(
         &self,
         tx_bytes: &[u8],
         fee_payer_signer: &alloy_signer_local::PrivateKeySigner,
         fee_token: Address,
     ) -> Result<Vec<u8>, VerificationError> {
-        use alloy::eips::Encodable2718;
-        use alloy::rlp::Decodable;
+        use alloy::consensus::transaction::SignerRecoverable;
+        use alloy::eips::{Decodable2718, Encodable2718};
         use alloy::signers::SignerSync;
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
@@ -583,116 +578,45 @@ where
             return Err(VerificationError::new("Empty transaction bytes"));
         }
 
-        // Require 0x78 fee payer envelope — reject standard 0x76 or untyped.
+        // Require 0x76 Tempo transaction type
         let type_byte = tx_bytes[0];
-        if type_byte
-            != tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE
-        {
+        if type_byte != tempo_primitives::transaction::TEMPO_TX_TYPE_ID {
             return Err(VerificationError::new(format!(
-                "Expected fee payer envelope (0x78), got 0x{type_byte:02x}"
+                "Expected Tempo transaction (0x76), got 0x{type_byte:02x}"
             )));
         }
 
-        let mut rlp_data = &tx_bytes[1..];
+        // Decode the standard 0x76 transaction
+        let signed = tempo_primitives::AASigned::decode_2718(&mut &tx_bytes[..])
+            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {e}")))?;
 
-        // Decode the outer RLP list header
-        let header = alloy::rlp::Header::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode RLP header: {e}")))?;
-        if !header.list {
-            return Err(VerificationError::new(
-                "Expected RLP list for fee payer envelope",
-            ));
-        }
+        // Recover sender address from client signature via ecrecover
+        let sender = signed
+            .recover_signer()
+            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {e}")))?;
 
-        // Decode fields in the same order as rlp_encode_fields:
-        // chain_id, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
-        // calls, access_list, nonce_key, nonce, valid_before, valid_after,
-        // fee_token, fee_payer_signature_slot (sender addr), authorization_list,
-        // [key_authorization], client_signature
-        let chain_id: u64 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode chain_id: {e}")))?;
-        let max_priority_fee_per_gas: u128 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode gas fields: {e}")))?;
-        let max_fee_per_gas: u128 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode gas fields: {e}")))?;
-        let gas_limit: u64 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode gas_limit: {e}")))?;
-        let calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode calls: {e}")))?;
-        let access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode access_list: {e}")))?;
-        let nonce_key: U256 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode nonce_key: {e}")))?;
-        let nonce: u64 = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode nonce: {e}")))?;
-
-        // valid_before / valid_after: 0x80 = None, otherwise u64
-        let valid_before: Option<u64> = if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE)
-        {
-            rlp_data = &rlp_data[1..];
-            None
-        } else {
-            Some(Decodable::decode(&mut rlp_data).map_err(|e| {
-                VerificationError::new(format!("Failed to decode valid_before: {e}"))
-            })?)
-        };
-        let valid_after: Option<u64> = if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE) {
-            rlp_data = &rlp_data[1..];
-            None
-        } else {
-            Some(Decodable::decode(&mut rlp_data).map_err(|e| {
-                VerificationError::new(format!("Failed to decode valid_after: {e}"))
-            })?)
-        };
-
-        // fee_token: should be empty (0x80) in fee payer envelope
-        if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE) {
-            rlp_data = &rlp_data[1..];
-        } else {
-            return Err(VerificationError::new(
-                "Fee payer envelope must not include fee_token (server sets it)",
-            ));
-        }
-
-        // fee_payer_signature slot: contains sender address (20 bytes) in 0x78 format
-        let sender: Address = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode sender address: {e}")))?;
-
-        // authorization_list
-        let tempo_authorization_list: Vec<tempo_primitives::transaction::TempoSignedAuthorization> =
-            Decodable::decode(&mut rlp_data).map_err(|e| {
-                VerificationError::new(format!("Failed to decode authorization_list: {e}"))
-            })?;
-
-        // key_authorization (optional — only present if next byte starts an RLP list)
-        let key_authorization: Option<
-            tempo_primitives::transaction::key_authorization::SignedKeyAuthorization,
-        > = if let Some(&first) = rlp_data.first() {
-            if first >= 0xc0 {
-                Some(Decodable::decode(&mut rlp_data).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode key_authorization: {e}"))
-                })?)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // Client signature (remaining bytes)
-        let sig_bytes: alloy::primitives::Bytes = Decodable::decode(&mut rlp_data)
-            .map_err(|e| VerificationError::new(format!("Failed to decode signature: {e}")))?;
-        let client_signature =
-            tempo_primitives::transaction::TempoSignature::from_bytes(&sig_bytes)
-                .map_err(|e| VerificationError::new(format!("Invalid client signature: {e}")))?;
+        let tx = signed.tx();
 
         // Validate fee-payer invariants
-        if nonce_key != TEMPO_EXPIRING_NONCE_KEY {
+        if tx.fee_payer_signature.is_none() {
+            return Err(VerificationError::new(
+                "Transaction must include fee_payer_signature placeholder",
+            ));
+        }
+
+        if tx.fee_token.is_some() {
+            return Err(VerificationError::new(
+                "Fee payer transaction must not include fee_token (server sets it)",
+            ));
+        }
+
+        if tx.nonce_key != TEMPO_EXPIRING_NONCE_KEY {
             return Err(VerificationError::new(
                 "Fee payer envelope must use expiring nonce key (U256::MAX)",
             ));
         }
-        match valid_before {
+
+        match tx.valid_before {
             None => {
                 return Err(VerificationError::new(
                     "Fee payer envelope must include valid_before",
@@ -711,23 +635,11 @@ where
             }
         }
 
-        // Rebuild the transaction with fee_token set
-        let mut tx = tempo_primitives::TempoTransaction {
-            chain_id,
-            nonce,
-            nonce_key,
-            gas_limit,
-            max_fee_per_gas,
-            max_priority_fee_per_gas,
-            fee_token: Some(fee_token),
-            fee_payer_signature: None,
-            valid_before,
-            valid_after,
-            calls,
-            access_list,
-            tempo_authorization_list,
-            key_authorization,
-        };
+        // Rebuild the transaction with fee_token set and real fee_payer_signature
+        let (tx, client_signature, _hash) = signed.into_parts();
+        let mut tx = tx;
+        tx.fee_token = Some(fee_token);
+        tx.fee_payer_signature = None; // Clear placeholder before computing hash
 
         // Compute the fee payer signature hash and co-sign
         let fp_hash = tx.fee_payer_signature_hash(sender);
@@ -997,60 +909,6 @@ mod tests {
 
     // ==================== Fee payer co-sign unit tests ====================
 
-    /// Helper: build a 0x78 fee payer envelope using encode_fee_payer_envelope
-    /// from provider.rs (replicated here since it's private to that module).
-    fn build_fee_payer_envelope(
-        tx: &tempo_primitives::TempoTransaction,
-        sender: Address,
-        signature: tempo_primitives::transaction::TempoSignature,
-    ) -> Vec<u8> {
-        use alloy::primitives::bytes::BufMut;
-        use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
-
-        let mut fields = Vec::new();
-
-        tx.chain_id.encode(&mut fields);
-        tx.max_priority_fee_per_gas.encode(&mut fields);
-        tx.max_fee_per_gas.encode(&mut fields);
-        tx.gas_limit.encode(&mut fields);
-        tx.calls.encode(&mut fields);
-        tx.access_list.encode(&mut fields);
-        tx.nonce_key.encode(&mut fields);
-        tx.nonce.encode(&mut fields);
-
-        if let Some(vb) = tx.valid_before {
-            vb.encode(&mut fields);
-        } else {
-            fields.put_u8(EMPTY_STRING_CODE);
-        }
-        if let Some(va) = tx.valid_after {
-            va.encode(&mut fields);
-        } else {
-            fields.put_u8(EMPTY_STRING_CODE);
-        }
-        // feeToken — always empty in fee payer envelope
-        fields.put_u8(EMPTY_STRING_CODE);
-        // Sender address in the fee_payer_signature slot
-        sender.encode(&mut fields);
-        tx.tempo_authorization_list.encode(&mut fields);
-        if let Some(key_auth) = &tx.key_authorization {
-            key_auth.encode(&mut fields);
-        }
-        signature.encode(&mut fields);
-
-        let rlp_header = alloy::rlp::Header {
-            list: true,
-            payload_length: fields.len(),
-        };
-
-        let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
-        out.put_u8(0x78);
-        rlp_header.encode(&mut out);
-        out.extend_from_slice(&fields);
-
-        out
-    }
-
     /// Helper: build a valid TempoTransaction for fee payer tests.
     fn make_fee_payer_tx(valid_before_secs_from_now: u64) -> tempo_primitives::TempoTransaction {
         let now = std::time::SystemTime::now()
@@ -1084,22 +942,24 @@ mod tests {
         }
     }
 
-    /// Helper: sign a tx and build a 0x78 envelope.
-    fn sign_and_encode_fee_payer_envelope(
-        tx: &tempo_primitives::TempoTransaction,
+    /// Helper: sign a tx and encode as standard 0x76.
+    fn sign_and_encode(
+        tx: tempo_primitives::TempoTransaction,
         signer: &alloy_signer_local::PrivateKeySigner,
     ) -> Vec<u8> {
+        use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
 
         let sig_hash = tx.signature_hash();
         let sig = signer.sign_hash_sync(&sig_hash).unwrap();
-        build_fee_payer_envelope(tx, signer.address(), sig.into())
+        let signed = tx.into_signed(sig.into());
+        signed.encoded_2718()
     }
 
-    /// Round-trip: encode_fee_payer_envelope → cosign_fee_payer_transaction
-    /// succeeds and produces a valid 0x76 transaction.
+    /// Round-trip: sign 0x76 → cosign_fee_payer_transaction
+    /// succeeds and produces a valid co-signed 0x76 transaction.
     #[test]
-    fn test_fee_payer_envelope_round_trip() {
+    fn test_fee_payer_round_trip() {
         use alloy::eips::Decodable2718;
 
         let client_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1109,14 +969,14 @@ mod tests {
             .unwrap();
 
         let tx = make_fee_payer_tx(60);
-        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+        let encoded = sign_and_encode(tx, &client_signer);
 
-        // Verify it starts with 0x78
-        assert_eq!(envelope[0], 0x78);
+        // Verify it starts with 0x76
+        assert_eq!(
+            encoded[0],
+            tempo_primitives::transaction::TEMPO_TX_TYPE_ID
+        );
 
-        // Create a dummy ChargeMethod to call cosign_fee_payer_transaction.
-        // We need a Provider<TempoNetwork>, but cosign doesn't use it — use
-        // a mock HTTP provider that we never call.
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
                 .connect_http("http://127.0.0.1:1".parse().unwrap());
@@ -1124,12 +984,12 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &envelope,
+            &encoded,
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let co_signed = result.expect("cosign should succeed for valid 0x78 envelope");
+        let co_signed = result.expect("cosign should succeed for valid 0x76 tx");
 
         // Result should be a valid 0x76 transaction
         assert_eq!(
@@ -1150,9 +1010,9 @@ mod tests {
         assert!(decoded_tx.valid_before.is_some());
     }
 
-    /// cosign_fee_payer_transaction rejects a standard 0x76 transaction.
+    /// cosign_fee_payer_transaction rejects a tx without fee_payer_signature placeholder.
     #[test]
-    fn test_cosign_rejects_0x76_input() {
+    fn test_cosign_rejects_no_placeholder() {
         use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
 
@@ -1162,16 +1022,14 @@ mod tests {
             .parse()
             .unwrap();
 
-        let tx = make_fee_payer_tx(60);
+        // Build a tx WITHOUT fee_payer_signature placeholder
+        let mut tx = make_fee_payer_tx(60);
+        tx.fee_payer_signature = None;
+
         let sig_hash = tx.signature_hash();
         let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
         let signed = tx.into_signed(sig.into());
-        let encoded_0x76 = signed.encoded_2718();
-
-        assert_eq!(
-            encoded_0x76[0],
-            tempo_primitives::transaction::TEMPO_TX_TYPE_ID
-        );
+        let encoded = signed.encoded_2718();
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1180,20 +1038,19 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &encoded_0x76,
+            &encoded,
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject 0x76 input");
+        let err = result.expect_err("should reject tx without placeholder");
         assert!(
-            err.to_string()
-                .contains("Expected fee payer envelope (0x78)"),
-            "error should mention 0x78, got: {err}"
+            err.to_string().contains("fee_payer_signature placeholder"),
+            "error should mention placeholder, got: {err}"
         );
     }
 
-    /// cosign_fee_payer_transaction rejects envelopes with wrong nonce_key.
+    /// cosign_fee_payer_transaction rejects txs with wrong nonce_key.
     #[test]
     fn test_cosign_rejects_wrong_nonce_key() {
         let client_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1205,7 +1062,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.nonce_key = U256::ZERO; // Wrong — should be U256::MAX
 
-        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+        let encoded = sign_and_encode(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1214,7 +1071,7 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &envelope,
+            &encoded,
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
@@ -1226,7 +1083,7 @@ mod tests {
         );
     }
 
-    /// cosign_fee_payer_transaction rejects envelopes without valid_before.
+    /// cosign_fee_payer_transaction rejects txs without valid_before.
     #[test]
     fn test_cosign_rejects_missing_valid_before() {
         let client_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1238,7 +1095,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.valid_before = None; // Missing
 
-        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+        let encoded = sign_and_encode(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1247,7 +1104,7 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &envelope,
+            &encoded,
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
@@ -1259,7 +1116,7 @@ mod tests {
         );
     }
 
-    /// cosign_fee_payer_transaction rejects envelopes with expired valid_before.
+    /// cosign_fee_payer_transaction rejects txs with expired valid_before.
     #[test]
     fn test_cosign_rejects_expired_valid_before() {
         let client_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1278,7 +1135,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.valid_before = Some(past);
 
-        let envelope = sign_and_encode_fee_payer_envelope(&tx, &client_signer);
+        let encoded = sign_and_encode(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1287,7 +1144,7 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &envelope,
+            &encoded,
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
@@ -1323,6 +1180,34 @@ mod tests {
         assert!(
             err.to_string().contains("Empty transaction bytes"),
             "error should mention empty, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects non-0x76 type byte.
+    #[test]
+    fn test_cosign_rejects_wrong_type_byte() {
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &[0x78, 0xc0], // wrong type byte
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject 0x78 input");
+        assert!(
+            err.to_string()
+                .contains("Expected Tempo transaction (0x76)"),
+            "error should mention 0x76, got: {err}"
         );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -390,12 +390,15 @@ where
         }
 
         // Skip type byte (0x76 or 0x78) for Tempo transactions
-        let tx_data =
-            if !tx_bytes.is_empty() && (tx_bytes[0] == 0x76 || tx_bytes[0] == 0x78) {
-                &tx_bytes[1..]
-            } else {
-                tx_bytes
-            };
+        let tx_data = if !tx_bytes.is_empty()
+            && (tx_bytes[0] == tempo_primitives::transaction::TEMPO_TX_TYPE_ID
+                || tx_bytes[0]
+                    == tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE)
+        {
+            &tx_bytes[1..]
+        } else {
+            tx_bytes
+        };
 
         // Decode the signed Tempo transaction (AASigned = tx fields + signature).
         let signed = tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..])
@@ -500,7 +503,6 @@ where
             .parse::<Bytes>()
             .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {}", e)))?;
 
-        // Pre-broadcast validation: verify transaction contains expected payment call
         let expected_recipient = charge.recipient_address().map_err(|e| {
             VerificationError::new(format!("Invalid recipient address in request: {}", e))
         })?;
@@ -512,16 +514,10 @@ where
         })?;
         let memo = charge.memo();
 
-        self.validate_transaction(
-            &tx_bytes,
-            currency,
-            expected_recipient,
-            expected_amount,
-            memo.as_deref(),
-            expected_chain_id,
-        )?;
-
-        // Fee payer co-signing: decode the client tx, set fee_token, co-sign, re-encode
+        // Fee payer co-signing must happen before validation because the 0x78
+        // envelope contains a sender address in the fee_payer_signature slot,
+        // which AASigned::rlp_decode cannot parse. Co-signing converts it to a
+        // standard 0x76 transaction that validate_transaction can decode.
         let final_tx_bytes = if charge.fee_payer() {
             let fee_payer_signer = self.fee_payer_signer.as_ref().ok_or_else(|| {
                 VerificationError::new(
@@ -534,6 +530,15 @@ where
         } else {
             tx_bytes.to_vec()
         };
+
+        self.validate_transaction(
+            &final_tx_bytes,
+            currency,
+            expected_recipient,
+            expected_amount,
+            memo.as_deref(),
+            expected_chain_id,
+        )?;
 
         let pending = self
             .provider
@@ -558,60 +563,167 @@ where
 
     /// Co-sign a fee payer transaction.
     ///
-    /// Handles both 0x78 (fee payer envelope) and 0x76 (standard) formats.
-    /// Decodes the client-signed transaction, recovers the sender, sets the fee_token,
-    /// computes the fee payer signature hash (0x78 domain), signs it, and re-encodes
-    /// as a standard 0x76 transaction with both signatures.
+    /// Requires a 0x78 fee payer envelope from the client. The 0x78 format
+    /// places the sender address in the fee_payer_signature slot, which
+    /// standard `AASigned::rlp_decode` cannot parse. This method manually
+    /// decodes the RLP, extracts the sender address, then rebuilds and
+    /// co-signs as a standard 0x76 transaction.
     fn cosign_fee_payer_transaction(
         &self,
         tx_bytes: &[u8],
         fee_payer_signer: &alloy_signer_local::PrivateKeySigner,
         fee_token: Address,
     ) -> Result<Vec<u8>, VerificationError> {
-        use alloy::consensus::transaction::SignerRecoverable;
         use alloy::eips::Encodable2718;
+        use alloy::rlp::Decodable;
         use alloy::signers::SignerSync;
+        use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         if tx_bytes.is_empty() {
             return Err(VerificationError::new("Empty transaction bytes"));
         }
 
-        // Both 0x78 (fee payer envelope) and 0x76 (standard) formats use the
-        // same RLP field layout. The AASigned decoder handles both — the
-        // fee_payer_signature slot may contain a sender address (0x78 format)
-        // or a placeholder (0x76 format), both of which decode successfully.
+        // Require 0x78 fee payer envelope — reject standard 0x76 or untyped.
         let type_byte = tx_bytes[0];
-        let rlp_data = if type_byte == 0x76 || type_byte == 0x78 {
-            &tx_bytes[1..]
+        if type_byte
+            != tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE
+        {
+            return Err(VerificationError::new(format!(
+                "Expected fee payer envelope (0x78), got 0x{type_byte:02x}"
+            )));
+        }
+
+        let mut rlp_data = &tx_bytes[1..];
+
+        // Decode the outer RLP list header
+        let header = alloy::rlp::Header::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode RLP header: {e}")))?;
+        if !header.list {
+            return Err(VerificationError::new(
+                "Expected RLP list for fee payer envelope",
+            ));
+        }
+
+        // Decode fields in the same order as rlp_encode_fields:
+        // chain_id, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+        // calls, access_list, nonce_key, nonce, valid_before, valid_after,
+        // fee_token, fee_payer_signature_slot (sender addr), authorization_list,
+        // [key_authorization], client_signature
+        let chain_id: u64 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode chain_id: {e}")))?;
+        let max_priority_fee_per_gas: u128 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode gas fields: {e}")))?;
+        let max_fee_per_gas: u128 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode gas fields: {e}")))?;
+        let gas_limit: u64 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode gas_limit: {e}")))?;
+        let calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode calls: {e}")))?;
+        let access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode access_list: {e}")))?;
+        let nonce_key: U256 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode nonce_key: {e}")))?;
+        let nonce: u64 = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode nonce: {e}")))?;
+
+        // valid_before / valid_after: 0x80 = None, otherwise u64
+        let valid_before: Option<u64> = if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE)
+        {
+            rlp_data = &rlp_data[1..];
+            None
         } else {
-            tx_bytes
+            Some(Decodable::decode(&mut rlp_data).map_err(|e| {
+                VerificationError::new(format!("Failed to decode valid_before: {e}"))
+            })?)
+        };
+        let valid_after: Option<u64> = if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE) {
+            rlp_data = &rlp_data[1..];
+            None
+        } else {
+            Some(Decodable::decode(&mut rlp_data).map_err(|e| {
+                VerificationError::new(format!("Failed to decode valid_after: {e}"))
+            })?)
         };
 
-        // Decode the signed transaction (AASigned = tx fields + sender signature)
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &rlp_data[..])
-            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
+        // fee_token: should be empty (0x80) in fee payer envelope
+        if rlp_data.first() == Some(&alloy::rlp::EMPTY_STRING_CODE) {
+            rlp_data = &rlp_data[1..];
+        } else {
+            return Err(VerificationError::new(
+                "Fee payer envelope must not include fee_token (server sets it)",
+            ));
+        }
 
-        // Recover the sender address from the client's signature
-        let sender = signed
-            .recover_signer()
-            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {}", e)))?;
+        // fee_payer_signature slot: contains sender address (20 bytes) in 0x78 format
+        let sender: Address = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode sender address: {e}")))?;
 
-        let client_signature = signed.signature().clone();
-        let mut tx = signed.into_parts().0;
+        // authorization_list
+        let tempo_authorization_list: Vec<tempo_primitives::transaction::TempoSignedAuthorization> =
+            Decodable::decode(&mut rlp_data).map_err(|e| {
+                VerificationError::new(format!("Failed to decode authorization_list: {e}"))
+            })?;
 
-        // Set the fee token (server chooses which token to pay gas with)
-        tx.fee_token = Some(fee_token);
+        // key_authorization (optional — only present if next byte starts an RLP list)
+        let key_authorization: Option<
+            tempo_primitives::transaction::key_authorization::SignedKeyAuthorization,
+        > = if let Some(&first) = rlp_data.first() {
+            if first >= 0xc0 {
+                Some(Decodable::decode(&mut rlp_data).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode key_authorization: {e}"))
+                })?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
 
-        // Compute the fee payer signature hash (0x78 domain) and sign
+        // Client signature (remaining bytes)
+        let sig_bytes: alloy::primitives::Bytes = Decodable::decode(&mut rlp_data)
+            .map_err(|e| VerificationError::new(format!("Failed to decode signature: {e}")))?;
+        let client_signature =
+            tempo_primitives::transaction::TempoSignature::from_bytes(&sig_bytes)
+                .map_err(|e| VerificationError::new(format!("Invalid client signature: {e}")))?;
+
+        // Validate fee-payer invariants
+        if nonce_key != TEMPO_EXPIRING_NONCE_KEY {
+            return Err(VerificationError::new(
+                "Fee payer envelope must use expiring nonce key (U256::MAX)",
+            ));
+        }
+        if valid_before.is_none() {
+            return Err(VerificationError::new(
+                "Fee payer envelope must include valid_before",
+            ));
+        }
+
+        // Rebuild the transaction with fee_token set
+        let mut tx = tempo_primitives::TempoTransaction {
+            chain_id,
+            nonce,
+            nonce_key,
+            gas_limit,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            fee_token: Some(fee_token),
+            fee_payer_signature: None,
+            valid_before,
+            valid_after,
+            calls,
+            access_list,
+            tempo_authorization_list,
+            key_authorization,
+        };
+
+        // Compute the fee payer signature hash and co-sign
         let fp_hash = tx.fee_payer_signature_hash(sender);
         let fp_sig = fee_payer_signer
             .sign_hash_sync(&fp_hash)
-            .map_err(|e| VerificationError::new(format!("Failed to co-sign transaction: {}", e)))?;
+            .map_err(|e| VerificationError::new(format!("Failed to co-sign transaction: {e}")))?;
 
-        // Set the real fee payer signature (replacing the placeholder)
         tx.fee_payer_signature = Some(fp_sig);
 
-        // Re-encode as standard 0x76 transaction with both signatures
         let signed_tx = tx.into_signed(client_signature);
         Ok(signed_tx.encoded_2718())
     }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -972,10 +972,7 @@ mod tests {
         let encoded = sign_and_encode(tx, &client_signer);
 
         // Verify it starts with 0x76
-        assert_eq!(
-            encoded[0],
-            tempo_primitives::transaction::TEMPO_TX_TYPE_ID
-        );
+        assert_eq!(encoded[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -257,10 +257,7 @@ fn encode_fee_payer_envelope_for_test(
 }
 
 /// Query TIP-20 pathUSD balance for an address.
-async fn tip20_balance(
-    provider: &impl Provider<TempoNetwork>,
-    addr: Address,
-) -> U256 {
+async fn tip20_balance(provider: &impl Provider<TempoNetwork>, addr: Address) -> U256 {
     let balance_call = ITIP20::balanceOfCall::new((addr,)).abi_encode();
     let result = provider
         .call(
@@ -1065,8 +1062,7 @@ async fn test_fee_payer_wrong_recipient_rejected() {
     let currency: Address = charge.currency.parse().unwrap();
 
     // Build transferWithMemo to wrong_recipient instead of server_signer
-    let transfer_data =
-        ITIP20::transferCall::new((wrong_recipient.address(), amount)).abi_encode();
+    let transfer_data = ITIP20::transferCall::new((wrong_recipient.address(), amount)).abi_encode();
 
     let provider_http =
         ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
@@ -1195,11 +1191,13 @@ async fn test_fee_payer_balance_accounting() {
         "client pathUSD should decrease by at least {charge_amount}, but decreased by {client_decrease}"
     );
 
-    // Server (recipient) should receive the payment amount.
+    // Server is both recipient and fee payer. Its net change is:
+    //   +charge_amount (received payment) - gas_cost (paid gas in pathUSD)
+    // So the server's balance should increase, but by less than charge_amount.
     let server_increase = server_balance_after - server_balance_before;
     assert!(
-        server_increase >= charge_amount,
-        "server pathUSD should increase by at least {charge_amount}, but increased by {server_increase}"
+        !server_increase.is_zero(),
+        "server pathUSD should increase (received payment minus gas), but didn't change"
     );
 
     // In fee payer mode, the fee payer (server) pays gas. The client's decrease

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -773,3 +773,223 @@ async fn test_client_balance_decreases_after_payment() {
     handle.abort();
     let _ = handle.await;
 }
+
+// ==================== Fee payer vs non-fee-payer tests ====================
+
+/// E2E round-trip WITHOUT fee payer: client signs a standard 0x76 transaction
+/// and broadcasts it directly. Server verifies on-chain.
+#[tokio::test]
+async fn test_e2e_charge_without_fee_payer() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    // Server configured WITHOUT fee_payer
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("no-fee-payer-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("non-fee-payer payment failed");
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200 after successful non-fee-payer payment"
+    );
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
+    assert_eq!(receipt.method.as_str(), "tempo");
+    assert!(receipt.reference.starts_with("0x"));
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "paid content");
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// E2E round-trip WITH fee payer: client signs a 0x78 fee payer envelope,
+/// server co-signs and broadcasts as 0x76.
+#[tokio::test]
+async fn test_e2e_charge_with_fee_payer() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer)
+        .secret_key("fee-payer-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("fee-payer payment failed");
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "expected 200 after successful fee-payer payment"
+    );
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
+    assert_eq!(receipt.method.as_str(), "tempo");
+    assert!(receipt.reference.starts_with("0x"));
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "paid content");
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Fee payer requested but server has no signer configured → 402.
+#[tokio::test]
+async fn test_fee_payer_requested_but_no_signer_returns_402() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    // Enable fee_payer in challenges but do NOT set a fee_payer_signer
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .secret_key("no-signer-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        402,
+        "fee payer requested without signer should return 402"
+    );
+    assert!(
+        resp.headers().contains_key("www-authenticate"),
+        "should return a fresh challenge for retry"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Fee-payer-enabled server handles premium ($1) charges correctly.
+#[tokio::test]
+async fn test_e2e_fee_payer_premium_charge() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer)
+        .secret_key("fee-payer-premium-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/premium"))
+        .send_with_payment(&provider)
+        .await
+        .expect("fee-payer premium payment failed");
+
+    assert_eq!(resp.status(), 200);
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["message"], "premium content");
+    assert_eq!(body["tier"], "gold");
+
+    handle.abort();
+    let _ = handle.await;
+}

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -203,6 +203,79 @@ async fn fund_account(rpc: &str, to: Address) {
     .await;
 }
 
+// ==================== Fee payer test helpers ====================
+
+/// Encode a 0x78 fee payer envelope for testing (mirrors encode_fee_payer_envelope
+/// in provider.rs which is private).
+fn encode_fee_payer_envelope_for_test(
+    tx: &TempoTransaction,
+    sender: Address,
+    signature: tempo_primitives::transaction::TempoSignature,
+) -> Vec<u8> {
+    use alloy::primitives::bytes::BufMut;
+    use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
+
+    let mut fields = Vec::new();
+
+    tx.chain_id.encode(&mut fields);
+    tx.max_priority_fee_per_gas.encode(&mut fields);
+    tx.max_fee_per_gas.encode(&mut fields);
+    tx.gas_limit.encode(&mut fields);
+    tx.calls.encode(&mut fields);
+    tx.access_list.encode(&mut fields);
+    tx.nonce_key.encode(&mut fields);
+    tx.nonce.encode(&mut fields);
+
+    if let Some(vb) = tx.valid_before {
+        vb.encode(&mut fields);
+    } else {
+        fields.put_u8(EMPTY_STRING_CODE);
+    }
+    if let Some(va) = tx.valid_after {
+        va.encode(&mut fields);
+    } else {
+        fields.put_u8(EMPTY_STRING_CODE);
+    }
+    fields.put_u8(EMPTY_STRING_CODE); // feeToken — always empty
+    sender.encode(&mut fields); // fee_payer_signature slot
+    tx.tempo_authorization_list.encode(&mut fields);
+    if let Some(key_auth) = &tx.key_authorization {
+        key_auth.encode(&mut fields);
+    }
+    signature.encode(&mut fields);
+
+    let rlp_header = alloy::rlp::Header {
+        list: true,
+        payload_length: fields.len(),
+    };
+
+    let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
+    out.put_u8(0x78);
+    rlp_header.encode(&mut out);
+    out.extend_from_slice(&fields);
+    out
+}
+
+/// Query TIP-20 pathUSD balance for an address.
+async fn tip20_balance(
+    provider: &impl Provider<TempoNetwork>,
+    addr: Address,
+) -> U256 {
+    let balance_call = ITIP20::balanceOfCall::new((addr,)).abi_encode();
+    let result = provider
+        .call(
+            alloy::rpc::types::TransactionRequest::default()
+                .to(PATH_USD)
+                .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
+                    balance_call,
+                )))
+                .into(),
+        )
+        .await
+        .expect("balanceOf call failed");
+    U256::from_be_slice(&result)
+}
+
 // ==================== ChargeConfig types ====================
 
 struct OneCent;
@@ -935,6 +1008,207 @@ async fn test_fee_payer_requested_but_no_signer_returns_402() {
     assert!(
         resp.headers().contains_key("www-authenticate"),
         "should return a fresh challenge for retry"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Fee payer with malicious 0x78 envelope (wrong recipient) → server rejects with 402.
+/// The server co-signs (it can't avoid it) but validate_transaction catches the
+/// wrong recipient before broadcasting.
+#[tokio::test]
+async fn test_fee_payer_wrong_recipient_rejected() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+    let wrong_recipient = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer.clone())
+        .secret_key("wrong-recipient-fp-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    // Step 1: Get a 402 challenge.
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 402);
+
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let challenge = mpp::parse_www_authenticate(www_auth).expect("failed to parse challenge");
+
+    // Step 2: Build a 0x78 fee payer envelope that sends to the WRONG recipient.
+    let charge: mpp::ChargeRequest = challenge.request.decode().unwrap();
+    let amount: U256 = charge.amount.parse().unwrap();
+    let currency: Address = charge.currency.parse().unwrap();
+
+    // Build transferWithMemo to wrong_recipient instead of server_signer
+    let transfer_data =
+        ITIP20::transferCall::new((wrong_recipient.address(), amount)).abi_encode();
+
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+    let gas_price = provider_http
+        .get_gas_price()
+        .await
+        .expect("failed to get gas price");
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let tx = TempoTransaction {
+        chain_id,
+        nonce: 0,
+        nonce_key: U256::MAX,
+        gas_limit: 1_000_000,
+        max_fee_per_gas: gas_price,
+        max_priority_fee_per_gas: gas_price,
+        fee_token: None,
+        fee_payer_signature: Some(alloy::primitives::Signature::new(
+            U256::ZERO,
+            U256::ZERO,
+            false,
+        )),
+        valid_before: Some(now + 25),
+        valid_after: None,
+        calls: vec![Call {
+            to: TxKind::Call(currency),
+            value: U256::ZERO,
+            input: Bytes::from(transfer_data),
+        }],
+        ..Default::default()
+    };
+
+    // Sign and encode as 0x78 envelope
+    let sig_hash = tx.signature_hash();
+    let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
+
+    let tx_bytes = encode_fee_payer_envelope_for_test(&tx, client_signer.address(), sig.into());
+    let signed_tx_hex = format!("0x{}", hex::encode(&tx_bytes));
+
+    // Step 3: Build a credential with the malicious envelope.
+    let echo = challenge.to_echo();
+    let credential = mpp::PaymentCredential::with_source(
+        echo,
+        format!("did:pkh:eip155:{}:{}", chain_id, client_signer.address()),
+        mpp::PaymentPayload::transaction(signed_tx_hex),
+    );
+    let auth_header =
+        mpp::format_authorization(&credential).expect("failed to format authorization");
+
+    // Step 4: Submit — should be rejected with 402.
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .header("authorization", &auth_header)
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        402,
+        "wrong-recipient fee payer envelope should be rejected"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Verify that with fee payer enabled, the client's pathUSD balance decreases
+/// (payment amount) while the fee payer's native/pathUSD balance is used for gas.
+#[tokio::test]
+async fn test_fee_payer_balance_accounting() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+
+    // Record balances before payment.
+    let client_balance_before = tip20_balance(&provider_http, client_signer.address()).await;
+    let server_balance_before = tip20_balance(&provider_http, server_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer.clone())
+        .secret_key("balance-accounting-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider =
+        TempoProvider::new(client_signer.clone(), &rpc).expect("failed to create TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("fee-payer payment failed");
+    assert_eq!(resp.status(), 200);
+
+    // Record balances after payment.
+    let client_balance_after = tip20_balance(&provider_http, client_signer.address()).await;
+    let server_balance_after = tip20_balance(&provider_http, server_signer.address()).await;
+
+    let charge_amount = U256::from(10_000u64); // $0.01 with 6 decimals
+
+    // Client's pathUSD should decrease by at least the charge amount.
+    let client_decrease = client_balance_before - client_balance_after;
+    assert!(
+        client_decrease >= charge_amount,
+        "client pathUSD should decrease by at least {charge_amount}, but decreased by {client_decrease}"
+    );
+
+    // Server (recipient) should receive the payment amount.
+    let server_increase = server_balance_after - server_balance_before;
+    assert!(
+        server_increase >= charge_amount,
+        "server pathUSD should increase by at least {charge_amount}, but increased by {server_increase}"
+    );
+
+    // In fee payer mode, the fee payer (server) pays gas. The client's decrease
+    // should be exactly the charge amount — no gas cost for the client.
+    // Allow a small tolerance in case of rounding.
+    assert_eq!(
+        client_decrease, charge_amount,
+        "in fee payer mode, client should only pay the charge amount (no gas), \
+         but client balance decreased by {client_decrease} instead of {charge_amount}"
     );
 
     handle.abort();


### PR DESCRIPTION
## Summary

Implements full fee payer support in mpp-rs, compatible with the mppx TypeScript server.

### Client-side (`TempoProvider::pay`)
When `feePayer: true` in the challenge's `methodDetails`:
- Uses **expiring nonces** (`nonce_key=U256::MAX`, `nonce=0`, `valid_before=now+25s`) to avoid nonce collisions when the server broadcasts
- Sets `fee_payer_signature` placeholder → triggers `skip_fee_token` in the signing hash so the client does NOT commit to a fee token
- Serializes as a **0x78 fee payer envelope** with the sender address in the fee payer slot (matching viem/ox behavior)

### Server-side (`ChargeMethod::broadcast_transaction`)
New `cosign_fee_payer_transaction()` method:
1. Decodes the client-signed 0x78 (or 0x76) transaction
2. Recovers the sender address from the client's signature
3. Sets `fee_token` to the charge currency (e.g., pathUSD)
4. Computes the fee payer signature hash (0x78 domain) and co-signs
5. Re-encodes as standard 0x76 with both signatures for broadcast

### Testing
Verified end-to-end against `mpp.sh/api/ping/paid` via purl — payment succeeds with 200 OK.

```
PURL_PASSWORD=testpass123 ./target/debug/purl 'https://mpp.sh/api/ping/paid' -vv
...
Response Status: 200
tm! thanks for paying
```