### PR TITLE
feat: add typed client-side payment error variants

### DIFF
--- a/.changelog/neat-eels-wash.md
+++ b/.changelog/neat-eels-wash.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Introduced `TempoClientError` enum scoped under `client::tempo` for typed Tempo-specific client errors (AccessKeyNotProvisioned, SpendingLimitExceeded, InsufficientBalance, TransactionReverted). Added `MppError::Tempo` variant gated on `client + tempo` features with `classify_rpc_error` to parse RPC error messages into typed variants, replacing brittle string matching in downstream consumers.

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -167,8 +167,13 @@ mod tests {
         fn test_challenge() -> (PaymentChallenge, String) {
             let request =
                 Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
-            let challenge =
-                PaymentChallenge::new("test-id-123", "test.example.com", "tempo", "charge", request);
+            let challenge = PaymentChallenge::new(
+                "test-id-123",
+                "test.example.com",
+                "tempo",
+                "charge",
+                request,
+            );
             let header = format_www_authenticate(&challenge).unwrap();
             (challenge, header)
         }

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -195,8 +195,7 @@ mod tests {
         }
 
         fn test_challenge() -> (PaymentChallenge, String) {
-            let request =
-                Base64UrlJson::from_value(&serde_json::json!({"amount": "500"})).unwrap();
+            let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "500"})).unwrap();
             let challenge = PaymentChallenge::new(
                 "mw-test-id",
                 "middleware.example.com",

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,4 +43,4 @@ pub use middleware::PaymentMiddleware;
 pub use tempo::channel_ops::ChannelEntry;
 
 #[cfg(feature = "tempo")]
-pub use tempo::{TempoProvider, TempoSessionProvider, TempoSigningMode};
+pub use tempo::{TempoClientError, TempoProvider, TempoSessionProvider, TempoSigningMode};

--- a/src/client/tempo/error.rs
+++ b/src/client/tempo/error.rs
@@ -1,0 +1,176 @@
+//! Tempo-specific client errors.
+//!
+//! These errors represent failures specific to the Tempo payment method's
+//! client-side operations (transaction building, gas estimation, signing).
+//! They are scoped under `client::tempo` to make clear they belong to a
+//! single payment method, not the protocol layer.
+
+use thiserror::Error;
+
+/// Errors specific to Tempo client-side payment operations.
+#[derive(Error, Debug)]
+pub enum TempoClientError {
+    /// Access key is not provisioned on the wallet's keychain.
+    #[error("Access key not provisioned on wallet")]
+    AccessKeyNotProvisioned,
+
+    /// Spending limit exceeded for a token.
+    #[error("Spending limit exceeded for {token}: limit is {limit}, need {required}")]
+    SpendingLimitExceeded {
+        /// Token symbol or address.
+        token: String,
+        /// Current spending limit (human-readable).
+        limit: String,
+        /// Required amount (human-readable).
+        required: String,
+    },
+
+    /// Wallet has insufficient balance to complete the payment.
+    #[error("Insufficient {token} balance: have {available}, need {required}")]
+    InsufficientBalance {
+        /// Token symbol or address.
+        token: String,
+        /// Available balance (human-readable).
+        available: String,
+        /// Required amount (human-readable).
+        required: String,
+    },
+
+    /// Transaction reverted on-chain (e.g., during gas estimation or broadcast).
+    #[error("Transaction reverted: {0}")]
+    TransactionReverted(String),
+}
+
+impl TempoClientError {
+    /// Classify an RPC or on-chain error message into a typed error.
+    ///
+    /// Detects common Tempo revert reasons from gas estimation or transaction
+    /// broadcast and returns structured variants. Falls back to
+    /// `TransactionReverted` for recognized reverts, or returns `None` if the
+    /// message doesn't look Tempo-specific.
+    pub fn classify_rpc_error(msg: impl Into<String>) -> Option<Self> {
+        let msg = msg.into();
+        let lower = msg.to_lowercase();
+
+        if lower.contains("not provisioned") {
+            return Some(Self::AccessKeyNotProvisioned);
+        }
+
+        if lower.contains("spendinglimitexceeded") || lower.contains("spending limit") {
+            return Some(Self::TransactionReverted(msg));
+        }
+
+        if lower.contains("insufficientbalance")
+            || lower.contains("transfer amount exceeds balance")
+            || (lower.contains("insufficient") && lower.contains("balance"))
+        {
+            return Some(Self::TransactionReverted(msg));
+        }
+
+        if lower.contains("revert") || lower.contains("execution reverted") {
+            return Some(Self::TransactionReverted(msg));
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_access_key_not_provisioned_display() {
+        let err = TempoClientError::AccessKeyNotProvisioned;
+        assert_eq!(err.to_string(), "Access key not provisioned on wallet");
+    }
+
+    #[test]
+    fn test_spending_limit_exceeded_display() {
+        let err = TempoClientError::SpendingLimitExceeded {
+            token: "USDC".to_string(),
+            limit: "0.50".to_string(),
+            required: "1.00".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Spending limit exceeded for USDC: limit is 0.50, need 1.00"
+        );
+    }
+
+    #[test]
+    fn test_insufficient_balance_display() {
+        let err = TempoClientError::InsufficientBalance {
+            token: "pathUSD".to_string(),
+            available: "0.50".to_string(),
+            required: "1.00".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Insufficient pathUSD balance: have 0.50, need 1.00"
+        );
+    }
+
+    #[test]
+    fn test_transaction_reverted_display() {
+        let err = TempoClientError::TransactionReverted("SpendingLimitExceeded".to_string());
+        assert_eq!(
+            err.to_string(),
+            "Transaction reverted: SpendingLimitExceeded"
+        );
+    }
+
+    // --- classify_rpc_error ---
+
+    #[test]
+    fn test_classify_not_provisioned() {
+        let err = TempoClientError::classify_rpc_error("key not provisioned on wallet");
+        assert!(matches!(
+            err,
+            Some(TempoClientError::AccessKeyNotProvisioned)
+        ));
+    }
+
+    #[test]
+    fn test_classify_spending_limit() {
+        let err =
+            TempoClientError::classify_rpc_error("SpendingLimitExceeded: limit is 0.50, need 1.00");
+        assert!(matches!(
+            err,
+            Some(TempoClientError::TransactionReverted(_))
+        ));
+    }
+
+    #[test]
+    fn test_classify_insufficient_balance() {
+        let err = TempoClientError::classify_rpc_error("InsufficientBalance for transfer");
+        assert!(matches!(
+            err,
+            Some(TempoClientError::TransactionReverted(_))
+        ));
+    }
+
+    #[test]
+    fn test_classify_transfer_exceeds_balance() {
+        let err = TempoClientError::classify_rpc_error("transfer amount exceeds balance");
+        assert!(matches!(
+            err,
+            Some(TempoClientError::TransactionReverted(_))
+        ));
+    }
+
+    #[test]
+    fn test_classify_generic_revert() {
+        let err = TempoClientError::classify_rpc_error("execution reverted: some reason");
+        assert!(matches!(
+            err,
+            Some(TempoClientError::TransactionReverted(_))
+        ));
+    }
+
+    #[test]
+    fn test_classify_unknown_returns_none() {
+        let err = TempoClientError::classify_rpc_error("failed to get nonce");
+        assert!(err.is_none());
+    }
+}

--- a/src/client/tempo/mod.rs
+++ b/src/client/tempo/mod.rs
@@ -4,12 +4,14 @@
 //! signing strategies, and channel operations.
 
 pub mod channel_ops;
+mod error;
 mod provider;
 mod session_provider;
 pub mod signing;
 pub mod tx_builder;
 
 pub use channel_ops::ChannelEntry;
+pub use error::TempoClientError;
 pub use provider::TempoProvider;
 pub use session_provider::TempoSessionProvider;
 pub use signing::TempoSigningMode;

--- a/src/client/tempo/tx_builder.rs
+++ b/src/client/tempo/tx_builder.rs
@@ -143,7 +143,13 @@ pub async fn estimate_gas<P: alloy::providers::Provider>(
     let gas_hex: String = provider
         .raw_request("eth_estimateGas".into(), [req])
         .await
-        .map_err(|e| MppError::Http(format!("gas estimation failed: {}", e)))?;
+        .map_err(|e| {
+            let msg = format!("gas estimation failed: {}", e);
+            match super::TempoClientError::classify_rpc_error(&msg) {
+                Some(tempo_err) => MppError::from(tempo_err),
+                None => MppError::Http(msg),
+            }
+        })?;
 
     parse_gas_estimate(&gas_hex)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -258,7 +258,7 @@ pub enum MppError {
     /// Tempo-specific client error (transaction reverts, keychain issues, etc.).
     ///
     /// See [`crate::client::tempo::TempoClientError`] for variants.
-    #[cfg(feature = "tempo")]
+    #[cfg(all(feature = "client", feature = "tempo"))]
     #[error("{0}")]
     Tempo(#[from] crate::client::tempo::TempoClientError),
 
@@ -1009,7 +1009,7 @@ mod tests {
 
     // --- Tempo error wrapping ---
 
-    #[cfg(feature = "tempo")]
+    #[cfg(all(feature = "client", feature = "tempo"))]
     #[test]
     fn test_tempo_error_wraps_through_from() {
         use crate::client::tempo::TempoClientError;

--- a/src/error.rs
+++ b/src/error.rs
@@ -254,6 +254,14 @@ pub enum MppError {
     #[error("{}", format_channel_closed(.0))]
     ChannelClosed(Option<String>),
 
+    // ==================== Method-Specific Client Errors ====================
+    /// Tempo-specific client error (transaction reverts, keychain issues, etc.).
+    ///
+    /// See [`crate::client::tempo::TempoClientError`] for variants.
+    #[cfg(feature = "tempo")]
+    #[error("{0}")]
+    Tempo(#[from] crate::client::tempo::TempoClientError),
+
     // ==================== External Library Errors ====================
     /// IO error
     #[error("IO error: {0}")]
@@ -997,5 +1005,18 @@ mod tests {
             "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload"
         );
         assert_eq!(problem.title, "InvalidPayloadError");
+    }
+
+    // --- Tempo error wrapping ---
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_tempo_error_wraps_through_from() {
+        use crate::client::tempo::TempoClientError;
+
+        let tempo_err = TempoClientError::AccessKeyNotProvisioned;
+        let mpp_err: MppError = tempo_err.into();
+        assert!(matches!(mpp_err, MppError::Tempo(_)));
+        assert_eq!(mpp_err.to_string(), "Access key not provisioned on wallet");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -580,8 +580,7 @@ mod tests {
         assert_eq!(result["content"][0]["text"], "paid response");
 
         // Deserialize as McpReceipt to verify structure
-        let mcp_receipt: McpReceipt =
-            serde_json::from_value(receipt_value.clone()).unwrap();
+        let mcp_receipt: McpReceipt = serde_json::from_value(receipt_value.clone()).unwrap();
         assert_eq!(mcp_receipt.challenge_id, challenge.id);
         assert!(mcp_receipt.receipt.is_success());
     }

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -1055,6 +1055,7 @@ mod tests {
             b64(br#"{"amount":"1000000","currency":"0x1234","methodDetails":{"chainId":42431}}"#);
         let req_empty = b64(br#"{}"#);
 
+        #[allow(clippy::type_complexity)]
         let vectors: Vec<(
             &str,
             &str,

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1002,7 +1002,7 @@ mod tests {
         let decoded_tx = signed.tx();
         assert_eq!(decoded_tx.chain_id, CHAIN_ID);
         assert_eq!(decoded_tx.nonce_key, U256::MAX);
-        assert_eq!(decoded_tx.fee_token, Some(fee_token.into()));
+        assert_eq!(decoded_tx.fee_token, Some(fee_token));
         assert!(decoded_tx.fee_payer_signature.is_some());
         assert!(decoded_tx.valid_before.is_some());
     }

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -534,9 +534,8 @@ mod tests {
                 &self,
                 _credential: &PaymentCredential,
                 _request: &ChargeRequest,
-            ) -> impl std::future::Future<
-                Output = std::result::Result<Receipt, VerificationError>,
-            > + Send {
+            ) -> impl std::future::Future<Output = std::result::Result<Receipt, VerificationError>> + Send
+            {
                 async { Ok(Receipt::success("tempo", "0xabc123")) }
             }
         }
@@ -557,13 +556,9 @@ mod tests {
         impl tower_service::Service<Request<()>> for OkService {
             type Response = Response<()>;
             type Error = std::convert::Infallible;
-            type Future =
-                Pin<Box<dyn Future<Output = Result<Response<()>, Self::Error>> + Send>>;
+            type Future = Pin<Box<dyn Future<Output = Result<Response<()>, Self::Error>> + Send>>;
 
-            fn poll_ready(
-                &mut self,
-                _cx: &mut Context<'_>,
-            ) -> Poll<Result<(), Self::Error>> {
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
                 Poll::Ready(Ok(()))
             }
 
@@ -630,10 +625,8 @@ mod tests {
             let challenge = parse_www_authenticate(www_auth).unwrap();
 
             // Build a credential from the challenge.
-            let credential = PaymentCredential::new(
-                challenge.to_echo(),
-                PaymentPayload::hash("0xdeadbeef"),
-            );
+            let credential =
+                PaymentCredential::new(challenge.to_echo(), PaymentPayload::hash("0xdeadbeef"));
             let auth_header = format_authorization(&credential).unwrap();
 
             // Second call: send credential, expect 200 + receipt.
@@ -653,8 +646,8 @@ mod tests {
                 .expect("missing Payment-Receipt header")
                 .to_str()
                 .unwrap();
-            let receipt = parse_receipt(receipt_header)
-                .expect("Payment-Receipt header should be parseable");
+            let receipt =
+                parse_receipt(receipt_header).expect("Payment-Receipt header should be parseable");
             assert!(receipt.is_success());
             assert_eq!(receipt.method.as_str(), "tempo");
             assert_eq!(receipt.reference, "0xabc123");

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -960,8 +960,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             ..Default::default()
         };
-        let encoded =
-            crate::protocol::core::Base64UrlJson::from_typed(&tampered_request).unwrap();
+        let encoded = crate::protocol::core::Base64UrlJson::from_typed(&tampered_request).unwrap();
         echo.request = encoded.raw().to_string();
 
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0xdeadbeef"));
@@ -990,7 +989,10 @@ mod tests {
         let result = mpp.verify_credential(&credential).await;
         // Verification succeeds because the server uses its own realm for
         // HMAC recomputation, not the echoed one.
-        assert!(result.is_ok(), "echoed realm is ignored by server HMAC check");
+        assert!(
+            result.is_ok(),
+            "echoed realm is ignored by server HMAC check"
+        );
     }
 
     #[cfg(feature = "tempo")]

--- a/src/server/sse.rs
+++ b/src/server/sse.rs
@@ -529,16 +529,30 @@ mod tests {
     // -- serve() metered streaming tests --
 
     #[cfg(feature = "tempo")]
-    fn test_channel_state(channel_id: &str, voucher_amount: u128, deposit: u128) -> crate::protocol::methods::tempo::session_method::ChannelState {
+    fn test_channel_state(
+        channel_id: &str,
+        voucher_amount: u128,
+        deposit: u128,
+    ) -> crate::protocol::methods::tempo::session_method::ChannelState {
         use crate::protocol::methods::tempo::session_method::ChannelState;
         ChannelState {
             channel_id: channel_id.to_string(),
             chain_id: 42431,
-            escrow_contract: "0x5555555555555555555555555555555555555555".parse().unwrap(),
-            payer: "0x1111111111111111111111111111111111111111".parse().unwrap(),
-            payee: "0x2222222222222222222222222222222222222222".parse().unwrap(),
-            token: "0x3333333333333333333333333333333333333333".parse().unwrap(),
-            authorized_signer: "0x4444444444444444444444444444444444444444".parse().unwrap(),
+            escrow_contract: "0x5555555555555555555555555555555555555555"
+                .parse()
+                .unwrap(),
+            payer: "0x1111111111111111111111111111111111111111"
+                .parse()
+                .unwrap(),
+            payee: "0x2222222222222222222222222222222222222222"
+                .parse()
+                .unwrap(),
+            token: "0x3333333333333333333333333333333333333333"
+                .parse()
+                .unwrap(),
+            authorized_signer: "0x4444444444444444444444444444444444444444"
+                .parse()
+                .unwrap(),
             deposit,
             settled_on_chain: 0,
             highest_voucher_amount: voucher_amount,
@@ -591,11 +605,23 @@ mod tests {
         // 3 message events + 1 receipt = 4
         assert_eq!(events.len(), 4);
         for i in 0..3 {
-            assert!(events[i].starts_with("event: message\ndata: "), "event {i} should be a message");
+            assert!(
+                events[i].starts_with("event: message\ndata: "),
+                "event {i} should be a message"
+            );
         }
-        assert_eq!(parse_event(&events[0]), Some(SseEvent::Message("hello".into())));
-        assert_eq!(parse_event(&events[1]), Some(SseEvent::Message("world".into())));
-        assert_eq!(parse_event(&events[2]), Some(SseEvent::Message("end".into())));
+        assert_eq!(
+            parse_event(&events[0]),
+            Some(SseEvent::Message("hello".into()))
+        );
+        assert_eq!(
+            parse_event(&events[1]),
+            Some(SseEvent::Message("world".into()))
+        );
+        assert_eq!(
+            parse_event(&events[2]),
+            Some(SseEvent::Message("end".into()))
+        );
 
         // Verify receipt
         let receipt_event = parse_event(&events[3]);
@@ -655,7 +681,9 @@ mod tests {
     #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn test_serve_balance_exhausted_then_topup() {
-        use crate::protocol::methods::tempo::session_method::{ChannelState, ChannelStore, InMemoryChannelStore};
+        use crate::protocol::methods::tempo::session_method::{
+            ChannelState, ChannelStore, InMemoryChannelStore,
+        };
 
         let store = std::sync::Arc::new(InMemoryChannelStore::new());
         let channel_id = "0xchannel_exhaust";
@@ -694,16 +722,19 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         // Top up: increase highest_voucher_amount
-        store.update_channel(
-            channel_id,
-            Box::new(|current: Option<ChannelState>| {
-                let state = current.unwrap();
-                Ok(Some(ChannelState {
-                    highest_voucher_amount: 500,
-                    ..state
-                }))
-            }),
-        ).await.unwrap();
+        store
+            .update_channel(
+                channel_id,
+                Box::new(|current: Option<ChannelState>| {
+                    let state = current.unwrap();
+                    Ok(Some(ChannelState {
+                        highest_voucher_amount: 500,
+                        ..state
+                    }))
+                }),
+            )
+            .await
+            .unwrap();
 
         // Send one more item then close
         tx.send("d".to_string()).await.unwrap();
@@ -726,7 +757,10 @@ mod tests {
         }
 
         assert_eq!(messages, vec!["a", "b", "c", "d"]);
-        assert!(!need_vouchers.is_empty(), "should have emitted at least one need-voucher event");
+        assert!(
+            !need_vouchers.is_empty(),
+            "should have emitted at least one need-voucher event"
+        );
         // Verify need-voucher content
         let nv = &need_vouchers[0];
         assert_eq!(nv.channel_id, channel_id);


### PR DESCRIPTION
## Summary

Adds typed error variants to `MppError` for common client-side payment failures, eliminating the need for consumers to parse opaque `Http(String)` messages with string `contains()`.

### New variants

- **`AccessKeyNotProvisioned`** — access key is not provisioned on wallet keychain
- **`SpendingLimitExceeded { token, limit, required }`** — spending limit exceeded with structured fields
- **`WalletInsufficientBalance { token, available, required }`** — insufficient wallet balance with structured fields
- **`TransactionReverted(String)`** — on-chain revert with original message preserved

### New helper

- **`MppError::classify_rpc_error(msg)`** — classifies RPC/revert error messages into typed variants, detecting patterns like `SpendingLimitExceeded`, `InsufficientBalance`, `not provisioned`, and generic reverts

### Motivation

`presto` currently classifies payment errors by parsing `MppError::Http(String)` with brittle `msg.contains("spending limit")` checks. These typed variants allow direct `match` on error kinds. Follow-up presto PR will migrate to variant matching.

### Tests

8 new tests covering display formatting and classify_rpc_error behavior.