### PR TITLE
feat: default currency to USDC on mainnet, pathUSD on testnet

### DIFF
--- a/.changelog/vain-bats-draw.md
+++ b/.changelog/vain-bats-draw.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added network-specific default currencies for Tempo, defaulting to USDC (USDC.e) on mainnet and pathUSD on testnet. Deprecated the `DEFAULT_CURRENCY` constant in favor of `DEFAULT_CURRENCY_MAINNET` and `DEFAULT_CURRENCY_TESTNET`.

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -160,7 +160,10 @@ pub const DEFAULT_CURRENCY_MAINNET: &str = USDC;
 pub const DEFAULT_CURRENCY_TESTNET: &str = PATH_USD;
 
 /// Default currency address (USDC on mainnet).
-#[deprecated(since = "0.6.0", note = "use DEFAULT_CURRENCY_MAINNET or DEFAULT_CURRENCY_TESTNET")]
+#[deprecated(
+    since = "0.6.0",
+    note = "use DEFAULT_CURRENCY_MAINNET or DEFAULT_CURRENCY_TESTNET"
+)]
 pub const DEFAULT_CURRENCY: &str = USDC;
 
 /// Default challenge expiration in minutes.

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -147,8 +147,21 @@ pub const MODERATO_CHAIN_ID: u64 = 42431;
 /// Default RPC URL for Tempo mainnet.
 pub const DEFAULT_RPC_URL: &str = "https://rpc.tempo.xyz";
 
-/// Default currency address (pathUSD).
-pub const DEFAULT_CURRENCY: &str = "0x20c0000000000000000000000000000000000000";
+/// USDC currency address (USDC.e on Tempo mainnet).
+pub const USDC: &str = "0x20C000000000000000000000b9537d11c60E8b50";
+
+/// pathUSD currency address.
+pub const PATH_USD: &str = "0x20c0000000000000000000000000000000000000";
+
+/// Default currency address for Tempo mainnet (USDC).
+pub const DEFAULT_CURRENCY_MAINNET: &str = USDC;
+
+/// Default currency address for Tempo testnet (pathUSD).
+pub const DEFAULT_CURRENCY_TESTNET: &str = PATH_USD;
+
+/// Default currency address (USDC on mainnet).
+#[deprecated(since = "0.6.0", note = "use DEFAULT_CURRENCY_MAINNET or DEFAULT_CURRENCY_TESTNET")]
+pub const DEFAULT_CURRENCY: &str = USDC;
 
 /// Default challenge expiration in minutes.
 pub const DEFAULT_EXPIRES_MINUTES: u64 = 5;

--- a/src/protocol/methods/tempo/network.rs
+++ b/src/protocol/methods/tempo/network.rs
@@ -28,7 +28,10 @@ impl TempoNetwork {
 
     /// Returns the default currency address for this network.
     pub const fn default_currency(self) -> &'static str {
-        super::DEFAULT_CURRENCY
+        match self {
+            Self::Mainnet => super::DEFAULT_CURRENCY_MAINNET,
+            Self::Moderato => super::DEFAULT_CURRENCY_TESTNET,
+        }
     }
 
     /// Returns the network for a given chain ID, if known.
@@ -106,11 +109,11 @@ mod tests {
         );
         assert_eq!(
             TempoNetwork::Mainnet.default_currency(),
-            super::super::DEFAULT_CURRENCY
+            super::super::DEFAULT_CURRENCY_MAINNET
         );
         assert_eq!(
             TempoNetwork::Moderato.default_currency(),
-            super::super::DEFAULT_CURRENCY
+            super::super::DEFAULT_CURRENCY_TESTNET
         );
     }
 
@@ -127,14 +130,18 @@ mod tests {
     }
 
     #[test]
