### PR TITLE
fix(tempo): accept + emit 0x78 fee payer envelope (mppx/viem interop)

### DIFF
--- a/.changelog/brave-owls-growl.md
+++ b/.changelog/brave-owls-growl.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added end-to-end support for the `0x78` fee payer envelope format, enabling clients to request gas sponsorship by sending a `0x78 || RLP(...)` encoded transaction that servers co-sign and broadcast as a standard `0x76` Tempo transaction. Extended server-side verification to accept both `0x76` and `0x78` transaction types, added `sign_and_encode_fee_payer_envelope` signing helpers, and added integration tests asserting on-chain fee payer and sender addresses.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
 evm = ["alloy", "alloy-signer-local", "hex", "rand"]
-tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid", "alloy-rlp"]
+tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
 
 # Utilities
 utils = ["hex", "rand"]
@@ -57,7 +57,6 @@ futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "1.2", features = ["full"], optional = true }
 alloy-signer-local = { version = "1.2", optional = true }
-alloy-rlp = { version = "0.3", optional = true }
 
 # Tempo dependencies (optional)
 # Note: tempo feature requires git dependency - add to your Cargo.toml:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
 evm = ["alloy", "alloy-signer-local", "hex", "rand"]
-tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
+tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid", "alloy-rlp"]
 
 # Utilities
 utils = ["hex", "rand"]
@@ -57,6 +57,7 @@ futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "1.2", features = ["full"], optional = true }
 alloy-signer-local = { version = "1.2", optional = true }
+alloy-rlp = { version = "0.3", optional = true }
 
 # Tempo dependencies (optional)
 # Note: tempo feature requires git dependency - add to your Cargo.toml:

--- a/src/client/tempo/charge.rs
+++ b/src/client/tempo/charge.rs
@@ -277,7 +277,7 @@ impl TempoCharge {
         // If fee sponsorship is requested, send the `0x78` fee payer envelope
         // so MPPx servers can co-sign and broadcast (standard `0x76`).
         let tx_bytes = if self.fee_payer {
-            sign_and_encode_fee_payer_envelope_async(tx, signer, &signing_mode, from).await?
+            sign_and_encode_fee_payer_envelope_async(tx, signer, &signing_mode).await?
         } else {
             sign_and_encode_async(tx, signer, &signing_mode).await?
         };

--- a/src/client/tempo/charge.rs
+++ b/src/client/tempo/charge.rs
@@ -32,7 +32,9 @@ use alloy::primitives::{Address, TxKind, U256};
 use tempo_primitives::transaction::{Call, SignedKeyAuthorization};
 
 use super::abi::encode_transfer;
-use super::signing::{sign_and_encode_async, TempoSigningMode};
+use super::signing::{
+    sign_and_encode_async, sign_and_encode_fee_payer_envelope_async, TempoSigningMode,
+};
 use super::tx_builder::{build_charge_credential, build_tempo_tx, estimate_gas, TempoTxOptions};
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
@@ -272,7 +274,13 @@ impl TempoCharge {
             key_authorization: tx_key_authorization,
         });
 
-        let tx_bytes = sign_and_encode_async(tx, signer, &signing_mode).await?;
+        // If fee sponsorship is requested, send the `0x78` fee payer envelope
+        // so MPPx servers can co-sign and broadcast (standard `0x76`).
+        let tx_bytes = if self.fee_payer {
+            sign_and_encode_fee_payer_envelope_async(tx, signer, &signing_mode, from).await?
+        } else {
+            sign_and_encode_async(tx, signer, &signing_mode).await?
+        };
 
         Ok(SignedTempoCharge {
             challenge: self.challenge,

--- a/src/client/tempo/signing.rs
+++ b/src/client/tempo/signing.rs
@@ -9,6 +9,19 @@ use tempo_primitives::transaction::SignedKeyAuthorization;
 
 use crate::error::MppError;
 
+/// Fee payer envelope magic byte.
+///
+/// This is **not** a broadcastable Tempo transaction type.
+///
+/// It is a helper encoding used when `feePayer: true` (fee sponsorship) is
+/// requested:
+/// - Client sends `0x78 || rlp([... senderAddress ... signatureEnvelope ])`
+/// - Server/fee payer turns it into a standard `0x76...` Tempo transaction by
+///   attaching a `fee_payer_signature`, then broadcasts.
+///
+/// This matches the `ox/tempo` / `viem/tempo` `format: 'feePayer'` serializer.
+const TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID: u8 = 0x78;
+
 /// How to sign Tempo transactions.
 ///
 /// # Variants
@@ -94,6 +107,24 @@ pub fn sign_and_encode(
     Ok(signed_tx.encoded_2718())
 }
 
+/// Sign a [`TempoTransaction`] and return the **fee payer envelope** encoded bytes.
+///
+/// The resulting bytes start with `0x78` and are meant to be sent to an MPPx server
+/// (or fee payer proxy) which will co-sign and broadcast.
+pub fn sign_and_encode_fee_payer_envelope(
+    tx: tempo_primitives::transaction::TempoTransaction,
+    signer: &impl alloy::signers::SignerSync,
+    mode: &TempoSigningMode,
+    sender: Address,
+) -> Result<Vec<u8>, MppError> {
+    let sig_hash = tx.signature_hash();
+    let inner_signature = signer
+        .sign_hash_sync(&sig_hash)
+        .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
+    let signature = build_tempo_signature(inner_signature, mode);
+    Ok(encode_fee_payer_envelope(tx, sender, signature))
+}
+
 /// Async version of [`sign_and_encode`] for signers that require async signing.
 pub async fn sign_and_encode_async(
     tx: tempo_primitives::transaction::TempoTransaction,
@@ -110,6 +141,119 @@ pub async fn sign_and_encode_async(
 
     let signed_tx = tx.into_signed(build_tempo_signature(inner_signature, mode));
     Ok(signed_tx.encoded_2718())
+}
+
+/// Async version of [`sign_and_encode_fee_payer_envelope`].
+pub async fn sign_and_encode_fee_payer_envelope_async(
+    tx: tempo_primitives::transaction::TempoTransaction,
+    signer: &(impl alloy::signers::Signer + Clone),
+    mode: &TempoSigningMode,
+    sender: Address,
+) -> Result<Vec<u8>, MppError> {
+    let sig_hash = tx.signature_hash();
+    let inner_signature = signer
+        .sign_hash(&sig_hash)
+        .await
+        .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
+    let signature = build_tempo_signature(inner_signature, mode);
+    Ok(encode_fee_payer_envelope(tx, sender, signature))
+}
+
+fn encode_fee_payer_envelope(
+    tx: tempo_primitives::transaction::TempoTransaction,
+    sender: Address,
+    signature: tempo_primitives::transaction::TempoSignature,
+) -> Vec<u8> {
+    // Import traits here so `.encode()` and `.length()` resolve correctly.
+    use alloy_rlp::{BufMut, Encodable, Header, EMPTY_STRING_CODE};
+
+    // RLP list payload length (sum of each element length).
+    //
+    // Order matches `ox/tempo` `TxEnvelopeTempo.serialize` and Tempo's
+    // canonical `0x76` envelope field order, except the `feePayerSignature`
+    // slot is replaced with the `sender` address.
+    let mut payload_length = 0usize;
+    payload_length += tx.chain_id.length();
+    payload_length += tx.max_priority_fee_per_gas.length();
+    payload_length += tx.max_fee_per_gas.length();
+    payload_length += tx.gas_limit.length();
+    payload_length += tx.calls.length();
+    payload_length += tx.access_list.length();
+    payload_length += tx.nonce_key.length();
+    payload_length += tx.nonce.length();
+
+    payload_length += tx
+        .valid_before
+        .map_or(1, |valid_before| valid_before.length());
+    payload_length += tx.valid_after.map_or(1, |valid_after| valid_after.length());
+
+    payload_length += tx.fee_token.map_or(1, |fee_token| fee_token.length());
+
+    // feePayerSignatureOrSender
+    payload_length += sender.length();
+
+    // authorizationList
+    payload_length += tx.tempo_authorization_list.length();
+
+    if let Some(key_authorization) = &tx.key_authorization {
+        payload_length += key_authorization.length();
+    }
+
+    // signature envelope
+    payload_length += signature.length();
+
+    let header = Header {
+        list: true,
+        payload_length,
+    };
+
+    let mut out = Vec::with_capacity(1 + header.length_with_payload());
+
+    out.put_u8(TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
+    header.encode(&mut out);
+
+    tx.chain_id.encode(&mut out);
+    tx.max_priority_fee_per_gas.encode(&mut out);
+    tx.max_fee_per_gas.encode(&mut out);
+    tx.gas_limit.encode(&mut out);
+    tx.calls.encode(&mut out);
+    tx.access_list.encode(&mut out);
+    tx.nonce_key.encode(&mut out);
+    tx.nonce.encode(&mut out);
+
+    if let Some(valid_before) = tx.valid_before {
+        valid_before.encode(&mut out);
+    } else {
+        out.put_u8(EMPTY_STRING_CODE);
+    }
+
+    if let Some(valid_after) = tx.valid_after {
+        valid_after.encode(&mut out);
+    } else {
+        out.put_u8(EMPTY_STRING_CODE);
+    }
+
+    if let Some(fee_token) = tx.fee_token {
+        fee_token.encode(&mut out);
+    } else {
+        out.put_u8(EMPTY_STRING_CODE);
+    }
+
+    // feePayerSignatureOrSender
+    sender.encode(&mut out);
+
+    // authorizationList
+    tx.tempo_authorization_list.encode(&mut out);
+
+    // key_authorization (truly optional - only encoded if present)
+    if let Some(key_authorization) = tx.key_authorization {
+        key_authorization.encode(&mut out);
+    }
+
+    // signature envelope (always present for client credentials)
+    signature.encode(&mut out);
+
+    out
 }
 
 #[cfg(test)]
@@ -232,6 +376,85 @@ mod tests {
         assert_eq!(decoded.tx().chain_id, 42431);
         assert_eq!(decoded.tx().nonce, 1);
         assert_eq!(decoded.tx().gas_limit, 500_000);
+    }
+
+    #[test]
+    fn test_sign_and_encode_fee_payer_envelope_encodes_sender_address() {
+        use alloy_rlp::Decodable;
+        use tempo_primitives::transaction::{TempoSignature, TempoSignedAuthorization};
+
+        let signer = test_signer();
+
+        // The tx must have `fee_payer_signature.is_some()` so the user's
+        // signature_hash skips feeToken commitment (fee sponsorship flow).
+        let mut tx = test_tx();
+        tx.fee_token = None;
+        tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
+            alloy::primitives::U256::ZERO,
+            alloy::primitives::U256::ZERO,
+            false,
+        ));
+
+        let sender = Address::repeat_byte(0xAB);
+        let bytes =
+            sign_and_encode_fee_payer_envelope(tx, &signer, &TempoSigningMode::Direct, sender)
+                .unwrap();
+
+        assert_eq!(bytes[0], 0x78, "fee payer envelope must start with 0x78");
+
+        // Decode enough of the RLP payload to ensure the `feePayerSignatureOrSender`
+        // slot is the sender address.
+        let mut buf = &bytes[1..];
+        let header = alloy_rlp::Header::decode(&mut buf).unwrap();
+        let before_len = buf.len();
+
+        let _chain_id: u64 = Decodable::decode(&mut buf).unwrap();
+        let _max_priority_fee_per_gas: u128 = Decodable::decode(&mut buf).unwrap();
+        let _max_fee_per_gas: u128 = Decodable::decode(&mut buf).unwrap();
+        let _gas_limit: u64 = Decodable::decode(&mut buf).unwrap();
+        let _calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut buf).unwrap();
+        let _access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut buf).unwrap();
+        let _nonce_key: alloy::primitives::U256 = Decodable::decode(&mut buf).unwrap();
+        let _nonce: u64 = Decodable::decode(&mut buf).unwrap();
+
+        // validBefore
+        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
+            buf = &buf[1..];
+        } else {
+            let _: u64 = Decodable::decode(&mut buf).unwrap();
+        }
+
+        // validAfter
+        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
+            buf = &buf[1..];
+        } else {
+            let _: u64 = Decodable::decode(&mut buf).unwrap();
+        }
+
+        // feeToken
+        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
+            buf = &buf[1..];
+        } else {
+            let _: Address = Decodable::decode(&mut buf).unwrap();
+        }
+
+        // feePayerSignatureOrSender
+        let decoded_sender: Address = Decodable::decode(&mut buf).unwrap();
+        assert_eq!(decoded_sender, sender);
+
+        // authorizationList
+        let _authz: Vec<TempoSignedAuthorization> = Decodable::decode(&mut buf).unwrap();
+
+        // signature envelope bytes
+        let sig_bytes: alloy::primitives::Bytes = Decodable::decode(&mut buf).unwrap();
+        TempoSignature::from_bytes(&sig_bytes).expect("signature envelope should parse");
+
+        // Ensure we consumed exactly the RLP list payload.
+        let consumed = before_len - buf.len();
+        assert_eq!(
+            consumed, header.payload_length,
+            "RLP decode should consume the whole list payload"
+        );
     }
 
     #[test]

