### PR TITLE
rename stream → session in problem type URIs, types, and docs

### DIFF
--- a/src/client/tempo/channel_ops.rs
+++ b/src/client/tempo/channel_ops.rs
@@ -1,4 +1,4 @@
-//! Shared client-side channel operations for Tempo streaming payments.
+//! Shared client-side channel operations for Tempo session payments.
 //!
 //! Provides low-level helpers for escrow resolution, channel ID computation,
 //! voucher/close/open payload construction, channel recovery from on-chain state,

--- a/src/client/tempo/session_provider.rs
+++ b/src/client/tempo/session_provider.rs
@@ -183,7 +183,7 @@ impl TempoSessionProvider {
 
     /// Send a voucher for a need-voucher SSE event.
     ///
-    /// Called during SSE streaming when the server emits a `payment-need-voucher`
+    /// Called during SSE session metering when the server emits a `payment-need-voucher`
     /// event. Updates the internal cumulative amount and POSTs a signed voucher
     /// credential to the server.
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,12 @@ pub type Result<T> = std::result::Result<T, MppError>;
 /// Base URI for core payment-auth problem types.
 pub const CORE_PROBLEM_TYPE_BASE: &str = "https://tempoxyz.github.io/payment-auth-spec/problems";
 
-/// Base URI for stream/channel problem types.
-pub const STREAM_PROBLEM_TYPE_BASE: &str = "https://paymentauth.org/problems/stream";
+/// Base URI for session/channel problem types.
+pub const SESSION_PROBLEM_TYPE_BASE: &str = "https://paymentauth.org/problems/session";
+
+/// Deprecated: use [`SESSION_PROBLEM_TYPE_BASE`] instead. Remove in next major version.
+#[deprecated(since = "0.5.0", note = "renamed to SESSION_PROBLEM_TYPE_BASE")]
+pub const STREAM_PROBLEM_TYPE_BASE: &str = SESSION_PROBLEM_TYPE_BASE;
 
 /// RFC 9457 Problem Details structure for payment errors.
 ///
@@ -75,11 +79,17 @@ impl PaymentErrorDetails {
         Self::new(format!("{}/{}", CORE_PROBLEM_TYPE_BASE, suffix))
     }
 
-    /// Create a PaymentErrorDetails for a stream/channel problem.
+    /// Create a PaymentErrorDetails for a session/channel problem.
     ///
-    /// The full type URI will be `{STREAM_PROBLEM_TYPE_BASE}/{suffix}`.
+    /// The full type URI will be `{SESSION_PROBLEM_TYPE_BASE}/{suffix}`.
+    pub fn session(suffix: impl std::fmt::Display) -> Self {
+        Self::new(format!("{}/{}", SESSION_PROBLEM_TYPE_BASE, suffix))
+    }
+
+    /// Deprecated: use [`PaymentErrorDetails::session`] instead. Remove in next major version.
+    #[deprecated(since = "0.5.0", note = "renamed to session()")]
     pub fn stream(suffix: impl std::fmt::Display) -> Self {
-        Self::new(format!("{}/{}", STREAM_PROBLEM_TYPE_BASE, suffix))
+        Self::session(suffix)
     }
 
     /// Set the title.
@@ -518,13 +528,13 @@ impl MppError {
             Self::PaymentRequired { .. } => Some("payment-required"),
             Self::InvalidPayload(_) => Some("invalid-payload"),
             Self::BadRequest(_) => Some("bad-request"),
-            Self::InsufficientBalance(_) => Some("stream/insufficient-balance"),
-            Self::InvalidSignature(_) => Some("stream/invalid-signature"),
-            Self::SignerMismatch(_) => Some("stream/signer-mismatch"),
-            Self::AmountExceedsDeposit(_) => Some("stream/amount-exceeds-deposit"),
-            Self::DeltaTooSmall(_) => Some("stream/delta-too-small"),
-            Self::ChannelNotFound(_) => Some("stream/channel-not-found"),
-            Self::ChannelClosed(_) => Some("stream/channel-finalized"),
+            Self::InsufficientBalance(_) => Some("session/insufficient-balance"),
+            Self::InvalidSignature(_) => Some("session/invalid-signature"),
+            Self::SignerMismatch(_) => Some("session/signer-mismatch"),
+            Self::AmountExceedsDeposit(_) => Some("session/amount-exceeds-deposit"),
+            Self::DeltaTooSmall(_) => Some("session/delta-too-small"),
+            Self::ChannelNotFound(_) => Some("session/channel-not-found"),
+            Self::ChannelClosed(_) => Some("session/channel-finalized"),
             _ => None,
         }
     }