-    fn default_currency_identical_across_networks() {
+    fn default_currency_per_network() {
         assert_eq!(
             TempoNetwork::Mainnet.default_currency(),
-            TempoNetwork::Moderato.default_currency()
+            "0x20C000000000000000000000b9537d11c60E8b50"
         );
         assert_eq!(
-            TempoNetwork::Mainnet.default_currency(),
+            TempoNetwork::Moderato.default_currency(),
             "0x20c0000000000000000000000000000000000000"
+        );
+        assert_ne!(
+            TempoNetwork::Mainnet.default_currency(),
+            TempoNetwork::Moderato.default_currency()
         );
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -71,6 +71,7 @@ pub struct TempoConfig<'a> {
 #[cfg(feature = "tempo")]
 pub struct TempoBuilder {
     pub(crate) currency: String,
+    pub(crate) currency_explicit: bool,
     pub(crate) recipient: String,
     pub(crate) rpc_url: String,
     pub(crate) realm: String,
@@ -102,9 +103,10 @@ impl TempoBuilder {
         self
     }
 
-    /// Override the token currency (default: pathUSD `0x20c0...`).
+    /// Override the token currency (default: USDC on mainnet, pathUSD on testnet).
     pub fn currency(mut self, addr: &str) -> Self {
         self.currency = addr.to_string();
+        self.currency_explicit = true;
         self
     }
 
@@ -218,6 +220,7 @@ pub struct ChargeOptions<'a> {
 pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
     TempoBuilder {
         currency: crate::protocol::methods::tempo::DEFAULT_CURRENCY_MAINNET.to_string(),
+        currency_explicit: false,
         recipient: config.recipient.to_string(),
         rpc_url: crate::protocol::methods::tempo::DEFAULT_RPC_URL.to_string(),
         realm: mpp::detect_realm(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -217,7 +217,7 @@ pub struct ChargeOptions<'a> {
 #[cfg(feature = "tempo")]
 pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
     TempoBuilder {
-        currency: crate::protocol::methods::tempo::DEFAULT_CURRENCY.to_string(),
+        currency: crate::protocol::methods::tempo::DEFAULT_CURRENCY_MAINNET.to_string(),
         recipient: config.recipient.to_string(),
         rpc_url: crate::protocol::methods::tempo::DEFAULT_RPC_URL.to_string(),
         realm: mpp::detect_realm(),

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -767,7 +767,7 @@ mod tests {
         assert_eq!(mpp.realm(), "MPP Payment");
         assert_eq!(
             mpp.currency(),
-            Some("0x20c0000000000000000000000000000000000000")
+            Some("0x20C000000000000000000000b9537d11c60E8b50")
         );
         assert_eq!(
             mpp.recipient(),
@@ -790,7 +790,7 @@ mod tests {
         assert_eq!(request.amount, "100000");
         assert_eq!(
             request.currency,
-            "0x20c0000000000000000000000000000000000000"
+            "0x20C000000000000000000000b9537d11c60E8b50"
         );
         assert_eq!(
             request.recipient,

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -565,12 +565,24 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
             method = method.with_fee_payer(signer);
         }
 
+        // Resolve currency from chain_id when not explicitly set
+        let currency = if builder.currency_explicit {
+            builder.currency
+        } else {
+            use crate::protocol::methods::tempo::network::TempoNetwork;
+            builder
+                .chain_id
+                .and_then(TempoNetwork::from_chain_id)
+                .map(|n| n.default_currency().to_string())
+                .unwrap_or_else(|| crate::protocol::methods::tempo::PATH_USD.to_string())
+        };
+
         Ok(Self {
             method,
             session_method: None,
             realm: builder.realm,
             secret_key,
-            currency: Some(builder.currency),
+            currency: Some(currency),
             recipient: Some(builder.recipient),
             decimals: builder.decimals,
             fee_payer: builder.fee_payer,
@@ -765,9 +777,10 @@ mod tests {
     fn test_mpp_create() {
         let mpp = create_test_mpp();
         assert_eq!(mpp.realm(), "MPP Payment");
+        // No chain_id set → unknown chain → defaults to pathUSD
         assert_eq!(
             mpp.currency(),
-            Some("0x20C000000000000000000000b9537d11c60E8b50")
+            Some("0x20c0000000000000000000000000000000000000")
         );
         assert_eq!(
             mpp.recipient(),
@@ -790,7 +803,7 @@ mod tests {
         assert_eq!(request.amount, "100000");
         assert_eq!(
             request.currency,
-            "0x20C000000000000000000000b9537d11c60E8b50"
+            "0x20c0000000000000000000000000000000000000"
         );
         assert_eq!(
             request.recipient,


### PR DESCRIPTION
## Summary

Add USDC (USDC.e) as the default currency for **explicit mainnet** (chain ID 4217). All other cases — testnet (42431), unknown chain IDs, and unset chain ID — default to pathUSD.

### Currency Resolution Rule

| Chain ID | Default Currency |
|----------|-----------------|
| `4217` (mainnet) | USDC (`0x20C000000000000000000000b9537d11c60E8b50`) |
| `42431` (testnet) | pathUSD (`0x20c0...000`) |
| Unknown / unset | pathUSD |

### Changes

- Add `USDC` and `PATH_USD` named constants
- Add `DEFAULT_CURRENCY_MAINNET` (USDC) and `DEFAULT_CURRENCY_TESTNET` (pathUSD)
- Deprecate `DEFAULT_CURRENCY` in favor of network-specific constants
- `TempoNetwork::default_currency()` returns USDC for mainnet, pathUSD for testnet
- `Mpp::create()` resolves currency via `TempoNetwork::from_chain_id()` — unknown/unset chain IDs fall back to pathUSD via `unwrap_or_else`
- `tempo()` builder initializes with `DEFAULT_CURRENCY_MAINNET` but `Mpp::create()` overrides based on chain ID

### Breaking Changes

- `DEFAULT_CURRENCY` now points to USDC instead of pathUSD (deprecated, use `DEFAULT_CURRENCY_MAINNET` / `DEFAULT_CURRENCY_TESTNET`)

### CI

All checks passing ✅

Part of cross-SDK USDC default currency rollout ([mppx#120](https://github.com/wevm/mppx/pull/120), [pympp#67](https://github.com/tempoxyz/pympp/pull/67), mpp-rs#81).