--- a/src/client/tempo/signing.rs
+++ b/src/client/tempo/signing.rs
@@ -101,7 +101,7 @@ pub fn sign_and_encode(
 /// (or fee payer proxy) which will co-sign and broadcast.
 pub fn sign_and_encode_fee_payer_envelope(
     tx: tempo_primitives::transaction::TempoTransaction,
-    signer: &impl alloy::signers::SignerSync,
+    signer: &(impl alloy::signers::SignerSync + alloy::signers::Signer),
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
     use alloy::primitives::U256;
@@ -325,6 +325,8 @@ mod tests {
         // signature_hash skips feeToken commitment (fee sponsorship flow).
         let mut tx = test_tx();
         tx.fee_token = None;
+        tx.nonce_key = alloy::primitives::U256::MAX;
+        tx.valid_before = Some(9999999999);
         tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
             alloy::primitives::U256::ZERO,
             alloy::primitives::U256::ZERO,

--- a/src/client/tempo/signing.rs
+++ b/src/client/tempo/signing.rs
@@ -8,19 +8,7 @@ use alloy::primitives::Address;
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
 use crate::error::MppError;
-
-/// Fee payer envelope magic byte.
-///
-/// This is **not** a broadcastable Tempo transaction type.
-///
-/// It is a helper encoding used when `feePayer: true` (fee sponsorship) is
-/// requested:
-/// - Client sends `0x78 || rlp([... senderAddress ... signatureEnvelope ])`
-/// - Server/fee payer turns it into a standard `0x76...` Tempo transaction by
-///   attaching a `fee_payer_signature`, then broadcasts.
-///
-/// This matches the `ox/tempo` / `viem/tempo` `format: 'feePayer'` serializer.
-const TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID: u8 = 0x78;
+use crate::protocol::methods::tempo::FeePayerEnvelope78;
 
 /// How to sign Tempo transactions.
 ///
@@ -115,20 +103,44 @@ pub fn sign_and_encode_fee_payer_envelope(
     tx: tempo_primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::SignerSync,
     mode: &TempoSigningMode,
-    sender: Address,
 ) -> Result<Vec<u8>, MppError> {
+    use alloy::primitives::U256;
+
+    let sender = mode.from_address(signer.address());
+    if tx.fee_payer_signature.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope requires fee_payer_signature placeholder; build tx with TempoTxOptions { fee_payer: true }"
+                .to_string(),
+        ));
+    }
+    if tx.fee_token.is_some() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must not include fee_token (server chooses)".to_string(),
+        ));
+    }
+    if tx.nonce_key != U256::MAX {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must use expiring nonce key (U256::MAX)".to_string(),
+        ));
+    }
+    if tx.valid_before.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must include valid_before".to_string(),
+        ));
+    }
+
     let sig_hash = tx.signature_hash();
     let inner_signature = signer
         .sign_hash_sync(&sig_hash)
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
     let signature = build_tempo_signature(inner_signature, mode);
-    Ok(encode_fee_payer_envelope(tx, sender, signature))
+    Ok(FeePayerEnvelope78::from_signing_tx(tx, sender, signature).encoded_envelope())
 }
 
 /// Async version of [`sign_and_encode`] for signers that require async signing.
 pub async fn sign_and_encode_async(
     tx: tempo_primitives::transaction::TempoTransaction,
-    signer: &(impl alloy::signers::Signer + Clone),
+    signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
     use alloy::eips::Encodable2718;
@@ -146,114 +158,41 @@ pub async fn sign_and_encode_async(
 /// Async version of [`sign_and_encode_fee_payer_envelope`].
 pub async fn sign_and_encode_fee_payer_envelope_async(
     tx: tempo_primitives::transaction::TempoTransaction,
-    signer: &(impl alloy::signers::Signer + Clone),
+    signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
-    sender: Address,
 ) -> Result<Vec<u8>, MppError> {
+    use alloy::primitives::U256;
+
+    let sender = mode.from_address(signer.address());
+    if tx.fee_payer_signature.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope requires fee_payer_signature placeholder; build tx with TempoTxOptions { fee_payer: true }"
+                .to_string(),
+        ));
+    }
+    if tx.fee_token.is_some() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must not include fee_token (server chooses)".to_string(),
+        ));
+    }
+    if tx.nonce_key != U256::MAX {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must use expiring nonce key (U256::MAX)".to_string(),
+        ));
+    }
+    if tx.valid_before.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must include valid_before".to_string(),
+        ));
+    }
+
     let sig_hash = tx.signature_hash();
     let inner_signature = signer
         .sign_hash(&sig_hash)
         .await
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
     let signature = build_tempo_signature(inner_signature, mode);
-    Ok(encode_fee_payer_envelope(tx, sender, signature))
-}
-
-fn encode_fee_payer_envelope(
-    tx: tempo_primitives::transaction::TempoTransaction,
-    sender: Address,
-    signature: tempo_primitives::transaction::TempoSignature,
-) -> Vec<u8> {
-    // Import traits here so `.encode()` and `.length()` resolve correctly.
-    use alloy_rlp::{BufMut, Encodable, Header, EMPTY_STRING_CODE};
-
-    // RLP list payload length (sum of each element length).
-    //
-    // Order matches `ox/tempo` `TxEnvelopeTempo.serialize` and Tempo's
-    // canonical `0x76` envelope field order, except the `feePayerSignature`
-    // slot is replaced with the `sender` address.
-    let mut payload_length = 0usize;
-    payload_length += tx.chain_id.length();
-    payload_length += tx.max_priority_fee_per_gas.length();
-    payload_length += tx.max_fee_per_gas.length();
-    payload_length += tx.gas_limit.length();
-    payload_length += tx.calls.length();
-    payload_length += tx.access_list.length();
-    payload_length += tx.nonce_key.length();
-    payload_length += tx.nonce.length();
-
-    payload_length += tx
-        .valid_before
-        .map_or(1, |valid_before| valid_before.length());
-    payload_length += tx.valid_after.map_or(1, |valid_after| valid_after.length());
-
-    payload_length += tx.fee_token.map_or(1, |fee_token| fee_token.length());
-
-    // feePayerSignatureOrSender
-    payload_length += sender.length();
-
-    // authorizationList
-    payload_length += tx.tempo_authorization_list.length();
-
-    if let Some(key_authorization) = &tx.key_authorization {
-        payload_length += key_authorization.length();
-    }
-
-    // signature envelope
-    payload_length += signature.length();
-
-    let header = Header {
-        list: true,
-        payload_length,
-    };
-
-    let mut out = Vec::with_capacity(1 + header.length_with_payload());
-
-    out.put_u8(TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
-    header.encode(&mut out);
-
-    tx.chain_id.encode(&mut out);
-    tx.max_priority_fee_per_gas.encode(&mut out);
-    tx.max_fee_per_gas.encode(&mut out);
-    tx.gas_limit.encode(&mut out);
-    tx.calls.encode(&mut out);
-    tx.access_list.encode(&mut out);
-    tx.nonce_key.encode(&mut out);
-    tx.nonce.encode(&mut out);
-
-    if let Some(valid_before) = tx.valid_before {
-        valid_before.encode(&mut out);
-    } else {
-        out.put_u8(EMPTY_STRING_CODE);
-    }
-
-    if let Some(valid_after) = tx.valid_after {
-        valid_after.encode(&mut out);
-    } else {
-        out.put_u8(EMPTY_STRING_CODE);
-    }
-
-    if let Some(fee_token) = tx.fee_token {
-        fee_token.encode(&mut out);
-    } else {
-        out.put_u8(EMPTY_STRING_CODE);
-    }
-
-    // feePayerSignatureOrSender
-    sender.encode(&mut out);
-
-    // authorizationList
-    tx.tempo_authorization_list.encode(&mut out);
-
-    // key_authorization (truly optional - only encoded if present)
-    if let Some(key_authorization) = tx.key_authorization {
-        key_authorization.encode(&mut out);
-    }
-
-    // signature envelope (always present for client credentials)
-    signature.encode(&mut out);
-
-    out
+    Ok(FeePayerEnvelope78::from_signing_tx(tx, sender, signature).encoded_envelope())
 }
 
 #[cfg(test)]
@@ -380,9 +319,6 @@ mod tests {
 
     #[test]
     fn test_sign_and_encode_fee_payer_envelope_encodes_sender_address() {
-        use alloy_rlp::Decodable;
-        use tempo_primitives::transaction::{TempoSignature, TempoSignedAuthorization};
-
         let signer = test_signer();
 
         // The tx must have `fee_payer_signature.is_some()` so the user's
@@ -395,66 +331,20 @@ mod tests {
             false,
         ));
 
-        let sender = Address::repeat_byte(0xAB);
-        let bytes =
-            sign_and_encode_fee_payer_envelope(tx, &signer, &TempoSigningMode::Direct, sender)
-                .unwrap();
+        let mode = TempoSigningMode::Keychain {
+            wallet: Address::repeat_byte(0xAB),
+            key_authorization: None,
+        };
 
-        assert_eq!(bytes[0], 0x78, "fee payer envelope must start with 0x78");
-
-        // Decode enough of the RLP payload to ensure the `feePayerSignatureOrSender`
-        // slot is the sender address.
-        let mut buf = &bytes[1..];
-        let header = alloy_rlp::Header::decode(&mut buf).unwrap();
-        let before_len = buf.len();
-
-        let _chain_id: u64 = Decodable::decode(&mut buf).unwrap();
-        let _max_priority_fee_per_gas: u128 = Decodable::decode(&mut buf).unwrap();
-        let _max_fee_per_gas: u128 = Decodable::decode(&mut buf).unwrap();
-        let _gas_limit: u64 = Decodable::decode(&mut buf).unwrap();
-        let _calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut buf).unwrap();
-        let _access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut buf).unwrap();
-        let _nonce_key: alloy::primitives::U256 = Decodable::decode(&mut buf).unwrap();
-        let _nonce: u64 = Decodable::decode(&mut buf).unwrap();
-
-        // validBefore
-        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
-            buf = &buf[1..];
-        } else {
-            let _: u64 = Decodable::decode(&mut buf).unwrap();
-        }
-
-        // validAfter
-        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
-            buf = &buf[1..];
-        } else {
-            let _: u64 = Decodable::decode(&mut buf).unwrap();
-        }
-
-        // feeToken
-        if buf.first() == Some(&alloy_rlp::EMPTY_STRING_CODE) {
-            buf = &buf[1..];
-        } else {
-            let _: Address = Decodable::decode(&mut buf).unwrap();
-        }
-
-        // feePayerSignatureOrSender
-        let decoded_sender: Address = Decodable::decode(&mut buf).unwrap();
-        assert_eq!(decoded_sender, sender);
-
-        // authorizationList
-        let _authz: Vec<TempoSignedAuthorization> = Decodable::decode(&mut buf).unwrap();
-
-        // signature envelope bytes
-        let sig_bytes: alloy::primitives::Bytes = Decodable::decode(&mut buf).unwrap();
-        TempoSignature::from_bytes(&sig_bytes).expect("signature envelope should parse");
-
-        // Ensure we consumed exactly the RLP list payload.
-        let consumed = before_len - buf.len();
+        let bytes = sign_and_encode_fee_payer_envelope(tx, &signer, &mode).unwrap();
         assert_eq!(
-            consumed, header.payload_length,
-            "RLP decode should consume the whole list payload"
+            bytes[0],
+            crate::protocol::methods::tempo::TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID,
+            "fee payer envelope must start with 0x78"
         );
