### PR TITLE
feat: make unit_type optional in session intent

### DIFF
--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -148,10 +148,10 @@ async fn scrape(
     let challenge = payment
         .session_challenge_with_details(
             AMOUNT_PER_REQUEST,
-            "page",
             currency,
             recipient,
             SessionChallengeOptions {
+                unit_type: Some("page"),
                 suggested_deposit: Some("1000000"),
                 ..Default::default()
             },

--- a/examples/session/sse/src/server.rs
+++ b/examples/session/sse/src/server.rs
@@ -133,10 +133,12 @@ async fn chat(
                 .payment
                 .session_challenge_with_details(
                     &PRICE_PER_TOKEN.to_string(),
-                    UNIT_TYPE,
                     CURRENCY,
                     state.payment.recipient().unwrap(),
-                    SessionChallengeOptions::default(),
+                    SessionChallengeOptions {
+                        unit_type: Some(UNIT_TYPE),
+                        ..Default::default()
+                    },
                 )
                 .expect("failed to create session challenge");
 

--- a/src/protocol/intents/session.rs
+++ b/src/protocol/intents/session.rs
@@ -20,7 +20,7 @@ use crate::error::{MppError, Result};
 ///
 /// let req = SessionRequest {
 ///     amount: "1000".to_string(),
-///     unit_type: "second".to_string(),
+///     unit_type: Some("second".to_string()),
 ///     currency: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
 ///     decimals: None,
 ///     recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string()),
@@ -29,16 +29,16 @@ use crate::error::{MppError, Result};
 /// };
 ///
 /// assert_eq!(req.amount, "1000");
-/// assert_eq!(req.unit_type, "second");
+/// assert_eq!(req.unit_type, Some("second".to_string()));
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SessionRequest {
     /// Amount per unit in base units (e.g., wei per second)
     pub amount: String,
 
-    /// Unit type for the streaming rate (e.g., "second", "minute", "request")
-    #[serde(rename = "unitType")]
-    pub unit_type: String,
+    /// Unit type for the streaming rate (e.g., "second", "minute", "request"). Optional.
+    #[serde(rename = "unitType", skip_serializing_if = "Option::is_none")]
+    pub unit_type: Option<String>,
 
     /// Currency/asset identifier (token address, ISO 4217 code, or symbol)
     pub currency: String,
@@ -121,7 +121,7 @@ mod tests {
     fn test_session_request_serialization() {
         let req = SessionRequest {
             amount: "1000".to_string(),
-            unit_type: "second".to_string(),
+            unit_type: Some("second".to_string()),
             currency: "0x123".to_string(),
             recipient: Some("0x456".to_string()),
             suggested_deposit: Some("60000".to_string()),
@@ -141,7 +141,7 @@ mod tests {
 
         let parsed: SessionRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.amount, "1000");
-        assert_eq!(parsed.unit_type, "second");
+        assert_eq!(parsed.unit_type, Some("second".to_string()));
         assert_eq!(parsed.suggested_deposit.as_deref(), Some("60000"));
     }
 
@@ -149,7 +149,7 @@ mod tests {
     fn test_session_request_optional_fields_omitted() {
         let req = SessionRequest {
             amount: "500".to_string(),
-            unit_type: "request".to_string(),
+            unit_type: Some("request".to_string()),
             currency: "USD".to_string(),
             ..Default::default()
         };
@@ -165,7 +165,7 @@ mod tests {
         let json = r#"{"amount":"2000","unitType":"minute","currency":"0xabc"}"#;
         let parsed: SessionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.amount, "2000");
-        assert_eq!(parsed.unit_type, "minute");
+        assert_eq!(parsed.unit_type, Some("minute".to_string()));
         assert_eq!(parsed.currency, "0xabc");
         assert!(parsed.recipient.is_none());
         assert!(parsed.suggested_deposit.is_none());
@@ -203,7 +203,7 @@ mod tests {
     fn test_with_base_units() {
         let req = SessionRequest {
             amount: "1.5".to_string(),
-            unit_type: "second".to_string(),
+            unit_type: Some("second".to_string()),
             currency: "0x123".to_string(),
             decimals: Some(6),
             suggested_deposit: Some("60".to_string()),
@@ -219,11 +219,19 @@ mod tests {
     fn test_with_base_units_no_decimals() {
         let req = SessionRequest {
             amount: "1000000".to_string(),
-            unit_type: "second".to_string(),
+            unit_type: Some("second".to_string()),
             currency: "0x123".to_string(),
             ..Default::default()
         };
         let converted = req.with_base_units().unwrap();
         assert_eq!(converted.amount, "1000000");
+    }
+
+    #[test]
+    fn test_session_request_without_unit_type() {
+        let json = r#"{"amount":"2000","currency":"0xabc"}"#;
+        let parsed: SessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.amount, "2000");
+        assert!(parsed.unit_type.is_none());
     }
 }

--- a/src/protocol/methods/tempo/session.rs
+++ b/src/protocol/methods/tempo/session.rs
@@ -128,7 +128,7 @@ pub enum SessionCredentialPayload {
 ///
 /// let req = SessionRequest {
 ///     amount: "1000".to_string(),
-///     unit_type: "second".to_string(),
+///     unit_type: Some("second".to_string()),
 ///     currency: "0x123".to_string(),
 ///     method_details: Some(serde_json::json!({
 ///         "escrowContract": "0xescrow",
@@ -228,7 +228,7 @@ mod tests {
     fn test_session_request() -> SessionRequest {
         SessionRequest {
             amount: "1000".to_string(),
-            unit_type: "second".to_string(),
+            unit_type: Some("second".to_string()),
             currency: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string()),
             suggested_deposit: Some("60000".to_string()),

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -155,7 +155,7 @@ mod tests {
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
         let request = SessionRequest {
             amount: "1000".into(),
-            unit_type: "second".into(),
+            unit_type: Some("second".into()),
             currency: "usd".into(),
             ..Default::default()
         };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -151,6 +151,8 @@ impl TempoBuilder {
 /// Options for [`Mpp::session_challenge_with_details()`].
 #[derive(Debug, Default)]
 pub struct SessionChallengeOptions<'a> {
+    /// Unit type label (e.g., "token", "byte", "request"). Optional.
+    pub unit_type: Option<&'a str>,
     /// Suggested deposit amount in base units.
     pub suggested_deposit: Option<&'a str>,
     /// Enable fee sponsorship.

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -370,7 +370,6 @@ where
     pub fn session_challenge(
         &self,
         amount: &str,
-        unit_type: &str,
         currency: &str,
         recipient: &str,
     ) -> crate::error::Result<PaymentChallenge> {
@@ -378,7 +377,6 @@ where
 
         let request = SessionRequest {
             amount: amount.to_string(),
-            unit_type: unit_type.to_string(),
             currency: currency.to_string(),
             recipient: Some(recipient.to_string()),
             ..Default::default()
@@ -419,10 +417,10 @@ where
     /// ```ignore
     /// let challenge = mpp.session_challenge_with_details(
     ///     "1000",
-    ///     "second",
     ///     "0x20c0...",
     ///     "0x742d...",
     ///     SessionChallengeOptions {
+    ///         unit_type: Some("second"),
     ///         suggested_deposit: Some("60000"),
     ///         fee_payer: true,
     ///         ..Default::default()
@@ -433,7 +431,6 @@ where
     pub fn session_challenge_with_details(
         &self,
         amount: &str,
-        unit_type: &str,
         currency: &str,
         recipient: &str,
         options: super::SessionChallengeOptions<'_>,
@@ -453,7 +450,7 @@ where
 
         let request = SessionRequest {
             amount: amount.to_string(),
-            unit_type: unit_type.to_string(),
+            unit_type: options.unit_type.map(|s| s.to_string()),
             currency: currency.to_string(),
             recipient: Some(recipient.to_string()),
             suggested_deposit: options.suggested_deposit.map(|s| s.to_string()),


### PR DESCRIPTION
Matches the spec change (tempoxyz/mpp-specs) making `unitType` OPTIONAL.

Changes:
- `SessionRequest.unit_type`: `String` → `Option<String>` with `skip_serializing_if`
- Removed `unit_type` from `session_challenge()` and `session_challenge_with_details()` positional args
- Added `unit_type: Option<&str>` to `SessionChallengeOptions` instead (like mppx)
- Updated examples to use the new API
- Added test for deserializing without unitType