@@ -560,26 +570,26 @@ impl PaymentError for MppError {
             Self::BadRequest(_) => PaymentErrorDetails::core("bad-request")
                 .with_title("BadRequestError")
                 .with_status(400),
-            // Stream/channel errors
-            Self::InsufficientBalance(_) => PaymentErrorDetails::stream("insufficient-balance")
+            // Session/channel errors
+            Self::InsufficientBalance(_) => PaymentErrorDetails::session("insufficient-balance")
                 .with_title("InsufficientBalanceError")
                 .with_status(402),
-            Self::InvalidSignature(_) => PaymentErrorDetails::stream("invalid-signature")
+            Self::InvalidSignature(_) => PaymentErrorDetails::session("invalid-signature")
                 .with_title("InvalidSignatureError")
                 .with_status(402),
-            Self::SignerMismatch(_) => PaymentErrorDetails::stream("signer-mismatch")
+            Self::SignerMismatch(_) => PaymentErrorDetails::session("signer-mismatch")
                 .with_title("SignerMismatchError")
                 .with_status(402),
-            Self::AmountExceedsDeposit(_) => PaymentErrorDetails::stream("amount-exceeds-deposit")
+            Self::AmountExceedsDeposit(_) => PaymentErrorDetails::session("amount-exceeds-deposit")
                 .with_title("AmountExceedsDepositError")
                 .with_status(402),
-            Self::DeltaTooSmall(_) => PaymentErrorDetails::stream("delta-too-small")
+            Self::DeltaTooSmall(_) => PaymentErrorDetails::session("delta-too-small")
                 .with_title("DeltaTooSmallError")
                 .with_status(402),
-            Self::ChannelNotFound(_) => PaymentErrorDetails::stream("channel-not-found")
+            Self::ChannelNotFound(_) => PaymentErrorDetails::session("channel-not-found")
                 .with_title("ChannelNotFoundError")
                 .with_status(410),
-            Self::ChannelClosed(_) => PaymentErrorDetails::stream("channel-finalized")
+            Self::ChannelClosed(_) => PaymentErrorDetails::session("channel-finalized")
                 .with_title("ChannelClosedError")
                 .with_status(410),
             // Non-payment-problem errors get a generic problem type
@@ -694,15 +704,15 @@ mod tests {
     }
 
     #[test]
-    fn test_problem_details_stream() {
-        let problem = PaymentErrorDetails::stream("insufficient-balance")
+    fn test_problem_details_session() {
+        let problem = PaymentErrorDetails::session("insufficient-balance")
             .with_title("InsufficientBalanceError")
             .with_status(402)
             .with_detail("Insufficient balance.");
 
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/insufficient-balance"
+            "https://paymentauth.org/problems/session/insufficient-balance"
         );
         assert_eq!(problem.title, "InsufficientBalanceError");
         assert_eq!(problem.status, 402);
@@ -868,7 +878,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/insufficient-balance"
+            "https://paymentauth.org/problems/session/insufficient-balance"
         );
         assert_eq!(problem.title, "InsufficientBalanceError");
         assert_eq!(problem.status, 402);
@@ -884,7 +894,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/invalid-signature"
+            "https://paymentauth.org/problems/session/invalid-signature"
         );
         assert_eq!(problem.title, "InvalidSignatureError");
         assert_eq!(problem.status, 402);
@@ -903,7 +913,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/signer-mismatch"
+            "https://paymentauth.org/problems/session/signer-mismatch"
         );
         assert_eq!(problem.title, "SignerMismatchError");
         assert_eq!(problem.status, 402);
@@ -925,7 +935,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/amount-exceeds-deposit"
+            "https://paymentauth.org/problems/session/amount-exceeds-deposit"
         );
         assert_eq!(problem.title, "AmountExceedsDepositError");
         assert_eq!(problem.status, 402);
@@ -941,7 +951,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/delta-too-small"
+            "https://paymentauth.org/problems/session/delta-too-small"
         );
         assert_eq!(problem.title, "DeltaTooSmallError");
         assert_eq!(problem.status, 402);