+
+        let env = FeePayerEnvelope78::decode_envelope(&bytes).unwrap();
+        assert_eq!(env.sender, Address::repeat_byte(0xAB));
     }
 
     #[test]

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -6,6 +6,14 @@
 //! `0x78 || rlp([...])` envelope to a sponsoring server, which validates the
 //! envelope, reconstitutes a normal 0x76 Tempo transaction, attaches a
 //! `fee_payer_signature`, and then broadcasts.
+//!
+//! Note: this envelope format is specific to mpp-rs. The TypeScript/Viem SDK
+//! (mppx) achieves fee sponsorship differently — the client sends a standard
+//! `0x76` transaction to a JSON-RPC sidecar (`Handler.feePayer()` in tempo-ts)
+//! via viem's `withFeePayer` transport, which cosigns using
+//! `signTransaction({ feePayer: account })` and returns a complete `0x76`.
+//! The `0x78` envelope exists in mpp-rs because it embeds the fee-payer flow
+//! inline in the MPP credential exchange rather than using a separate RPC hop.
 
 use alloy::eips::eip2930::AccessList;
 use alloy::primitives::{Address, Bytes, U256};

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -1,0 +1,290 @@
+//! Fee payer envelope (magic byte 0x78).
+//!
+//! This is a helper encoding used for fee-sponsored transactions.
+//!
+//! It is **not** a broadcastable Tempo transaction type. Instead, clients send a
+//! `0x78 || rlp([...])` envelope to a sponsoring server, which validates the
+//! envelope, reconstitutes a normal 0x76 Tempo transaction, attaches a
+//! `fee_payer_signature`, and then broadcasts.
+
+use alloy::eips::eip2930::AccessList;
+use alloy::primitives::{Address, Bytes, U256};
+use alloy::rlp::{Buf, BufMut, Decodable, Encodable, Error as RlpError, Header, EMPTY_STRING_CODE};
+
+use tempo_primitives::transaction::{
+    Call, SignedKeyAuthorization, TempoSignature, TempoSignedAuthorization,
+};
+
+/// Fee payer envelope magic byte.
+///
+/// Tempo primitives defines this as the fee payer signature domain-separation
+/// magic byte.
+pub const TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID: u8 =
+    tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE;
+
+/// RLP payload sent by a client when requesting fee sponsorship.
+///
+/// Wire format: `0x78 || rlp([ chainId, maxPriorityFeePerGas, maxFeePerGas, gasLimit, calls,
+/// accessList, nonceKey, nonce, validBefore?, validAfter?, feeToken?, senderAddress,
+/// authorizationList, keyAuthorization?, signatureEnvelope ])`
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FeePayerEnvelope78 {
+    pub chain_id: u64,
+    pub max_priority_fee_per_gas: u128,
+    pub max_fee_per_gas: u128,
+    pub gas_limit: u64,
+    pub calls: Vec<Call>,
+    pub access_list: AccessList,
+    pub nonce_key: U256,
+    pub nonce: u64,
+    pub valid_before: Option<u64>,
+    pub valid_after: Option<u64>,
+    pub fee_token: Option<Address>,
+    pub sender: Address,
+    pub tempo_authorization_list: Vec<TempoSignedAuthorization>,
+    pub key_authorization: Option<SignedKeyAuthorization>,
+    pub signature: TempoSignature,
+}
+
+impl FeePayerEnvelope78 {
+    /// Build an envelope from a transaction the client is signing.
+    ///
+    /// The provided `tx` is expected to be in the “fee payer signing shape”:
+    /// - `fee_token == None` (server chooses fee token)
+    /// - `fee_payer_signature.is_some()` placeholder (so `signature_hash()` skips fee_token)
+    pub fn from_signing_tx(
+        tx: tempo_primitives::transaction::TempoTransaction,
+        sender: Address,
+        signature: TempoSignature,
+    ) -> Self {
+        Self {
+            chain_id: tx.chain_id,
+            max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+            max_fee_per_gas: tx.max_fee_per_gas,
+            gas_limit: tx.gas_limit,
+            calls: tx.calls,
+            access_list: tx.access_list,
+            nonce_key: tx.nonce_key,
+            nonce: tx.nonce,
+            valid_before: tx.valid_before,
+            valid_after: tx.valid_after,
+            fee_token: tx.fee_token,
+            sender,
+            tempo_authorization_list: tx.tempo_authorization_list,
+            key_authorization: tx.key_authorization,
+            signature,
+        }
+    }
+
+    /// Encode full envelope bytes, including the leading magic byte `0x78`.
+    #[must_use]
+    pub fn encoded_envelope(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(1 + self.length());
+        out.put_u8(TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
+        self.encode(&mut out);
+        out
+    }
+
+    /// Decode full envelope bytes, including the leading magic byte `0x78`.
+    pub fn decode_envelope(mut bytes: &[u8]) -> alloy::rlp::Result<Self> {
+        if bytes.is_empty() {
+            return Err(RlpError::InputTooShort);
+        }
+
+        let magic = bytes[0];
+        bytes.advance(1);
+        if magic != TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID {
+            return Err(RlpError::Custom("invalid fee payer envelope magic byte"));
+        }
+
+        let env = Self::decode(&mut bytes)?;
+        if !bytes.is_empty() {
+            return Err(RlpError::UnexpectedLength);
+        }
+        Ok(env)
+    }
+
+    /// Reconstitute a normal Tempo 0x76 transaction for signature recovery.
+    ///
+    /// This sets the `fee_payer_signature` placeholder so Tempo's signing hash
+    /// skips `fee_token` (the user did not commit to a particular fee token).
+    #[must_use]
+    pub fn to_recoverable_signed(&self) -> tempo_primitives::AASigned {
+        let tx = tempo_primitives::TempoTransaction {
+            chain_id: self.chain_id,
+            nonce: self.nonce,
+            nonce_key: self.nonce_key,
+            gas_limit: self.gas_limit,
+            max_fee_per_gas: self.max_fee_per_gas,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            fee_token: self.fee_token,
+            calls: self.calls.clone(),
+            access_list: self.access_list.clone(),
+            fee_payer_signature: Some(alloy::primitives::Signature::new(
+                U256::ZERO,
+                U256::ZERO,
+                false,
+            )),
+            valid_before: self.valid_before,
+            valid_after: self.valid_after,
+            key_authorization: self.key_authorization.clone(),
+            tempo_authorization_list: self.tempo_authorization_list.clone(),
+        };
+
+        tempo_primitives::AASigned::new_unhashed(tx, self.signature.clone())
+    }
+}
+
+impl Encodable for FeePayerEnvelope78 {
+    fn encode(&self, out: &mut dyn BufMut) {
+        Header {
+            list: true,
+            payload_length: self.payload_length(),
+        }
+        .encode(out);
+
+        self.chain_id.encode(out);
+        self.max_priority_fee_per_gas.encode(out);
+        self.max_fee_per_gas.encode(out);
+        self.gas_limit.encode(out);
+        self.calls.encode(out);
+        self.access_list.encode(out);
+        self.nonce_key.encode(out);
+        self.nonce.encode(out);
+
+        match self.valid_before {
+            Some(v) => v.encode(out),
+            None => out.put_u8(EMPTY_STRING_CODE),
+        }
+        match self.valid_after {
+            Some(v) => v.encode(out),
+            None => out.put_u8(EMPTY_STRING_CODE),
+        }
+        match self.fee_token {
+            Some(a) => a.encode(out),
+            None => out.put_u8(EMPTY_STRING_CODE),
+        }
+
+        self.sender.encode(out);
+        self.tempo_authorization_list.encode(out);
+
+        if let Some(key_authorization) = &self.key_authorization {
+            key_authorization.encode(out);
+        }
+
+        self.signature.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        Header {
+            list: true,
+            payload_length: self.payload_length(),
+        }
+        .length_with_payload()
+    }
+}
+
+impl FeePayerEnvelope78 {
+    fn payload_length(&self) -> usize {
+        let mut payload_length = 0usize;
+        payload_length += self.chain_id.length();
+        payload_length += self.max_priority_fee_per_gas.length();
+        payload_length += self.max_fee_per_gas.length();
+        payload_length += self.gas_limit.length();
+        payload_length += self.calls.length();
+        payload_length += self.access_list.length();
+        payload_length += self.nonce_key.length();
+        payload_length += self.nonce.length();
+
+        payload_length += self.valid_before.map_or(1, |v| v.length());
+        payload_length += self.valid_after.map_or(1, |v| v.length());
+        payload_length += self.fee_token.map_or(1, |v| v.length());
+
+        payload_length += self.sender.length();
+        payload_length += self.tempo_authorization_list.length();
+        if let Some(key_authorization) = &self.key_authorization {
+            payload_length += key_authorization.length();
+        }
+        payload_length += self.signature.length();
+        payload_length
+    }
+
+    fn decode_optional<T: Decodable>(buf: &mut &[u8]) -> alloy::rlp::Result<Option<T>> {
+        match buf.first() {
+            Some(b) if *b == EMPTY_STRING_CODE => {
+                buf.advance(1);
+                Ok(None)
+            }
+            Some(_) => Ok(Some(T::decode(buf)?)),
+            None => Err(RlpError::InputTooShort),
+        }
+    }
+}
+
+impl Decodable for FeePayerEnvelope78 {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        let header = Header::decode(buf)?;
+        if !header.list {
+            return Err(RlpError::UnexpectedString);
+        }
+
+        if header.payload_length > buf.len() {
+            return Err(RlpError::InputTooShort);
+        }
+
+        let mut fields_buf = &buf[..header.payload_length];
+
+        let chain_id: u64 = Decodable::decode(&mut fields_buf)?;
+        let max_priority_fee_per_gas: u128 = Decodable::decode(&mut fields_buf)?;
+        let max_fee_per_gas: u128 = Decodable::decode(&mut fields_buf)?;
+        let gas_limit: u64 = Decodable::decode(&mut fields_buf)?;
+        let calls: Vec<Call> = Decodable::decode(&mut fields_buf)?;
+        let access_list: AccessList = Decodable::decode(&mut fields_buf)?;
+        let nonce_key: U256 = Decodable::decode(&mut fields_buf)?;
+        let nonce: u64 = Decodable::decode(&mut fields_buf)?;
+
+        let valid_before: Option<u64> = Self::decode_optional(&mut fields_buf)?;
+        let valid_after: Option<u64> = Self::decode_optional(&mut fields_buf)?;
+        let fee_token: Option<Address> = Self::decode_optional(&mut fields_buf)?;
+
+        let sender: Address = Decodable::decode(&mut fields_buf)?;
+        let tempo_authorization_list: Vec<TempoSignedAuthorization> =
+            Decodable::decode(&mut fields_buf)?;
+
+        // key_authorization is truly optional; if present it's an RLP list. If absent, the next
+        // element is the signature envelope bytes.
+        let key_authorization: Option<SignedKeyAuthorization> = match fields_buf.first() {
+            Some(b) if *b >= 0xc0 => Some(Decodable::decode(&mut fields_buf)?),
+            Some(_) => None,
+            None => return Err(RlpError::InputTooShort),
+        };
+
+        // Signature envelope is RLP bytes.
+        let sig_bytes: Bytes = Decodable::decode(&mut fields_buf)?;
+        let signature = TempoSignature::from_bytes(&sig_bytes)
+            .map_err(|_| RlpError::Custom("invalid signature envelope"))?;
+
+        if !fields_buf.is_empty() {
+            return Err(RlpError::UnexpectedLength);
+        }
+        buf.advance(header.payload_length);
+
+        Ok(Self {
+            chain_id,
+            max_priority_fee_per_gas,
+            max_fee_per_gas,
+            gas_limit,
+            calls,
+            access_list,
+            nonce_key,
+            nonce,
+            valid_before,
+            valid_after,
+            fee_token,
+            sender,
+            tempo_authorization_list,
+            key_authorization,
+            signature,
+        })
+    }
+}

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -288,3 +288,234 @@ impl Decodable for FeePayerEnvelope78 {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{Bytes, TxKind};
+    use alloy::signers::local::PrivateKeySigner;
+    use alloy::signers::SignerSync;
+    use tempo_primitives::transaction::{
+        Call, KeyAuthorization, PrimitiveSignature, SignatureType, TempoTransaction, TokenLimit,
+    };
+
+    fn test_signer() -> PrivateKeySigner {
+        "0x1234567890123456789012345678901234567890123456789012345678901234"
+            .parse()
+            .unwrap()
+    }
+
+    /// Build a minimal fee-payer-shaped tx (fee_token=None, placeholder fp sig,
+    /// expiring nonce key, valid_before set).
+    fn base_fee_payer_tx() -> TempoTransaction {
+        TempoTransaction {
+            chain_id: 42431,
+            nonce: 1,
+            gas_limit: 500_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 100_000_000,
+            fee_token: None,
+            calls: vec![Call {
+                to: TxKind::Call(Address::repeat_byte(0x22)),
+                value: U256::ZERO,
+                input: Bytes::from_static(&[0xaa, 0xbb]),
+            }],
+            nonce_key: U256::MAX,
+            key_authorization: None,
+            access_list: Default::default(),
+            fee_payer_signature: Some(alloy::primitives::Signature::new(
+                U256::ZERO,
+                U256::ZERO,
+                false,
+            )),
+            valid_before: Some(9999999999),
+            valid_after: None,
+            tempo_authorization_list: vec![],
+        }
+    }
+
+    /// Sign a tx and produce a `FeePayerEnvelope78`.
+    fn sign_envelope(tx: TempoTransaction, signer: &PrivateKeySigner) -> FeePayerEnvelope78 {
+        let sig_hash = tx.signature_hash();
+        let inner_sig = signer.sign_hash_sync(&sig_hash).unwrap();
+        let signature = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(inner_sig));
+        FeePayerEnvelope78::from_signing_tx(tx, signer.address(), signature)
+    }
+
+    fn make_signed_key_auth(signer: &PrivateKeySigner) -> SignedKeyAuthorization {
+        let auth = KeyAuthorization {
+            chain_id: 42431,
+            key_type: SignatureType::Secp256k1,
+            key_id: signer.address(),
+            expiry: Some(9999999999),
+            limits: Some(vec![TokenLimit {
+                token: Address::repeat_byte(0x33),
+                limit: U256::from(1_000_000u64),
+            }]),
+        };
+        let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
+        auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig))
+    }
+
+    /// Assert encode→decode roundtrip preserves all fields.
+    fn assert_roundtrip(original: &FeePayerEnvelope78) {
+        let bytes = original.encoded_envelope();
+        assert_eq!(
+            bytes[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID,
+            "envelope must start with 0x78"
+        );
+        let decoded = FeePayerEnvelope78::decode_envelope(&bytes)
+            .expect("decode_envelope should succeed");
+        assert_eq!(&decoded, original);
+    }
+
+    // ---- roundtrip tests ----
+
+    #[test]
+    fn roundtrip_minimal_no_optionals() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.valid_before = None;
+        tx.valid_after = None;
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.valid_before.is_none());
+        assert!(env.valid_after.is_none());
+        assert!(env.fee_token.is_none());
+        assert!(env.key_authorization.is_none());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_valid_before() {
+        let signer = test_signer();
+        let tx = base_fee_payer_tx(); // valid_before = Some(9999999999)
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.valid_before.is_some());
+        assert!(env.valid_after.is_none());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_valid_before_and_after() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.valid_after = Some(1000);
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.valid_before.is_some());
+        assert!(env.valid_after.is_some());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_fee_token() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.fee_token = Some(Address::repeat_byte(0x44));
+
+        let env = sign_envelope(tx, &signer);
+        assert_eq!(env.fee_token, Some(Address::repeat_byte(0x44)));
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_all_optionals_set() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.valid_after = Some(500);
+        tx.fee_token = Some(Address::repeat_byte(0x55));
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.valid_before.is_some());
+        assert!(env.valid_after.is_some());
+        assert!(env.fee_token.is_some());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_key_authorization() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.key_authorization = Some(make_signed_key_auth(&signer));
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.key_authorization.is_some());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_key_authorization_and_all_optionals() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.valid_after = Some(42);
+        tx.fee_token = Some(Address::repeat_byte(0x66));
+        tx.key_authorization = Some(make_signed_key_auth(&signer));
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.key_authorization.is_some());
+        assert!(env.valid_before.is_some());
+        assert!(env.valid_after.is_some());
+        assert!(env.fee_token.is_some());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_multiple_calls() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.calls = vec![
+            Call {
+                to: TxKind::Call(Address::repeat_byte(0x11)),
+                value: U256::from(100u64),
+                input: Bytes::from_static(&[0x01]),
+            },
+            Call {
+                to: TxKind::Call(Address::repeat_byte(0x22)),
+                value: U256::ZERO,
+                input: Bytes::from_static(&[0x02, 0x03, 0x04]),
+            },
+            Call {
+                to: TxKind::Call(Address::repeat_byte(0x33)),
+                value: U256::from(999u64),
+                input: Bytes::new(),
+            },
+        ];
+
+        let env = sign_envelope(tx, &signer);
+        assert_eq!(env.calls.len(), 3);
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_empty_calls() {
+        let signer = test_signer();
+        let mut tx = base_fee_payer_tx();
+        tx.calls = vec![];
+
+        let env = sign_envelope(tx, &signer);
+        assert!(env.calls.is_empty());
+        assert_roundtrip(&env);
+    }
+
+    #[test]
+    fn roundtrip_with_keychain_signature() {
+        use tempo_primitives::transaction::KeychainSignature;
+
+        let signer = test_signer();
+        let tx = base_fee_payer_tx();
+        let sig_hash = tx.signature_hash();
+        let inner_sig = signer.sign_hash_sync(&sig_hash).unwrap();
+
+        let wallet = Address::repeat_byte(0xAB);
+        let keychain_sig = KeychainSignature::new(
+            wallet,
+            PrimitiveSignature::Secp256k1(inner_sig),
+        );
+        let signature = TempoSignature::Keychain(keychain_sig);
+
+        let env = FeePayerEnvelope78::from_signing_tx(tx, wallet, signature);
+        assert_roundtrip(&env);
+    }
+}

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -364,8 +364,8 @@ mod tests {
             bytes[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID,
             "envelope must start with 0x78"
         );
-        let decoded = FeePayerEnvelope78::decode_envelope(&bytes)
-            .expect("decode_envelope should succeed");
+        let decoded =
+            FeePayerEnvelope78::decode_envelope(&bytes).expect("decode_envelope should succeed");
         assert_eq!(&decoded, original);
     }
 
