### PR TITLE
fix: make detect_realm pub(crate) to fix compilation

### DIFF
--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -45,7 +45,7 @@ const DEFAULT_REALM: &str = "MPP Payment";
 ///
 /// Checks platform-specific env vars in order (see [`REALM_ENV_VARS`]),
 /// falling back to `"MPP Payment"`.
-fn detect_realm() -> String {
+pub(crate) fn detect_realm() -> String {
     for name in REALM_ENV_VARS {
         if let Ok(value) = std::env::var(name) {
             if !value.is_empty() {


### PR DESCRIPTION
The `detect_realm()` function in `server/mpp.rs` was private but called from `server/mod.rs` in the `tempo()` builder function, causing a compilation error:

```
error[E0603]: function `detect_realm` is private
```

Changed visibility to `pub(crate)` to fix the build.