### PR TITLE
feat: auto-detect realm from environment variables

### DIFF
--- a/.changelog/dry-whales-write.md
+++ b/.changelog/dry-whales-write.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Added auto-detection of `realm` from environment variables in `Mpp::create()`. Checks `MPP_REALM`, `FLY_APP_NAME`, `HEROKU_APP_NAME`, `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`, `VERCEL_URL`, and `WEBSITE_HOSTNAME` in order, falling back to `"MPP Payment"`.

--- a/.changelog/warm-clouds-detect.md
+++ b/.changelog/warm-clouds-detect.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Auto-detect `realm` from environment variables in `Mpp::create()`. Checks `MPP_REALM`, `FLY_APP_NAME`, `HEROKU_APP_NAME`, `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`, `VERCEL_URL`, `WEBSITE_HOSTNAME` in order, falling back to `"MPP Payment"`.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -108,7 +108,7 @@ impl TempoBuilder {
         self
     }
 
-    /// Override the realm (default: `"MPP Payment"`).
+    /// Override the realm (default: auto-detected from environment variables).
     pub fn realm(mut self, realm: &str) -> Self {
         self.realm = realm.to_string();
         self
@@ -182,7 +182,9 @@ pub struct ChargeOptions<'a> {
 /// # Defaults
 ///
 /// - **rpc_url**: `https://rpc.tempo.xyz`
-/// - **realm**: `"MPP Payment"`
+/// - **realm**: auto-detected from `MPP_REALM`, `FLY_APP_NAME`, `HEROKU_APP_NAME`,
+///   `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`,
+///   `VERCEL_URL`, `WEBSITE_HOSTNAME` — falling back to `"MPP Payment"`
 /// - **secret_key**: reads `MPP_SECRET_KEY` env var, or generates a random UUID
 /// - **currency**: pathUSD (`0x20c0000000000000000000000000000000000000`)
 /// - **decimals**: `6` (for pathUSD / standard stablecoins)
@@ -216,7 +218,7 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         currency: crate::protocol::methods::tempo::DEFAULT_CURRENCY.to_string(),
         recipient: config.recipient.to_string(),
         rpc_url: crate::protocol::methods::tempo::DEFAULT_RPC_URL.to_string(),
-        realm: "MPP Payment".to_string(),
+        realm: mpp::detect_realm(),
         secret_key: None,
         decimals: 6,
         fee_payer: false,

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -26,6 +26,36 @@ use crate::protocol::traits::{ChargeMethod, VerificationError};
 const SECRET_KEY_ENV_VAR: &str = "MPP_SECRET_KEY";
 const DEFAULT_DECIMALS: u32 = 6;
 
+/// Environment variables checked (in order) to auto-detect the server realm.
+const REALM_ENV_VARS: &[&str] = &[
+    "MPP_REALM",
+    "FLY_APP_NAME",
+    "HEROKU_APP_NAME",
+    "HOST",
+    "HOSTNAME",
+    "RAILWAY_PUBLIC_DOMAIN",
+    "RENDER_EXTERNAL_HOSTNAME",
+    "VERCEL_URL",
+    "WEBSITE_HOSTNAME",
+];
+
+const DEFAULT_REALM: &str = "MPP Payment";
+
+/// Detect the server realm from environment variables.
+///
+/// Checks platform-specific env vars in order (see [`REALM_ENV_VARS`]),
+/// falling back to `"MPP Payment"`.
+fn detect_realm() -> String {
+    for name in REALM_ENV_VARS {
+        if let Ok(value) = std::env::var(name) {
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+    DEFAULT_REALM.to_string()
+}
+
 /// Result of session verification, including optional management response.
 pub struct SessionVerifyResult {
     /// The payment receipt.


### PR DESCRIPTION
Ports wevm/mpay#113 to mpp-rs.

Adds `detect_realm()` that checks platform-specific env vars in order, falling back to `"MPP Payment"`:

- `MPP_REALM`
- `FLY_APP_NAME`
- `HEROKU_APP_NAME`
- `HOST`
- `HOSTNAME`
- `RAILWAY_PUBLIC_DOMAIN`
- `RENDER_EXTERNAL_HOSTNAME`
- `VERCEL_URL`
- `WEBSITE_HOSTNAME`

The `tempo()` builder now calls `detect_realm()` instead of hardcoding `"MPP Payment"`. The `.realm()` builder method still allows explicit overrides.