@@ -509,10 +509,7 @@ mod tests {
         let inner_sig = signer.sign_hash_sync(&sig_hash).unwrap();
 
         let wallet = Address::repeat_byte(0xAB);
-        let keychain_sig = KeychainSignature::new(
-            wallet,
-            PrimitiveSignature::Secp256k1(inner_sig),
-        );
+        let keychain_sig = KeychainSignature::new(wallet, PrimitiveSignature::Secp256k1(inner_sig));
         let signature = TempoSignature::Keychain(keychain_sig);
 
         let env = FeePayerEnvelope78::from_signing_tx(tx, wallet, signature);

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -585,14 +585,13 @@ where
             )));
         }
 
-        let env = FeePayerEnvelope78::decode_envelope(tx_bytes).map_err(|e| {
-            VerificationError::new(format!("Failed to decode 0x78 envelope: {e}"))
-        })?;
+        let env = FeePayerEnvelope78::decode_envelope(tx_bytes)
+            .map_err(|e| VerificationError::new(format!("Failed to decode 0x78 envelope: {e}")))?;
 
         let signed = env.to_recoverable_signed();
-        let sender = signed.recover_signer().map_err(|e| {
-            VerificationError::new(format!("Failed to recover sender: {e}"))
-        })?;
+        let sender = signed
+            .recover_signer()
+            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {e}")))?;
         if sender != env.sender {
             return Err(VerificationError::new(format!(
                 "Sender mismatch in 0x78 envelope: envelope={:#x} recovered={:#x}",
@@ -958,8 +957,8 @@ mod tests {
         let sig_hash = tx.signature_hash();
         let sig = signer.sign_hash_sync(&sig_hash).unwrap();
         let signature: tempo_primitives::transaction::TempoSignature = sig.into();
-        let encoded = FeePayerEnvelope78::from_signing_tx(tx, signer.address(), signature)
-            .encoded_envelope();
+        let encoded =
+            FeePayerEnvelope78::from_signing_tx(tx, signer.address(), signature).encoded_envelope();
         assert_eq!(encoded[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
         encoded
     }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -578,22 +578,181 @@ where
             return Err(VerificationError::new("Empty transaction bytes"));
         }
 
-        // Require 0x76 Tempo transaction type
         let type_byte = tx_bytes[0];
-        if type_byte != tempo_primitives::transaction::TEMPO_TX_TYPE_ID {
-            return Err(VerificationError::new(format!(
-                "Expected Tempo transaction (0x76), got 0x{type_byte:02x}"
-            )));
-        }
+        let (signed, sender) = match type_byte {
+            // Standard 0x76 Tempo transaction.
+            tempo_primitives::transaction::TEMPO_TX_TYPE_ID => {
+                let signed =
+                    tempo_primitives::AASigned::decode_2718(&mut &tx_bytes[..]).map_err(|e| {
+                        VerificationError::new(format!("Failed to decode transaction: {e}"))
+                    })?;
 
-        // Decode the standard 0x76 transaction
-        let signed = tempo_primitives::AASigned::decode_2718(&mut &tx_bytes[..])
-            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {e}")))?;
+                // Recover sender address from client signature.
+                let sender = signed.recover_signer().map_err(|e| {
+                    VerificationError::new(format!("Failed to recover sender: {e}"))
+                })?;
 
-        // Recover sender address from client signature via ecrecover
-        let sender = signed
-            .recover_signer()
-            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {e}")))?;
+                (signed, sender)
+            }
+            // Fee payer envelope (0x78) used by `viem/tempo` (ox/tempo) and hosted mppx.
+            0x78 => {
+                use alloy_rlp::{Buf, Decodable, Header, EMPTY_STRING_CODE};
+                use tempo_primitives::transaction::TempoSignature;
+
+                let mut buf = &tx_bytes[1..];
+                let header = Header::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode 0x78 RLP header: {e}"))
+                })?;
+                if !header.list {
+                    return Err(VerificationError::new(
+                        "Invalid 0x78 envelope: expected RLP list",
+                    ));
+                }
+
+                let chain_id: u64 = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode chain_id: {e}"))
+                })?;
+                let max_priority_fee_per_gas: u128 = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!(
+                        "Failed to decode max_priority_fee_per_gas: {e}"
+                    ))
+                })?;
+                let max_fee_per_gas: u128 = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode max_fee_per_gas: {e}"))
+                })?;
+                let gas_limit: u64 = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode gas_limit: {e}"))
+                })?;
+                let calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut buf)
+                    .map_err(|e| {
+                    VerificationError::new(format!("Failed to decode calls: {e}"))
+                })?;
+                let access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut buf)
+                    .map_err(|e| {
+                        VerificationError::new(format!("Failed to decode access_list: {e}"))
+                    })?;
+                let nonce_key: U256 = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode nonce_key: {e}"))
+                })?;
+                let nonce: u64 = Decodable::decode(&mut buf)
+                    .map_err(|e| VerificationError::new(format!("Failed to decode nonce: {e}")))?;
+
+                let valid_before: Option<u64> = if let Some(first) = buf.first() {
+                    if *first == EMPTY_STRING_CODE {
+                        buf.advance(1);
+                        None
+                    } else {
+                        Some(Decodable::decode(&mut buf).map_err(|e| {
+                            VerificationError::new(format!("Failed to decode valid_before: {e}"))
+                        })?)
+                    }
+                } else {
+                    return Err(VerificationError::new("0x78 envelope truncated"));
+                };
+
+                let valid_after: Option<u64> = if let Some(first) = buf.first() {
+                    if *first == EMPTY_STRING_CODE {
+                        buf.advance(1);
+                        None
+                    } else {
+                        Some(Decodable::decode(&mut buf).map_err(|e| {
+                            VerificationError::new(format!("Failed to decode valid_after: {e}"))
+                        })?)
+                    }
+                } else {
+                    return Err(VerificationError::new("0x78 envelope truncated"));
+                };
+
+                let fee_token_in_envelope: Option<Address> = if let Some(first) = buf.first() {
+                    if *first == EMPTY_STRING_CODE {
+                        buf.advance(1);
+                        None
+                    } else {
+                        Some(Decodable::decode(&mut buf).map_err(|e| {
+                            VerificationError::new(format!("Failed to decode fee_token: {e}"))
+                        })?)
+                    }
+                } else {
+                    return Err(VerificationError::new("0x78 envelope truncated"));
+                };
+
+                let sender_in_envelope: Address = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode sender address: {e}"))
+                })?;
+
+                let tempo_authorization_list: Vec<
+                    tempo_primitives::transaction::TempoSignedAuthorization,
+                > = Decodable::decode(&mut buf).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode authorization_list: {e}"))
+                })?;
+
+                // key_authorization is truly optional; it is an RLP list.
+                let key_authorization: Option<
+                    tempo_primitives::transaction::SignedKeyAuthorization,
+                > = if let Some(first) = buf.first() {
+                    if *first >= 0xc0 {
+                        Some(Decodable::decode(&mut buf).map_err(|e| {
+                            VerificationError::new(format!(
+                                "Failed to decode key_authorization: {e}"
+                            ))
+                        })?)
+                    } else {
+                        None
+                    }
+                } else {
+                    return Err(VerificationError::new("0x78 envelope truncated"));
+                };
+
+                let sig_bytes: alloy::primitives::Bytes =
+                    Decodable::decode(&mut buf).map_err(|e| {
+                        VerificationError::new(format!("Failed to decode signature bytes: {e}"))
+                    })?;
+                let signature = TempoSignature::from_bytes(&sig_bytes).map_err(|e| {
+                    VerificationError::new(format!("Failed to parse signature: {e}"))
+                })?;
+
+                // Reconstruct the tx in the same shape the client signed (fee_payer_signature
+                // placeholder present so `signature_hash()` uses the 0x00 placeholder domain).
+                let tx = tempo_primitives::TempoTransaction {
+                    chain_id,
+                    nonce,
+                    nonce_key,
+                    gas_limit,
+                    max_fee_per_gas,
+                    max_priority_fee_per_gas,
+                    fee_token: fee_token_in_envelope,
+                    calls,
+                    access_list,
+                    fee_payer_signature: Some(alloy::primitives::Signature::new(
+                        U256::ZERO,
+                        U256::ZERO,
+                        false,
+                    )),
+                    valid_before,
+                    valid_after,
+                    key_authorization,
+                    tempo_authorization_list,
+                };
+
+                let signed = tempo_primitives::AASigned::new_unhashed(tx, signature);
+                let recovered = signed.recover_signer().map_err(|e| {
+                    VerificationError::new(format!("Failed to recover sender: {e}"))
+                })?;
+
+                if recovered != sender_in_envelope {
+                    return Err(VerificationError::new(format!(
+                        "Sender mismatch in 0x78 envelope: envelope={sender_in_envelope:#x} recovered={recovered:#x}"
+                    )));
+                }
+
+                (signed, recovered)
+            }
+            _ => {
+                return Err(VerificationError::new(format!(
+                    "Expected Tempo transaction (0x76) or fee payer envelope (0x78), got 0x{type_byte:02x}"
+                )));
+            }
+        };
 
         let tx = signed.tx();
 