@@ -960,7 +970,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/channel-not-found"
+            "https://paymentauth.org/problems/session/channel-not-found"
         );
         assert_eq!(problem.title, "ChannelNotFoundError");
         assert_eq!(problem.status, 410);
@@ -979,7 +989,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://paymentauth.org/problems/stream/channel-finalized"
+            "https://paymentauth.org/problems/session/channel-finalized"
         );
         assert_eq!(problem.title, "ChannelClosedError");
         assert_eq!(problem.status, 410);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,12 @@ pub use error::{MppError, Result};
 
 // RFC 9457 Problem Details
 pub use error::{
-    PaymentError, PaymentErrorDetails, CORE_PROBLEM_TYPE_BASE, STREAM_PROBLEM_TYPE_BASE,
+    PaymentError, PaymentErrorDetails, CORE_PROBLEM_TYPE_BASE, SESSION_PROBLEM_TYPE_BASE,
 };
+
+// Deprecated: remove in next major version.
+#[allow(deprecated)]
+pub use error::STREAM_PROBLEM_TYPE_BASE;
 
 // Core protocol types
 pub use protocol::core::{

--- a/src/protocol/intents/mod.rs
+++ b/src/protocol/intents/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides typed request structures for payment intents:
 //!
 //! - [`ChargeRequest`]: One-time payment (charge intent)
-//! - [`SessionRequest`]: Pay-as-you-go streaming payment (session intent)
+//! - [`SessionRequest`]: Pay-as-you-go session payment (session intent)
 //!
 //! **Zero heavy dependencies** - only serde and serde_json. No alloy, no blockchain types.
 //!

--- a/src/protocol/intents/session.rs
+++ b/src/protocol/intents/session.rs
@@ -1,6 +1,6 @@
 //! Session intent request type.
 //!
-//! The session intent represents a pay-as-you-go streaming payment request.
+//! The session intent represents a pay-as-you-go session payment request.
 //! This module provides the `SessionRequest` type with string-only fields -
 //! no typed helpers like `amount_u256()`. Those are provided by the methods layer.
 
@@ -10,7 +10,7 @@ use crate::error::{MppError, Result};
 
 /// Session request (for session intent).
 ///
-/// Represents a pay-as-you-go streaming payment request. All fields are strings
+/// Represents a pay-as-you-go session payment request. All fields are strings
 /// to remain method-agnostic. Use the methods layer for typed accessors.
 ///
 /// # Examples
@@ -36,7 +36,7 @@ pub struct SessionRequest {
     /// Amount per unit in base units (e.g., wei per second)
     pub amount: String,
 
-    /// Unit type for the streaming rate (e.g., "second", "minute", "request"). Optional.
+    /// Unit type for the session rate (e.g., "second", "minute", "request"). Optional.
     #[serde(rename = "unitType", skip_serializing_if = "Option::is_none")]
     pub unit_type: Option<String>,
 

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -98,7 +98,7 @@
 
 pub mod charge;
 pub mod session;
-pub mod stream_receipt;
+pub mod session_receipt;
 pub mod transaction;
 pub mod types;
 pub mod voucher;
@@ -110,7 +110,15 @@ pub mod session_method;
 
 pub use charge::TempoChargeExt;
 pub use session::{SessionCredentialPayload, TempoSessionExt, TempoSessionMethodDetails};
-pub use stream_receipt::StreamReceipt;
+pub use session_receipt::SessionReceipt;
+
+/// Deprecated: use [`session_receipt`] instead. Remove in next major version.
+#[deprecated(since = "0.5.0", note = "renamed to session_receipt")]
+pub use session_receipt as stream_receipt;
+
+/// Deprecated: use [`SessionReceipt`] instead. Remove in next major version.
+#[deprecated(since = "0.5.0", note = "renamed to SessionReceipt")]
+pub type StreamReceipt = SessionReceipt;
 pub use transaction::{
     Call, SignatureType, TempoTransaction, TempoTransactionRequest, TEMPO_SEND_TRANSACTION_METHOD,
     TEMPO_TX_TYPE_ID,

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -1,6 +1,6 @@
 //! Server-side session payment verification for Tempo.
 //!
-//! Implements the `SessionMethod` trait for Tempo streaming payments (pay-as-you-go).
+//! Implements the `SessionMethod` trait for Tempo session payments (pay-as-you-go).
 //! Handles four channel lifecycle actions: open, topUp, voucher, close.
 //!
 //! Ported from the TypeScript SDK's `Session.ts`.
@@ -195,7 +195,7 @@ pub struct SessionMethodConfig {
     pub min_voucher_delta: u128,
 }
 
-/// Tempo session method for server-side streaming payment verification.
+/// Tempo session method for server-side session payment verification.
 ///
 /// Handles four channel lifecycle actions:
 /// - `open`: broadcast open tx, verify initial voucher, create channel in store
@@ -582,7 +582,7 @@ where
 
         // Use cached channel state (verified during open/topUp) instead of
         // reading on-chain for every voucher. This avoids an RPC round-trip
-        // per voucher, critical for high-frequency streaming.
+        // per voucher, critical for high-frequency sessions.
         self.verify_and_accept_voucher(
             channel_id_str,
             &channel,

--- a/src/protocol/methods/tempo/session_receipt.rs
+++ b/src/protocol/methods/tempo/session_receipt.rs
@@ -1,21 +1,21 @@
-//! Stream receipt type for Tempo streaming payments.
+//! Session receipt type for Tempo session payments.
 
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::core::{MethodName, Receipt, ReceiptStatus};
 
-/// Stream receipt for Tempo session/streaming payments.
+/// Session receipt for Tempo session/pay-as-you-go payments.
 ///
-/// Extends the base [`Receipt`] with stream-specific fields like channel ID,
+/// Extends the base [`Receipt`] with session-specific fields like channel ID,
 /// cumulative amounts, and units consumed. The `reference` field mirrors
 /// `channel_id` for compatibility with the base receipt contract.
 ///
 /// # Examples
 ///
 /// ```
-/// use mpp::protocol::methods::tempo::StreamReceipt;
+/// use mpp::protocol::methods::tempo::SessionReceipt;
 ///
-/// let receipt = StreamReceipt::new(
+/// let receipt = SessionReceipt::new(
 ///     "2026-01-01T00:00:00Z",
 ///     "challenge-123",
 ///     "0xabc",
@@ -28,7 +28,7 @@ use crate::protocol::core::{MethodName, Receipt, ReceiptStatus};
 /// assert_eq!(receipt.reference, "0xabc");
 /// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct StreamReceipt {
+pub struct SessionReceipt {
     /// Payment method (always "tempo").
     pub method: String,
 
@@ -68,8 +68,8 @@ pub struct StreamReceipt {
     pub tx_hash: Option<String>,
 }
 
-impl StreamReceipt {
-    /// Create a new stream receipt with default method/intent/status.
+impl SessionReceipt {
+    /// Create a new session receipt with default method/intent/status.
     ///
     /// Sets `reference` to `channel_id` for base receipt compatibility.
     #[must_use]
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn test_new_sets_defaults() {
-        let receipt = StreamReceipt::new(
+        let receipt = SessionReceipt::new(
             "2026-01-01T00:00:00Z",
             "challenge-123",
             "0xabc",
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_serialization_roundtrip() {
-        let mut receipt = StreamReceipt::new(
+        let mut receipt = SessionReceipt::new(
             "2026-01-01T00:00:00Z",
             "challenge-123",
             "0xabc",
@@ -148,7 +148,7 @@ mod tests {
         receipt.tx_hash = Some("0xdef".to_string());
 
         let json = serde_json::to_string(&receipt).unwrap();
-        let parsed: StreamReceipt = serde_json::from_str(&json).unwrap();
+        let parsed: SessionReceipt = serde_json::from_str(&json).unwrap();
 
         assert_eq!(parsed.method, receipt.method);
         assert_eq!(parsed.intent, receipt.intent);
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_serialization_camel_case_keys() {
-        let receipt = StreamReceipt::new(
+        let receipt = SessionReceipt::new(
             "2026-01-01T00:00:00Z",
             "challenge-123",
             "0xabc",
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_serialization_optional_fields_present() {
-        let mut receipt = StreamReceipt::new(
+        let mut receipt = SessionReceipt::new(
             "2026-01-01T00:00:00Z",
             "challenge-123",
             "0xabc",
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_to_base_receipt() {
-        let receipt = StreamReceipt::new(
+        let receipt = SessionReceipt::new(
             "2026-01-01T00:00:00Z",
             "challenge-123",
             "0xabc",

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -38,7 +38,7 @@
 /// This is the main builder type for Tempo transactions, wrapping alloy's
 /// `TransactionRequest` with Tempo-specific fields:
 /// - `fee_token`: Optional TIP-20 token for gas payment
-/// - `nonce_key`: 2D nonce key for parallel transaction streams
+/// - `nonce_key`: 2D nonce key for parallel transaction sessions
 /// - `calls`: Optional multi-call support
 /// - `tempo_authorization_list`: Tempo-specific authorization list
 pub use tempo_alloy::rpc::TempoTransactionRequest;

--- a/src/protocol/methods/tempo/voucher.rs
+++ b/src/protocol/methods/tempo/voucher.rs
@@ -1,4 +1,4 @@
-//! Voucher signing and channel ID computation for Tempo streaming payments.
+//! Voucher signing and channel ID computation for Tempo session payments.
 //!
 //! Client-side helpers for EIP-712 voucher signing and channel ID computation,
 //! matching the TypeScript SDK's `Voucher.ts` and `Channel.ts`.

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -11,7 +11,7 @@ use std::future::Future;
 
 /// Trait for payment methods that implement the "session" intent.
 ///
-/// SessionMethod verifies session (streaming/pay-as-you-go) payment credentials
+/// SessionMethod verifies session (pay-as-you-go) payment credentials
 /// on the server side. All implementations use the same [`SessionRequest`] schema,
 /// enforcing consistent field names per the IETF spec.
 ///

--- a/src/server/sse.rs
+++ b/src/server/sse.rs
@@ -1,11 +1,11 @@
-//! SSE (Server-Sent Events) utilities for metered streaming payments.
+//! SSE (Server-Sent Events) utilities for metered session payments.
 //!
 //! Provides event formatting/parsing and helpers for building HTTP responses
 //! from SSE streams.
 //!
 //! # Event types
 //!
-//! Three SSE event types are used by mpp streaming:
+//! Three SSE event types are used by mpp sessions:
 //! - `message` — application data
 //! - `payment-need-voucher` — balance exhausted, client should send voucher
 //! - `payment-receipt` — final receipt
@@ -13,13 +13,13 @@
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "tempo")]
-use crate::protocol::methods::tempo::stream_receipt::StreamReceipt;
+use crate::protocol::methods::tempo::session_receipt::SessionReceipt;
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/// SSE event emitted when session balance is exhausted mid-stream.
+/// SSE event emitted when session balance is exhausted mid-session.
 ///
 /// The client responds by sending a new voucher credential.
 ///
@@ -61,24 +61,24 @@ pub enum SseEvent {
     Message(String),
     /// Balance exhausted — client should send a new voucher.
     PaymentNeedVoucher(NeedVoucherEvent),
-    /// Final receipt for the stream session.
+    /// Final receipt for the session.
     #[cfg(feature = "tempo")]
-    PaymentReceipt(StreamReceipt),
+    PaymentReceipt(SessionReceipt),
 }
 
 // ---------------------------------------------------------------------------
 // Event formatting
 // ---------------------------------------------------------------------------
 
-/// Format a stream receipt as a Server-Sent Event.
+/// Format a session receipt as a Server-Sent Event.
 ///
 /// # Example
 ///
 /// ```
 /// use mpp::server::sse::format_receipt_event;
-/// use mpp::protocol::methods::tempo::stream_receipt::StreamReceipt;
+/// use mpp::protocol::methods::tempo::session_receipt::SessionReceipt;
 ///
-/// let receipt = StreamReceipt::new(
+/// let receipt = SessionReceipt::new(
 ///     "2025-01-01T00:00:00Z",
 ///     "ch-1",
 ///     "0xabc",
@@ -90,16 +90,16 @@ pub enum SseEvent {
 /// assert!(event.ends_with("\n\n"));
 /// ```
 #[cfg(feature = "tempo")]
-pub fn format_receipt_event(receipt: &StreamReceipt) -> String {
+pub fn format_receipt_event(receipt: &SessionReceipt) -> String {
     format!(
         "event: payment-receipt\ndata: {}\n\n",
-        serde_json::to_string(receipt).expect("StreamReceipt serialization cannot fail")
+        serde_json::to_string(receipt).expect("SessionReceipt serialization cannot fail")
     )
 }
 
 /// Format a need-voucher event as a Server-Sent Event.
 ///
-/// Emitted when the channel balance is exhausted mid-stream.
+/// Emitted when the channel balance is exhausted mid-session.
 ///
 /// # Example
 ///
@@ -140,7 +140,7 @@ pub fn format_message_event(data: &str) -> String {
 
 /// Parse a raw SSE event string into a typed event.
 ///
-/// Handles the three event types used by mpp streaming:
+/// Handles the three event types used by mpp sessions:
 /// - `message` (default / no event field) — application data
 /// - `payment-need-voucher` — balance exhausted
 /// - `payment-receipt` — final receipt (requires `tempo` feature;
@@ -184,7 +184,7 @@ pub fn parse_event(raw: &str) -> Option<SseEvent> {
             .ok()
             .map(SseEvent::PaymentNeedVoucher),
         #[cfg(feature = "tempo")]
-        "payment-receipt" => serde_json::from_str::<StreamReceipt>(&data)
+        "payment-receipt" => serde_json::from_str::<SessionReceipt>(&data)
             .ok()
             .map(SseEvent::PaymentReceipt),
         _ => Some(SseEvent::Message(data)),
@@ -292,7 +292,7 @@ where
 
         // Emit final receipt
         if let Ok(Some(ch)) = store.get_channel(&channel_id).await {
-            let mut receipt = StreamReceipt::new(
+            let mut receipt = SessionReceipt::new(
                 now_iso8601(),
                 &challenge_id,
                 &channel_id,
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn test_format_receipt_event() {
         let mut receipt =
-            StreamReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
+            SessionReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
         receipt.units = Some(5);
         let event = format_receipt_event(&receipt);
         assert!(event.starts_with("event: payment-receipt\ndata: "));
@@ -489,13 +489,13 @@ mod tests {
         assert!(!is_event_stream(""));
     }
 
-    // -- StreamReceipt tests --
+    // -- SessionReceipt tests --
 
     #[cfg(feature = "tempo")]
     #[test]
-    fn test_stream_receipt_new() {
+    fn test_session_receipt_new() {
         let mut receipt =
-            StreamReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
+            SessionReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
         receipt.units = Some(5);
         receipt.tx_hash = Some("0xtx".into());
         assert_eq!(receipt.method, "tempo");
@@ -511,16 +511,16 @@ mod tests {
 
     #[cfg(feature = "tempo")]
     #[test]
-    fn test_stream_receipt_serialization() {
+    fn test_session_receipt_serialization() {
         let mut receipt =
-            StreamReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
+            SessionReceipt::new("2025-01-01T00:00:00Z", "ch-1", "0xabc", "1000000", "500000");
         receipt.units = Some(5);
         let json = serde_json::to_string(&receipt).unwrap();
         assert!(json.contains("\"challengeId\":\"ch-1\""));
         assert!(json.contains("\"acceptedCumulative\":\"1000000\""));
         assert!(!json.contains("\"txHash\""));
 
-        let roundtrip: StreamReceipt = serde_json::from_str(&json).unwrap();
+        let roundtrip: SessionReceipt = serde_json::from_str(&json).unwrap();
         assert_eq!(roundtrip.challenge_id, "ch-1");
         assert_eq!(roundtrip.units, Some(5));
         assert_eq!(roundtrip.tx_hash, None);


### PR DESCRIPTION
Aligns mpp-rs with the spec change landed in **mpp-specs PR #145** which renamed all problem type URIs from `problems/stream/*` to `problems/session/*`.

## Changes (13 files, 82+/82-)

### Error URIs
- `STREAM_PROBLEM_TYPE_BASE` → `SESSION_PROBLEM_TYPE_BASE` (constant + URL)
- `PaymentErrorDetails::stream()` → `PaymentErrorDetails::session()`
- All 7 `problem_type_suffix` match arms: `stream/` → `session/`
- All `to_problem_details` callers updated
- lib.rs re-export updated

### File & struct rename
- `stream_receipt.rs` → `session_receipt.rs`
- `StreamReceipt` → `SessionReceipt` (struct + all usages)

### Doc comments
- ~15 doc comments updated from "streaming payment" to "session payment"

## Not changed (intentionally)
- `"Tempo Stream Channel"` EIP-712 domain name (on-chain constant)
- SSE transport references (`text/event-stream`, `is_event_stream`, `async-stream` crate)
- Rust `Stream` trait / `tokio-stream` references
- Proxy `upstream` terminology

## Verification
- `cargo test` — all 28 tests pass
- `cargo clippy --all-features` — clean
- Broad grep confirms zero remaining protocol-concept "stream" references in src/