@@ -1007,6 +1166,102 @@ mod tests {
         assert!(decoded_tx.valid_before.is_some());
     }
 
+    /// Round-trip: sign 0x78 envelope → cosign_fee_payer_transaction
+    /// succeeds and produces a valid co-signed 0x76 transaction.
+    #[test]
+    fn test_fee_payer_round_trip_0x78_envelope() {
+        use alloy::eips::Decodable2718;
+        use alloy::signers::SignerSync;
+        use alloy_rlp::{BufMut, Encodable, EMPTY_STRING_CODE};
+
+        let client_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let tx = make_fee_payer_tx(60);
+
+        // Encode as a 0x78 fee payer envelope (sender address in the fee_payer slot).
+        let sig_hash = tx.signature_hash();
+        let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
+        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+
+        let mut fields = Vec::new();
+        tx.chain_id.encode(&mut fields);
+        tx.max_priority_fee_per_gas.encode(&mut fields);
+        tx.max_fee_per_gas.encode(&mut fields);
+        tx.gas_limit.encode(&mut fields);
+        tx.calls.encode(&mut fields);
+        tx.access_list.encode(&mut fields);
+        tx.nonce_key.encode(&mut fields);
+        tx.nonce.encode(&mut fields);
+
+        if let Some(vb) = tx.valid_before {
+            vb.encode(&mut fields);
+        } else {
+            fields.put_u8(EMPTY_STRING_CODE);
+        }
+        if let Some(va) = tx.valid_after {
+            va.encode(&mut fields);
+        } else {
+            fields.put_u8(EMPTY_STRING_CODE);
+        }
+        if let Some(fee_token) = tx.fee_token {
+            fee_token.encode(&mut fields);
+        } else {
+            fields.put_u8(EMPTY_STRING_CODE);
+        }
+
+        client_signer.address().encode(&mut fields);
+        tx.tempo_authorization_list.encode(&mut fields);
+        signature.encode(&mut fields);
+
+        let rlp_header = alloy_rlp::Header {
+            list: true,
+            payload_length: fields.len(),
+        };
+        let mut encoded = Vec::with_capacity(1 + rlp_header.length() + fields.len());
+        encoded.put_u8(0x78);
+        rlp_header.encode(&mut encoded);
+        encoded.extend_from_slice(&fields);
+
+        // Verify it starts with 0x78
+        assert_eq!(encoded[0], 0x78);
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &encoded,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let co_signed = result.expect("cosign should succeed for valid 0x78 envelope");
+
+        // Result should be a valid 0x76 transaction
+        assert_eq!(
+            co_signed[0],
+            tempo_primitives::transaction::TEMPO_TX_TYPE_ID,
+            "co-signed output should be 0x76"
+        );
+
+        // It should be decodable by AASigned
+        let signed = tempo_primitives::AASigned::decode_2718(&mut &co_signed[..])
+            .expect("co-signed tx should be decodable as AASigned");
+
+        let decoded_tx = signed.tx();
+        assert_eq!(decoded_tx.chain_id, CHAIN_ID);
+        assert_eq!(decoded_tx.nonce_key, U256::MAX);
+        assert_eq!(decoded_tx.fee_token, Some(fee_token));
+        assert!(decoded_tx.fee_payer_signature.is_some());
+        assert!(decoded_tx.valid_before.is_some());
+    }
+
     /// cosign_fee_payer_transaction rejects a tx without fee_payer_signature placeholder.
     #[test]
     fn test_cosign_rejects_no_placeholder() {
@@ -1195,16 +1450,16 @@ mod tests {
         let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
 
         let result = method.cosign_fee_payer_transaction(
-            &[0x78, 0xc0], // wrong type byte
+            &[0x79, 0xc0], // wrong type byte
             method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject 0x78 input");
+        let err = result.expect_err("should reject wrong type");
         assert!(
             err.to_string()
-                .contains("Expected Tempo transaction (0x76)"),
-            "error should mention 0x76, got: {err}"
+                .contains("Expected Tempo transaction (0x76) or fee payer envelope (0x78)"),
+            "error should mention 0x76/0x78, got: {err}"
         );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -559,10 +559,9 @@ where
 
     /// Co-sign a fee payer transaction.
     ///
-    /// Accepts a standard 0x76 Tempo transaction with a placeholder
-    /// fee_payer_signature. Recovers the sender address via ecrecover,
-    /// validates fee-payer invariants, then co-signs and returns a
-    /// complete 0x76 transaction ready for broadcast.
+    /// Accepts a `0x78` fee payer envelope, recovers the sender via
+    /// ecrecover, validates fee-payer invariants, then co-signs and
+    /// returns a complete `0x76` transaction ready for broadcast.
     fn cosign_fee_payer_transaction(
         &self,
         tx_bytes: &[u8],
@@ -571,7 +570,7 @@ where
     ) -> Result<Vec<u8>, VerificationError> {
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::consensus::transaction::SignerRecoverable;
-        use alloy::eips::{Decodable2718, Encodable2718};
+        use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
@@ -580,46 +579,26 @@ where
         }
 
         let type_byte = tx_bytes[0];
-        let (signed, sender) = match type_byte {
-            // Standard 0x76 Tempo transaction.
-            tempo_primitives::transaction::TEMPO_TX_TYPE_ID => {
-                let signed =
-                    tempo_primitives::AASigned::decode_2718(&mut &tx_bytes[..]).map_err(|e| {
-                        VerificationError::new(format!("Failed to decode transaction: {e}"))
-                    })?;
+        if type_byte != TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID {
+            return Err(VerificationError::new(format!(
+                "Expected fee payer envelope (0x78), got 0x{type_byte:02x}"
+            )));
+        }
 
-                // Recover sender address from client signature.
-                let sender = signed.recover_signer().map_err(|e| {
-                    VerificationError::new(format!("Failed to recover sender: {e}"))
-                })?;
+        let env = FeePayerEnvelope78::decode_envelope(tx_bytes).map_err(|e| {
+            VerificationError::new(format!("Failed to decode 0x78 envelope: {e}"))
+        })?;
 
-                (signed, sender)
-            }
-            // Fee payer envelope (0x78) used by `viem/tempo` (ox/tempo) and hosted mppx.
-            TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID => {
-                let env = FeePayerEnvelope78::decode_envelope(tx_bytes).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode 0x78 envelope: {e}"))
-                })?;
-
-                let signed = env.to_recoverable_signed();
-                let recovered = signed.recover_signer().map_err(|e| {
-                    VerificationError::new(format!("Failed to recover sender: {e}"))
-                })?;
-                if recovered != env.sender {
-                    return Err(VerificationError::new(format!(
-                        "Sender mismatch in 0x78 envelope: envelope={:#x} recovered={:#x}",
-                        env.sender, recovered
-                    )));
-                }
-
-                (signed, recovered)
-            }
-            _ => {
-                return Err(VerificationError::new(format!(
-                    "Expected Tempo transaction (0x76) or fee payer envelope (0x78), got 0x{type_byte:02x}"
-                )));
-            }
-        };
+        let signed = env.to_recoverable_signed();
+        let sender = signed.recover_signer().map_err(|e| {
+            VerificationError::new(format!("Failed to recover sender: {e}"))
+        })?;
+        if sender != env.sender {
+            return Err(VerificationError::new(format!(
+                "Sender mismatch in 0x78 envelope: envelope={:#x} recovered={:#x}",
+                env.sender, sender
+            )));
+        }
 
         let tx = signed.tx();
 
@@ -968,69 +947,21 @@ mod tests {
         }
     }
 
-    /// Helper: sign a tx and encode as standard 0x76.
-    fn sign_and_encode(
+    /// Helper: sign a tx and encode as a 0x78 fee payer envelope.
+    fn sign_and_encode_0x78(
         tx: tempo_primitives::TempoTransaction,
         signer: &alloy_signer_local::PrivateKeySigner,
     ) -> Vec<u8> {
-        use alloy::eips::Encodable2718;
+        use super::super::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::signers::SignerSync;
 
         let sig_hash = tx.signature_hash();
         let sig = signer.sign_hash_sync(&sig_hash).unwrap();
-        let signed = tx.into_signed(sig.into());
-        signed.encoded_2718()
-    }
-
-    /// Round-trip: sign 0x76 → cosign_fee_payer_transaction
-    /// succeeds and produces a valid co-signed 0x76 transaction.
-    #[test]
-    fn test_fee_payer_round_trip() {
-        use alloy::eips::Decodable2718;
-
-        let client_signer = alloy_signer_local::PrivateKeySigner::random();
-        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
-            .unwrap();
-
-        let tx = make_fee_payer_tx(60);
-        let encoded = sign_and_encode(tx, &client_signer);
-
-        // Verify it starts with 0x76
-        assert_eq!(encoded[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
-
-        let provider =
-            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
-                .connect_http("http://127.0.0.1:1".parse().unwrap());
-
-        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
-
-        let result = method.cosign_fee_payer_transaction(
-            &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
-            fee_token,
-        );
-
-        let co_signed = result.expect("cosign should succeed for valid 0x76 tx");
-
-        // Result should be a valid 0x76 transaction
-        assert_eq!(
-            co_signed[0],
-            tempo_primitives::transaction::TEMPO_TX_TYPE_ID,
-            "co-signed output should be 0x76"
-        );
-
-        // It should be decodable by AASigned
-        let signed = tempo_primitives::AASigned::decode_2718(&mut &co_signed[..])
-            .expect("co-signed tx should be decodable as AASigned");
-
-        let decoded_tx = signed.tx();
-        assert_eq!(decoded_tx.chain_id, CHAIN_ID);
-        assert_eq!(decoded_tx.nonce_key, U256::MAX);
-        assert_eq!(decoded_tx.fee_token, Some(fee_token));
-        assert!(decoded_tx.fee_payer_signature.is_some());
-        assert!(decoded_tx.valid_before.is_some());
+        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+        let encoded = FeePayerEnvelope78::from_signing_tx(tx, signer.address(), signature)
+            .encoded_envelope();
+        assert_eq!(encoded[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
+        encoded
     }
 
     /// Round-trip: sign 0x78 envelope → cosign_fee_payer_transaction
@@ -1091,46 +1022,6 @@ mod tests {
         assert!(decoded_tx.valid_before.is_some());
     }
 
-    /// cosign_fee_payer_transaction rejects a tx without fee_payer_signature placeholder.
-    #[test]
-    fn test_cosign_rejects_no_placeholder() {
-        use alloy::eips::Encodable2718;
-        use alloy::signers::SignerSync;
-
-        let client_signer = alloy_signer_local::PrivateKeySigner::random();
-        let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
-            .unwrap();
-
-        // Build a tx WITHOUT fee_payer_signature placeholder
-        let mut tx = make_fee_payer_tx(60);
-        tx.fee_payer_signature = None;
-
-        let sig_hash = tx.signature_hash();
-        let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
-        let signed = tx.into_signed(sig.into());
-        let encoded = signed.encoded_2718();
-
-        let provider =
-            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
-                .connect_http("http://127.0.0.1:1".parse().unwrap());
-
-        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
-
-        let result = method.cosign_fee_payer_transaction(
-            &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
-            fee_token,
-        );
-
-        let err = result.expect_err("should reject tx without placeholder");
-        assert!(
-            err.to_string().contains("fee_payer_signature placeholder"),
-            "error should mention placeholder, got: {err}"
-        );
-    }
-
     /// cosign_fee_payer_transaction rejects txs with wrong nonce_key.
     #[test]
     fn test_cosign_rejects_wrong_nonce_key() {
@@ -1143,7 +1034,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.nonce_key = U256::ZERO; // Wrong — should be U256::MAX
 
-        let encoded = sign_and_encode(tx, &client_signer);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1176,7 +1067,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.valid_before = None; // Missing
 
-        let encoded = sign_and_encode(tx, &client_signer);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1216,7 +1107,7 @@ mod tests {
         let mut tx = make_fee_payer_tx(60);
         tx.valid_before = Some(past);
 
-        let encoded = sign_and_encode(tx, &client_signer);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -1264,7 +1155,7 @@ mod tests {
         );
     }
 
-    /// cosign_fee_payer_transaction rejects non-0x76 type byte.
+    /// cosign_fee_payer_transaction rejects non-0x78 type byte.
     #[test]
     fn test_cosign_rejects_wrong_type_byte() {
         let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1287,8 +1178,8 @@ mod tests {
         let err = result.expect_err("should reject wrong type");
         assert!(
             err.to_string()
-                .contains("Expected Tempo transaction (0x76) or fee payer envelope (0x78)"),
-            "error should mention 0x76/0x78, got: {err}"
+                .contains("Expected fee payer envelope (0x78)"),
+            "error should mention 0x78, got: {err}"
         );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -569,6 +569,7 @@ where
         fee_payer_signer: &alloy_signer_local::PrivateKeySigner,
         fee_token: Address,
     ) -> Result<Vec<u8>, VerificationError> {
+        use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::consensus::transaction::SignerRecoverable;
         use alloy::eips::{Decodable2718, Encodable2718};
         use alloy::signers::SignerSync;
@@ -595,153 +596,19 @@ where
                 (signed, sender)
             }
             // Fee payer envelope (0x78) used by `viem/tempo` (ox/tempo) and hosted mppx.
-            0x78 => {
-                use alloy_rlp::{Buf, Decodable, Header, EMPTY_STRING_CODE};
-                use tempo_primitives::transaction::TempoSignature;
-
-                let mut buf = &tx_bytes[1..];
-                let header = Header::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode 0x78 RLP header: {e}"))
-                })?;
-                if !header.list {
-                    return Err(VerificationError::new(
-                        "Invalid 0x78 envelope: expected RLP list",
-                    ));
-                }
-
-                let chain_id: u64 = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode chain_id: {e}"))
-                })?;
-                let max_priority_fee_per_gas: u128 = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!(
-                        "Failed to decode max_priority_fee_per_gas: {e}"
-                    ))
-                })?;
-                let max_fee_per_gas: u128 = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode max_fee_per_gas: {e}"))
-                })?;
-                let gas_limit: u64 = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode gas_limit: {e}"))
-                })?;
-                let calls: Vec<tempo_primitives::transaction::Call> = Decodable::decode(&mut buf)
-                    .map_err(|e| {
-                    VerificationError::new(format!("Failed to decode calls: {e}"))
-                })?;
-                let access_list: alloy::eips::eip2930::AccessList = Decodable::decode(&mut buf)
-                    .map_err(|e| {
-                        VerificationError::new(format!("Failed to decode access_list: {e}"))
-                    })?;
-                let nonce_key: U256 = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode nonce_key: {e}"))
-                })?;
-                let nonce: u64 = Decodable::decode(&mut buf)
-                    .map_err(|e| VerificationError::new(format!("Failed to decode nonce: {e}")))?;
-
-                let valid_before: Option<u64> = if let Some(first) = buf.first() {
-                    if *first == EMPTY_STRING_CODE {
-                        buf.advance(1);
-                        None
-                    } else {
-                        Some(Decodable::decode(&mut buf).map_err(|e| {
-                            VerificationError::new(format!("Failed to decode valid_before: {e}"))
-                        })?)
-                    }
-                } else {
-                    return Err(VerificationError::new("0x78 envelope truncated"));
-                };
-
-                let valid_after: Option<u64> = if let Some(first) = buf.first() {
-                    if *first == EMPTY_STRING_CODE {
-                        buf.advance(1);
-                        None
-                    } else {
-                        Some(Decodable::decode(&mut buf).map_err(|e| {
-                            VerificationError::new(format!("Failed to decode valid_after: {e}"))
-                        })?)
-                    }
-                } else {
-                    return Err(VerificationError::new("0x78 envelope truncated"));
-                };
-
-                let fee_token_in_envelope: Option<Address> = if let Some(first) = buf.first() {
-                    if *first == EMPTY_STRING_CODE {
-                        buf.advance(1);
-                        None
-                    } else {
-                        Some(Decodable::decode(&mut buf).map_err(|e| {
-                            VerificationError::new(format!("Failed to decode fee_token: {e}"))
-                        })?)
-                    }
-                } else {
-                    return Err(VerificationError::new("0x78 envelope truncated"));
-                };
-
-                let sender_in_envelope: Address = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode sender address: {e}"))
+            TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID => {
+                let env = FeePayerEnvelope78::decode_envelope(tx_bytes).map_err(|e| {
+                    VerificationError::new(format!("Failed to decode 0x78 envelope: {e}"))
                 })?;
 
-                let tempo_authorization_list: Vec<
-                    tempo_primitives::transaction::TempoSignedAuthorization,
-                > = Decodable::decode(&mut buf).map_err(|e| {
-                    VerificationError::new(format!("Failed to decode authorization_list: {e}"))
-                })?;
-
-                // key_authorization is truly optional; it is an RLP list.
-                let key_authorization: Option<
-                    tempo_primitives::transaction::SignedKeyAuthorization,
-                > = if let Some(first) = buf.first() {
-                    if *first >= 0xc0 {
-                        Some(Decodable::decode(&mut buf).map_err(|e| {
-                            VerificationError::new(format!(
-                                "Failed to decode key_authorization: {e}"
-                            ))
-                        })?)
-                    } else {
-                        None
-                    }
-                } else {
-                    return Err(VerificationError::new("0x78 envelope truncated"));
-                };
-
-                let sig_bytes: alloy::primitives::Bytes =
-                    Decodable::decode(&mut buf).map_err(|e| {
-                        VerificationError::new(format!("Failed to decode signature bytes: {e}"))
-                    })?;
-                let signature = TempoSignature::from_bytes(&sig_bytes).map_err(|e| {
-                    VerificationError::new(format!("Failed to parse signature: {e}"))
-                })?;
-
-                // Reconstruct the tx in the same shape the client signed (fee_payer_signature
-                // placeholder present so `signature_hash()` uses the 0x00 placeholder domain).
-                let tx = tempo_primitives::TempoTransaction {
-                    chain_id,
-                    nonce,
-                    nonce_key,
-                    gas_limit,
-                    max_fee_per_gas,
-                    max_priority_fee_per_gas,
-                    fee_token: fee_token_in_envelope,
-                    calls,
-                    access_list,
-                    fee_payer_signature: Some(alloy::primitives::Signature::new(
-                        U256::ZERO,
-                        U256::ZERO,
-                        false,
-                    )),
-                    valid_before,
-                    valid_after,
-                    key_authorization,
-                    tempo_authorization_list,
-                };
-
-                let signed = tempo_primitives::AASigned::new_unhashed(tx, signature);
+                let signed = env.to_recoverable_signed();
                 let recovered = signed.recover_signer().map_err(|e| {
                     VerificationError::new(format!("Failed to recover sender: {e}"))
                 })?;
-
-                if recovered != sender_in_envelope {
+                if recovered != env.sender {
                     return Err(VerificationError::new(format!(
-                        "Sender mismatch in 0x78 envelope: envelope={sender_in_envelope:#x} recovered={recovered:#x}"
+                        "Sender mismatch in 0x78 envelope: envelope={:#x} recovered={:#x}",
+                        env.sender, recovered
                     )));
                 }
 
@@ -1170,9 +1037,9 @@ mod tests {
     /// succeeds and produces a valid co-signed 0x76 transaction.
     #[test]
     fn test_fee_payer_round_trip_0x78_envelope() {
+        use super::super::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::eips::Decodable2718;
         use alloy::signers::SignerSync;
-        use alloy_rlp::{BufMut, Encodable, EMPTY_STRING_CODE};
 
         let client_signer = alloy_signer_local::PrivateKeySigner::random();
         let fee_payer_signer = alloy_signer_local::PrivateKeySigner::random();
@@ -1187,47 +1054,9 @@ mod tests {
         let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
         let signature: tempo_primitives::transaction::TempoSignature = sig.into();
 
-        let mut fields = Vec::new();
-        tx.chain_id.encode(&mut fields);
-        tx.max_priority_fee_per_gas.encode(&mut fields);
-        tx.max_fee_per_gas.encode(&mut fields);
-        tx.gas_limit.encode(&mut fields);
-        tx.calls.encode(&mut fields);
-        tx.access_list.encode(&mut fields);
-        tx.nonce_key.encode(&mut fields);
-        tx.nonce.encode(&mut fields);
-
-        if let Some(vb) = tx.valid_before {
-            vb.encode(&mut fields);
-        } else {
-            fields.put_u8(EMPTY_STRING_CODE);
-        }
-        if let Some(va) = tx.valid_after {
-            va.encode(&mut fields);
-        } else {
-            fields.put_u8(EMPTY_STRING_CODE);
-        }
-        if let Some(fee_token) = tx.fee_token {
-            fee_token.encode(&mut fields);
-        } else {
-            fields.put_u8(EMPTY_STRING_CODE);
-        }
-
-        client_signer.address().encode(&mut fields);
-        tx.tempo_authorization_list.encode(&mut fields);
-        signature.encode(&mut fields);
-
-        let rlp_header = alloy_rlp::Header {
-            list: true,
-            payload_length: fields.len(),
-        };
-        let mut encoded = Vec::with_capacity(1 + rlp_header.length() + fields.len());
-        encoded.put_u8(0x78);
-        rlp_header.encode(&mut encoded);
-        encoded.extend_from_slice(&fields);
-
-        // Verify it starts with 0x78
-        assert_eq!(encoded[0], 0x78);
+        let encoded = FeePayerEnvelope78::from_signing_tx(tx, client_signer.address(), signature)
+            .encoded_envelope();
+        assert_eq!(encoded[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
 
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -97,6 +97,7 @@
 //! ```
 
 pub mod charge;
+pub mod fee_payer_envelope;
 pub mod network;
 pub mod session;
 pub mod session_receipt;
@@ -110,6 +111,7 @@ pub mod method;
 pub mod session_method;
 
 pub use charge::TempoChargeExt;
+pub use fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
 pub use network::TempoNetwork;
 pub use session::{SessionCredentialPayload, TempoSessionExt, TempoSessionMethodDetails};
 pub use session_receipt::SessionReceipt;

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1318,18 +1318,18 @@ async fn test_fee_payer_allows_client_without_gas_buffer() {
     let (url, handle) = start_server(Arc::new(mpp_no_fp) as Arc<dyn ChargeChallenger>).await;
     let provider = TempoProvider::new(client_signer.clone(), &rpc).expect("TempoProvider");
 
-    let resp = Client::new()
+    let result = Client::new()
         .get(format!("{url}/paid"))
         .send_with_payment(&provider)
-        .await
-        .expect("request should complete");
+        .await;
 
-    // In the non-sponsored flow, the server broadcasts the tx. With only `amount` funded,
-    // the broadcast should fail, and the server will return a fresh 402 challenge.
-    assert_eq!(resp.status(), 402);
+    // Without fee sponsorship, client-side gas estimation reverts because the
+    // account only holds the charge amount (no gas buffer). The payment
+    // provider surfaces this as an error before anything reaches the server.
     assert!(
-        resp.headers().contains_key("www-authenticate"),
-        "server should return a fresh challenge"
+        result.is_err(),
+        "expected client-side failure without fee payer, got: {:?}",
+        result,
     );
 
     // The transaction should not have succeeded on-chain; the client should still have the funds.

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -230,48 +230,12 @@ fn encode_fee_payer_envelope_for_test(
     sender: Address,
     signature: tempo_primitives::transaction::TempoSignature,
 ) -> Vec<u8> {
-    use alloy::primitives::bytes::BufMut;
-    use alloy::rlp::{Encodable, EMPTY_STRING_CODE};
-
-    let mut fields = Vec::new();
-
-    tx.chain_id.encode(&mut fields);
-    tx.max_priority_fee_per_gas.encode(&mut fields);
-    tx.max_fee_per_gas.encode(&mut fields);
-    tx.gas_limit.encode(&mut fields);
-    tx.calls.encode(&mut fields);
-    tx.access_list.encode(&mut fields);
-    tx.nonce_key.encode(&mut fields);
-    tx.nonce.encode(&mut fields);
-
-    if let Some(vb) = tx.valid_before {
-        vb.encode(&mut fields);
-    } else {
-        fields.put_u8(EMPTY_STRING_CODE);
-    }
-    if let Some(va) = tx.valid_after {
-        va.encode(&mut fields);
-    } else {
-        fields.put_u8(EMPTY_STRING_CODE);
-    }
-    fields.put_u8(EMPTY_STRING_CODE); // feeToken — always empty
-    sender.encode(&mut fields); // fee_payer_signature slot
-    tx.tempo_authorization_list.encode(&mut fields);
-    if let Some(key_auth) = &tx.key_authorization {
-        key_auth.encode(&mut fields);
-    }
-    signature.encode(&mut fields);
-
-    let rlp_header = alloy::rlp::Header {
-        list: true,
-        payload_length: fields.len(),
-    };
-
-    let mut out = Vec::with_capacity(1 + rlp_header.length() + fields.len());
-    out.put_u8(0x78);
-    rlp_header.encode(&mut out);
-    out.extend_from_slice(&fields);
-    out
+    mpp::protocol::methods::tempo::FeePayerEnvelope78::from_signing_tx(
+        tx.clone(),
+        sender,
+        signature,
+    )
+    .encoded_envelope()
 }
 
 /// Query TIP-20 pathUSD balance for an address.
@@ -294,14 +258,16 @@ async fn tip20_balance(provider: &impl Provider<TempoNetwork>, addr: Address) ->
 async fn wait_for_receipt(
     provider: &impl Provider<TempoNetwork>,
     tx_hash: B256,
-) -> tempo_alloy::rpc::TempoTransactionReceipt {
+) -> Result<tempo_alloy::rpc::TempoTransactionReceipt, String> {
     for _ in 0..40 {
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         if let Ok(Some(receipt)) = provider.get_transaction_receipt(tx_hash).await {
-            return receipt;
+            return Ok(receipt);
         }
     }
-    panic!("transaction receipt not found after 10s: {tx_hash:#x}");
+    Err(format!(
+        "transaction receipt not found after 10s: {tx_hash:#x}"
+    ))
 }
 
 // ==================== ChargeConfig types ====================
@@ -887,7 +853,6 @@ async fn test_e2e_charge_without_fee_payer() {
     let server_signer = PrivateKeySigner::random();
     let client_signer = PrivateKeySigner::random();
 
-    let _server_addr = server_signer.address();
     let client_addr = client_signer.address();
 
     fund_account(&rpc, server_signer.address()).await;
@@ -938,7 +903,9 @@ async fn test_e2e_charge_without_fee_payer() {
         .reference
         .parse()
         .expect("receipt reference should be B256");
-    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash)
+        .await
+        .expect("receipt not found");
     assert_eq!(chain_receipt.from(), client_addr);
     assert_eq!(
         chain_receipt.fee_payer, client_addr,
@@ -1014,7 +981,9 @@ async fn test_e2e_charge_with_fee_payer() {
         .reference
         .parse()
         .expect("receipt reference should be B256");
-    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash)
+        .await
+        .expect("receipt not found");
 
     assert_eq!(chain_receipt.from(), client_addr);
     assert_eq!(
@@ -1266,7 +1235,9 @@ async fn test_fee_payer_balance_accounting() {
         .reference
         .parse()
         .expect("receipt reference should be B256");
-    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash)
+        .await
+        .expect("receipt not found");
     assert_eq!(chain_receipt.from(), client_signer.address());
     assert_eq!(chain_receipt.fee_payer, server_signer.address());
 
@@ -1401,7 +1372,9 @@ async fn test_fee_payer_allows_client_without_gas_buffer() {
         .reference
         .parse()
         .expect("receipt reference should be B256");
-    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash)
+        .await
+        .expect("receipt not found");
     assert_eq!(chain_receipt.from(), client_addr);
     assert_eq!(chain_receipt.fee_payer, fee_payer_addr);
 

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -16,6 +16,7 @@
 use std::sync::Arc;
 
 use alloy::eips::Encodable2718;
+use alloy::network::ReceiptResponse;
 use alloy::primitives::{address, Address, Bytes, TxKind, B256, U256};
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::signers::SignerSync;
@@ -203,6 +204,23 @@ async fn fund_account(rpc: &str, to: Address) {
     .await;
 }
 
+/// Fund an account with an exact amount of pathUSD.
+async fn fund_account_amount(rpc: &str, to: Address, amount: U256) {
+    setup_liquidity(rpc).await;
+
+    let transfer_data = ITIP20::transferCall::new((to, amount)).abi_encode();
+
+    dev_send(
+        rpc,
+        vec![Call {
+            to: TxKind::Call(PATH_USD),
+            value: U256::ZERO,
+            input: Bytes::from(transfer_data),
+        }],
+    )
+    .await;
+}
+
 // ==================== Fee payer test helpers ====================
 
 /// Encode a 0x78 fee payer envelope for testing (mirrors encode_fee_payer_envelope
@@ -271,6 +289,19 @@ async fn tip20_balance(provider: &impl Provider<TempoNetwork>, addr: Address) ->
         .await
         .expect("balanceOf call failed");
     U256::from_be_slice(&result)
+}
+
+async fn wait_for_receipt(
+    provider: &impl Provider<TempoNetwork>,
+    tx_hash: B256,
+) -> tempo_alloy::rpc::TempoTransactionReceipt {
+    for _ in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        if let Ok(Some(receipt)) = provider.get_transaction_receipt(tx_hash).await {
+            return receipt;
+        }
+    }
+    panic!("transaction receipt not found after 10s: {tx_hash:#x}");
 }
 
 // ==================== ChargeConfig types ====================
@@ -856,6 +887,9 @@ async fn test_e2e_charge_without_fee_payer() {
     let server_signer = PrivateKeySigner::random();
     let client_signer = PrivateKeySigner::random();
 
+    let _server_addr = server_signer.address();
+    let client_addr = client_signer.address();
+
     fund_account(&rpc, server_signer.address()).await;
     fund_account(&rpc, client_signer.address()).await;
 
@@ -897,6 +931,20 @@ async fn test_e2e_charge_without_fee_payer() {
     assert_eq!(receipt.method.as_str(), "tempo");
     assert!(receipt.reference.starts_with("0x"));
 
+    // Assert on-chain receipt reports sender as fee payer (no sponsorship).
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+    let tx_hash: B256 = receipt
+        .reference
+        .parse()
+        .expect("receipt reference should be B256");
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    assert_eq!(chain_receipt.from(), client_addr);
+    assert_eq!(
+        chain_receipt.fee_payer, client_addr,
+        "without fee sponsorship, fee_payer should equal sender"
+    );
+
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["message"], "paid content");
 
@@ -914,12 +962,15 @@ async fn test_e2e_charge_with_fee_payer() {
     let server_signer = PrivateKeySigner::random();
     let client_signer = PrivateKeySigner::random();
 
+    let fee_payer_addr = server_signer.address();
+    let client_addr = client_signer.address();
+
     fund_account(&rpc, server_signer.address()).await;
     fund_account(&rpc, client_signer.address()).await;
 
     let mpp = Mpp::create(
         tempo(TempoConfig {
-            recipient: &format!("{}", server_signer.address()),
+            recipient: &format!("{}", fee_payer_addr),
         })
         .rpc_url(&rpc)
         .chain_id(chain_id)
@@ -955,6 +1006,31 @@ async fn test_e2e_charge_with_fee_payer() {
     assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
     assert_eq!(receipt.method.as_str(), "tempo");
     assert!(receipt.reference.starts_with("0x"));
+
+    // Assert on-chain receipt reports fee_payer as the sponsor (server), not the sender.
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+    let tx_hash: B256 = receipt
+        .reference
+        .parse()
+        .expect("receipt reference should be B256");
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+
+    assert_eq!(chain_receipt.from(), client_addr);
+    assert_eq!(
+        chain_receipt.fee_payer, fee_payer_addr,
+        "with fee sponsorship, fee_payer should be the configured sponsor"
+    );
+    assert_ne!(
+        chain_receipt.fee_payer,
+        chain_receipt.from(),
+        "with sponsorship, fee_payer must differ from sender"
+    );
+    assert_eq!(
+        chain_receipt.fee_token,
+        Some(PATH_USD),
+        "server should choose pathUSD as the fee token on localnet"
+    );
 
     let body: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(body["message"], "paid content");
@@ -1178,6 +1254,22 @@ async fn test_fee_payer_balance_accounting() {
         .expect("fee-payer payment failed");
     assert_eq!(resp.status(), 200);
 
+    // Assert on-chain receipt shows sponsorship.
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    let tx_hash: B256 = receipt
+        .reference
+        .parse()
+        .expect("receipt reference should be B256");
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    assert_eq!(chain_receipt.from(), client_signer.address());
+    assert_eq!(chain_receipt.fee_payer, server_signer.address());
+
     // Record balances after payment.
     let client_balance_after = tip20_balance(&provider_http, client_signer.address()).await;
     let server_balance_after = tip20_balance(&provider_http, server_signer.address()).await;
@@ -1208,6 +1300,114 @@ async fn test_fee_payer_balance_accounting() {
         "in fee payer mode, client should only pay the charge amount (no gas), \
          but client balance decreased by {client_decrease} instead of {charge_amount}"
     );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Regression: without fee sponsorship, a client that only has `amount` pathUSD should
+/// fail to pay (because it also needs gas). With fee sponsorship enabled, the same
+/// client should succeed (client only pays `amount`; sponsor pays gas).
+#[tokio::test]
+async fn test_fee_payer_allows_client_without_gas_buffer() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    let fee_payer_addr = server_signer.address();
+    let client_addr = client_signer.address();
+
+    // Sponsor has plenty of funds.
+    fund_account(&rpc, fee_payer_addr).await;
+
+    // Client has ONLY the charge amount.
+    let charge_amount = U256::from(10_000u64); // $0.01 with 6 decimals
+    fund_account_amount(&rpc, client_addr, charge_amount).await;
+
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+
+    // Sanity check: balance starts exactly at charge_amount.
+    let client_balance_before = tip20_balance(&provider_http, client_addr).await;
+    assert_eq!(client_balance_before, charge_amount);
+
+    // --- Case 1: NO fee payer → should fail with insufficient funds for gas.
+    let mpp_no_fp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", fee_payer_addr),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("no-fp-no-buffer"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp_no_fp) as Arc<dyn ChargeChallenger>).await;
+    let provider = TempoProvider::new(client_signer.clone(), &rpc).expect("TempoProvider");
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("request should complete");
+
+    // In the non-sponsored flow, the server broadcasts the tx. With only `amount` funded,
+    // the broadcast should fail, and the server will return a fresh 402 challenge.
+    assert_eq!(resp.status(), 402);
+    assert!(
+        resp.headers().contains_key("www-authenticate"),
+        "server should return a fresh challenge"
+    );
+
+    // The transaction should not have succeeded on-chain; the client should still have the funds.
+    let client_balance_after_failed = tip20_balance(&provider_http, client_addr).await;
+    assert_eq!(client_balance_after_failed, charge_amount);
+
+    handle.abort();
+    let _ = handle.await;
+
+    // --- Case 2: Fee payer enabled → should succeed.
+    let mpp_fp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", fee_payer_addr),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer)
+        .secret_key("fp-no-buffer"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp_fp) as Arc<dyn ChargeChallenger>).await;
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("fee payer payment should succeed");
+    assert_eq!(resp.status(), 200);
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    let tx_hash: B256 = receipt
+        .reference
+        .parse()
+        .expect("receipt reference should be B256");
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash).await;
+    assert_eq!(chain_receipt.from(), client_addr);
+    assert_eq!(chain_receipt.fee_payer, fee_payer_addr);
+
+    // Client should have paid exactly `charge_amount` and nothing else.
+    let client_balance_after = tip20_balance(&provider_http, client_addr).await;
+    assert_eq!(client_balance_after, U256::ZERO);
 
     handle.abort();
     let _ = handle.await;


### PR DESCRIPTION
## What

This fixes fee sponsorship interoperability with hosted mppx servers / viem(ox) Tempo tx serialization.

- Client now emits the `0x78` fee payer envelope when `feePayer: true` is requested in `methodDetails` (matches `viem/tempo` / `ox/tempo` `format: "feePayer"`).
- Server now accepts `0x78` fee payer envelopes for co-signing + broadcast.
- Introduces `FeePayerEnvelope78` as a single source-of-truth codec (Encodable/Decodable) for the envelope format.

## Why

We observed mpp-rs clients submitting `0x76...` in fee sponsorship mode to hosted mppx, which resulted in the tx being treated as sender-paid gas and failing with `insufficient funds for gas * price + value`. The working mppx/viem client sends the `0x78...` envelope and the server co-signs + broadcasts `0x76...`.

### Background: How Fee Sponsorship Works on Tempo

Tempo transactions use type `0x76`. When a client wants fee sponsorship (i.e. someone else pays gas), there are two actors:

1. **Sender** — signs the transaction body (the "what" — transfer X tokens to Y)
2. **Fee payer** — co-signs to agree to cover gas costs, then broadcasts

The problem is: how does the sender transmit their signed-but-not-yet-broadcastable transaction to the fee payer? This is where `0x78` comes in.

### The `0x78` Fee Payer Envelope

`0x78` is **not** a broadcastable transaction type. It is a wire format for the hand-off between sender and fee payer:

```
0x78 || RLP([
  chainId, maxPriorityFeePerGas, maxFeePerGas, gasLimit,
  calls, accessList, nonceKey, nonce,
  validBefore?, validAfter?, feeToken?,
  senderAddress,          ← replaces feePayerSignature slot
  authorizationList, keyAuthorization?,
  signatureEnvelope       ← sender's signature
])
```

The key detail: the `feePayerSignature` RLP slot in a normal `0x76` tx is **repurposed** to hold the `senderAddress`. This tells the fee payer whose fees to cover. The fee payer then:

1. Decodes the `0x78` envelope
2. Computes its own signing payload: `keccak256(0x78 || RLP([...fields, senderAddress]))`
3. Signs → produces `feePayerSignature`
4. Reconstructs a standard `0x76` tx with both signatures
5. Broadcasts the `0x76` tx to the network

The `0x78` prefix provides domain separation — the fee payer's signature commits to a different hash than the sender's `0x76`-based signature, preventing cross-domain replay.

### Comparison: viem/ox vs mpp-rs

**viem/ox** implements this via a transport-layer sidecar pattern:

In viem, `serializeTempo({ format: 'feePayer' })` in [ox/TxEnvelopeTempo.ts](https://github.com/wevm/ox/blob/main/src/tempo/TxEnvelopeTempo.ts) produces the `0x78` envelope. The `feePayerSignatureOrSender` RLP field is overloaded — it holds the sender's address in the `0x78` envelope, and the fee payer's actual `[v, r, s]` signature in the final `0x76` broadcast tx.

The [`withFeePayer(defaultTransport, relayTransport)`](https://github.com/wevm/viem/blob/main/src/tempo/Transport.ts) transport intercepts `eth_sendRawTransaction` calls. When it detects a `0x76` tx with `feePayerSignature === null` (the `0x00` marker byte), it routes to the relay via a custom `eth_signRawTransaction` RPC. The relay co-signs and returns a fully-signed `0x76`. The transport then broadcasts via the default transport.

```
viem Client             withFeePayer Transport       Fee Payer Relay         Node
  │                              │                         │                    │
  │ signTransaction()            │                         │                    │
  │ format:'feePayer' → 0x78     │                         │                    │
  │──eth_sendRawTransaction(0x78)│                         │                    │
  │                              │──eth_signRawTransaction(0x78)──▶            │
  │                              │                         │ deserialize        │
  │                              │                         │ co-sign            │
  │                              │                         │ reserialize → 0x76 │
  │                              │◀──────────0x76──────────│                    │
  │                              │──eth_sendRawTransaction(0x76)──────────────▶│
  │◀──────────txHash─────────────│                         │                    │
```

**mpp-rs** embeds the fee payer flow inline in the MPP credential exchange — there is no separate RPC hop or sidecar. The `0x78` envelope travels inside the MPP `Authorization` header credential:

```
mpp-rs Client                  MPPx Server                         Node
  │                               │                                │
  │ GET /resource                 │                                │
  │◀──402 + WWW-Authenticate─────│                                │
  │                               │                                │
  │ sign charge → 0x78 envelope   │                                │
  │──Authorization: credential────▶                                │
  │                               │ decode 0x78                    │
  │                               │ co-sign → 0x76                 │
  │                               │──eth_sendRawTransaction(0x76)─▶│
  │                               │◀──────────txHash───────────────│
  │◀──200 + receipt───────────────│                                │
```

The mppx server decodes the `0x78` envelope, co-signs, broadcasts, and returns the paid resource — all in one HTTP round-trip.

**Both approaches produce identical `0x78` envelopes on the wire.** This PR ensures mpp-rs clients produce `0x78` envelopes that mppx servers (which also serve viem clients) can decode and co-sign.

### Why `0x76` Didn't Work

Previously, mpp-rs was sending a `0x76` tx with a placeholder `feePayerSignature` (all zeros). The mppx server treated this as a complete, sender-paid transaction and attempted to broadcast it directly. Since the client account typically only holds enough tokens for the payment (not gas), this failed with `insufficient funds for gas * price + value`.

## Tests

- Strengthened `tests/integration_charge.rs` to assert on-chain receipt `fee_payer`/`fee_token`.
- Added a regression test showing a client with only the payment amount succeeds **with** sponsorship and fails **without** sponsorship.
- Added RLP roundtrip tests for `FeePayerEnvelope78` encoding/decoding.

To run locally:
```bash
docker compose up -d
TEMPO_RPC_URL=http://localhost:8545 make test-integration
docker compose down
```