### PR TITLE
feat: add opaque field for server-defined correlation data

### DIFF
--- a/src/client/tempo/channel_ops.rs
+++ b/src/client/tempo/channel_ops.rs
@@ -449,6 +449,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let override_addr: Address = "0x1111111111111111111111111111111111111111"
@@ -476,6 +477,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, None).unwrap();
@@ -504,6 +506,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, None).unwrap();
@@ -528,6 +531,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let result = resolve_escrow(&challenge, 9999, None);
@@ -552,6 +556,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let payload = SessionCredentialPayload::Voucher {
@@ -645,6 +650,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert_eq!(resolve_chain_id(&challenge), 4217);
@@ -668,6 +674,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert_eq!(resolve_chain_id(&challenge), MODERATO_CHAIN_ID);
@@ -689,6 +696,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         // Should fall back to MODERATO_CHAIN_ID on decode failure
@@ -717,6 +725,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         // Invalid address in challenge should fall back to default
@@ -742,6 +751,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let override_addr: Address = "0x3333333333333333333333333333333333333333"
@@ -798,6 +808,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let payload = SessionCredentialPayload::Voucher {
@@ -933,6 +944,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, Some(override_addr)).unwrap();

--- a/src/client/tempo/tx_builder.rs
+++ b/src/client/tempo/tx_builder.rs
@@ -387,6 +387,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let tx_bytes = vec![0x76, 0xab, 0xcd];
@@ -417,6 +418,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let from: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2"
@@ -443,6 +445,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let tx_bytes = vec![0x76, 0xab, 0xcd, 0xef];
@@ -473,6 +476,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let cred = build_charge_credential(&challenge, &[0x76], 42431, Address::ZERO);
@@ -751,6 +755,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let cred = build_charge_credential(&challenge, &[], 42431, Address::ZERO);
@@ -775,6 +780,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let from: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2"

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -209,6 +209,7 @@ mod tests {
                 request: "eyJhbW91bnQiOiIxMDAwIn0".to_string(),
                 expires: None,
                 digest: None,
+                opaque: None,
             },
             "did:pkh:eip155:42161:0xabc",
             PaymentPayload::transaction("0xdeadbeef"),
@@ -562,6 +563,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
         assert!(echoed_challenge.verify(secret));
 

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -55,6 +55,11 @@ pub struct PaymentChallenge {
     /// Request body digest for body binding (RFC 9530 Content-Digest)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
+
+    /// Server-defined correlation data (base64url-encoded JSON).
+    /// Clients MUST NOT modify.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opaque: Option<String>,
 }
 
 impl PaymentChallenge {
@@ -94,6 +99,7 @@ impl PaymentChallenge {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         }
     }
 
@@ -140,6 +146,7 @@ impl PaymentChallenge {
             request.raw(),
             None,
             None,
+            None,
         );
         Self {
             id,
@@ -150,6 +157,7 @@ impl PaymentChallenge {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         }
     }
 
@@ -167,6 +175,7 @@ impl PaymentChallenge {
         expires: Option<&str>,
         digest: Option<&str>,
         description: Option<&str>,
+        opaque: Option<&str>,
     ) -> Self {
         let realm = realm.into();
         let method = method.into();
@@ -179,6 +188,7 @@ impl PaymentChallenge {
             request.raw(),
             expires,
             digest,
+            opaque,
         );
         Self {
             id,
@@ -189,6 +199,7 @@ impl PaymentChallenge {
             expires: expires.map(String::from),
             description: description.map(String::from),
             digest: digest.map(String::from),
+            opaque: opaque.map(String::from),
         }
     }
 
@@ -232,6 +243,7 @@ impl PaymentChallenge {
             request: self.request.raw().to_string(),
             expires: self.expires.clone(),
             digest: self.digest.clone(),
+            opaque: self.opaque.clone(),
         }
     }
 
@@ -275,7 +287,7 @@ impl PaymentChallenge {
 
     /// Verify that this challenge's ID matches the expected HMAC for the given secret key.
     ///
-    /// Recomputes HMAC-SHA256 over `realm|method|intent|request|expires|digest`
+    /// Recomputes HMAC-SHA256 over `realm|method|intent|request|expires|digest|opaque`
     /// and performs a constant-time comparison against the challenge ID.
     ///
     /// This is the Rust equivalent of `Challenge.verify(challenge, { secretKey })` in the TS SDK.
@@ -299,6 +311,7 @@ impl PaymentChallenge {
             self.request.raw(),
             self.expires.as_deref(),
             self.digest.as_deref(),
+            self.opaque.as_deref(),
         );
         constant_time_eq(&self.id, &expected_id)
     }
@@ -386,7 +399,7 @@ impl PaymentChallenge {
 /// This is the canonical implementation used by both `PaymentChallenge::verify()`
 /// and challenge creation. The algorithm matches the TypeScript and Python SDKs:
 ///
-/// 1. Concatenate all fields `realm|method|intent|request|expires|digest` with `|` (empty string for absent optional fields)
+/// 1. Concatenate all fields `realm|method|intent|request|expires|digest|opaque` with `|` (empty string for absent optional fields)
 /// 2. Compute HMAC-SHA256 with the secret key
 /// 3. Base64url-encode the result (no padding)
 ///
@@ -403,8 +416,10 @@ impl PaymentChallenge {
 ///     "eyJhbW91bnQiOiIxMDAwMDAwIn0",
 ///     None,
 ///     None,
+///     None,
 /// );
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn compute_challenge_id(
     secret_key: &str,
     realm: &str,
@@ -413,6 +428,7 @@ pub fn compute_challenge_id(
     request: &str,
     expires: Option<&str>,
     digest: Option<&str>,
+    opaque: Option<&str>,
 ) -> String {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
@@ -421,7 +437,7 @@ pub fn compute_challenge_id(
 
     // All fields are always included in the pipe-delimited HMAC input,
     // with empty string for absent optional fields. This ensures challenges
-    // with vs without expires/digest produce different HMACs.
+    // with vs without expires/digest/opaque produce different HMACs.
     let hmac_input = [
         realm,
         method,
@@ -429,6 +445,7 @@ pub fn compute_challenge_id(
         request,
         expires.unwrap_or(""),
         digest.unwrap_or(""),
+        opaque.unwrap_or(""),
     ]
     .join("|");
 
@@ -480,6 +497,10 @@ pub struct ChallengeEcho {
     /// Request body digest for body binding (RFC 9530 Content-Digest)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub digest: Option<String>,
+
+    /// Server-defined correlation data (base64url-encoded JSON).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opaque: Option<String>,
 }
 
 /// Payment payload in credential.
@@ -813,6 +834,7 @@ mod tests {
             expires: Some("2024-01-01T00:00:00Z".to_string()),
             description: None,
             digest: None,
+            opaque: None,
         }
     }
 
@@ -1020,6 +1042,7 @@ mod tests {
             request.raw(),
             None,
             None,
+            None,
         );
 
         let challenge = PaymentChallenge {
@@ -1031,6 +1054,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert!(challenge.verify(secret));
@@ -1047,6 +1071,7 @@ mod tests {
             request.raw(),
             None,
             None,
+            None,
         );
 
         let challenge = PaymentChallenge {
@@ -1058,6 +1083,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert!(!challenge.verify("wrong-secret"));
@@ -1076,6 +1102,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert!(!challenge.verify("any-secret"));
@@ -1096,6 +1123,7 @@ mod tests {
             request.raw(),
             expires,
             digest,
+            None,
         );
 
         let challenge = PaymentChallenge {
@@ -1107,6 +1135,7 @@ mod tests {
             expires: expires.map(String::from),
             description: Some("test payment".to_string()),
             digest: digest.map(String::from),
+            opaque: None,
         };
 
         assert!(challenge.verify(secret));
@@ -1125,13 +1154,14 @@ mod tests {
             ),
             None,
             None,
+            None,
         );
-        assert_eq!(id, "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA");
+        assert_eq!(id, "XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4");
     }
 
     /// Cross-SDK golden vectors (shared with mppx and pympp).
     ///
-    /// HMAC input: realm | method | intent | base64url(canonicalize(request)) | expires | digest
+    /// HMAC input: realm | method | intent | base64url(canonicalize(request)) | expires | digest | opaque
     /// HMAC key:   UTF-8 bytes of secret_key ("test-vector-secret")
     /// Output:     base64url(HMAC-SHA256(key, input), no padding)
     ///
@@ -1167,7 +1197,7 @@ mod tests {
                 &req_amount,
                 None,
                 None,
-                "SOfbA51LV3LCkGE7RbomqwXdbWVlrZwlW-Z9aOHolxw",
+                "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4",
             ),
             (
                 "with expires",
@@ -1177,7 +1207,7 @@ mod tests {
                 &req_amount,
                 Some("2025-01-06T12:00:00Z"),
                 None,
-                "R1ZSIwoIjkFhMCSzUGiCTesiigf5vV65EQ_3gVNtsNw",
+                "ChPX33RkKSZoSUyZcu8ai4hhkvjZJFkZVnvWs5s0iXI",
             ),
             (
                 "with digest",
@@ -1187,7 +1217,7 @@ mod tests {
                 &req_amount,
                 None,
                 Some("sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"),
-                "AiMmBdsSOkOYpXTupMnzVnrzZbqMY_P2i80vENRUSN4",
+                "JHB7EFsPVb-xsYCo8LHcOzeX1gfXWVoUSzQsZhKAfKM",
             ),
             (
                 "with expires and digest",
@@ -1197,7 +1227,7 @@ mod tests {
                 &req_amount,
                 Some("2025-01-06T12:00:00Z"),
                 Some("sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"),
-                "FMBGqN7MzpKagHsCcartZM09CnUqv7UgmaCy45Ozgug",
+                "m39jbWWCIfmfJZSwCfvKFFtBl0Qwf9X4nOmDb21peLA",
             ),
             (
                 "multi-field request",
@@ -1207,7 +1237,7 @@ mod tests {
                 &req_multi,
                 None,
                 None,
-                "5CXJi4bWMz2W54WjnlmoxnwTYe-JKwhw0z32ICQ65Es",
+                "_H5TOnnlW0zduQ5OhQ3EyLVze_TqxLDPda2CGZPZxOc",
             ),
             (
                 "nested methodDetails",
@@ -1217,7 +1247,7 @@ mod tests {
                 &req_nested,
                 None,
                 None,
-                "eid66xXUZsj46Pb30AfAf7m5kPehgianI16rZ-QY8HU",
+                "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8",
             ),
             (
                 "empty request",
@@ -1227,7 +1257,7 @@ mod tests {
                 &req_empty,
                 None,
                 None,
-                "6kq-PYTyXtaGAHTHCVUrc_hIsAwLeskeQFtDZerMYhM",
+                "yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU",
             ),
             (
                 "different realm",
@@ -1237,7 +1267,7 @@ mod tests {
                 &req_amount,
                 None,
                 None,
-                "-gMjd8UeUvBcqUaUzarVj6ikH_YoDowpaNbEwK1Tmx8",
+                "3F5bOo2a9RUihdwKk4hGRvBvzQmVPBMDvW0YM-8GD00",
             ),
             (
                 "different method",
@@ -1247,7 +1277,7 @@ mod tests {
                 &req_amount,
                 None,
                 None,
-                "DRH9ycmIlZ2lYUatIHCrxpm9K7ig5pniZ3ulleb7vl0",
+                "o0ra2sd7HcB4Ph0Vns69gRDUhSj5WNOnUopcDqKPLz4",
             ),
             (
                 "different intent",
@@ -1257,13 +1287,14 @@ mod tests {
                 &req_amount,
                 None,
                 None,
-                "INeBi93MhinvbwdUxeUUIaT5Q_ufgLKPYZb5Tg43A1o",
+                "aAY7_IEDzsznNYplhOSE8cERQxvjFcT4Lcn-7FHjLVE",
             ),
         ];
 
         for (label, realm, method, intent, request, expires, digest, expected) in &vectors {
-            let id =
-                compute_challenge_id(secret, realm, method, intent, request, *expires, *digest);
+            let id = compute_challenge_id(
+                secret, realm, method, intent, request, *expires, *digest, None,
+            );
             assert_eq!(&id, expected, "golden vector failed: {}", label);
         }
     }
@@ -1323,6 +1354,7 @@ mod tests {
             request.raw(),
             None,
             None,
+            None,
         );
         let id2 = compute_challenge_id(
             "secret",
@@ -1330,6 +1362,7 @@ mod tests {
             "tempo",
             "charge",
             request.raw(),
+            None,
             None,
             None,
         );
@@ -1349,6 +1382,7 @@ mod tests {
             request.raw(),
             None,
             None,
+            None,
         );
         let id2 = compute_challenge_id(
             "secret-b",
@@ -1356,6 +1390,7 @@ mod tests {
             "tempo",
             "charge",
             request.raw(),
+            None,
             None,
             None,
         );
@@ -1368,7 +1403,16 @@ mod tests {
         let secret = "test-secret";
         let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
 
-        let id = compute_challenge_id(secret, "api", "tempo", "charge", request.raw(), None, None);
+        let id = compute_challenge_id(
+            secret,
+            "api",
+            "tempo",
+            "charge",
+            request.raw(),
+            None,
+            None,
+            None,
+        );
 
         // Build challenge with the valid HMAC ID but tampered request data
         let tampered_request =
@@ -1382,6 +1426,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         assert!(!challenge.verify(secret));
@@ -1427,11 +1472,107 @@ mod tests {
             Some("2026-01-01T00:00:00Z"),
             Some("sha-256=abc"),
             Some("test payment"),
+            None,
         );
         assert!(challenge.verify("my-secret"));
         assert_eq!(challenge.expires.as_deref(), Some("2026-01-01T00:00:00Z"));
         assert_eq!(challenge.digest.as_deref(), Some("sha-256=abc"));
         assert_eq!(challenge.description.as_deref(), Some("test payment"));
+    }
+
+    #[test]
+    fn test_opaque_affects_challenge_id() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let id_without = compute_challenge_id(
+            "test-secret",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request.raw(),
+            None,
+            None,
+            None,
+        );
+        let opaque_json =
+            serde_json::to_string(&serde_json::json!({"pi": "pi_3abc123XYZ"})).unwrap();
+        let opaque_b64 = crate::protocol::core::base64url_encode(opaque_json.as_bytes());
+        let id_with = compute_challenge_id(
+            "test-secret",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request.raw(),
+            None,
+            None,
+            Some(&opaque_b64),
+        );
+        assert_ne!(id_without, id_with);
+    }
+
+    #[test]
+    fn test_opaque_verify_roundtrip() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let opaque_json =
+            serde_json::to_string(&serde_json::json!({"pi": "pi_3abc123XYZ"})).unwrap();
+        let opaque_b64 = crate::protocol::core::base64url_encode(opaque_json.as_bytes());
+        let challenge = PaymentChallenge::with_secret_key_full(
+            "my-secret",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+            None,
+            None,
+            None,
+            Some(&opaque_b64),
+        );
+        assert_eq!(challenge.opaque.as_deref(), Some(opaque_b64.as_str()));
+        assert!(challenge.verify("my-secret"));
+    }
+
+    #[test]
+    fn test_opaque_tamper_fails_verify() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let opaque_json =
+            serde_json::to_string(&serde_json::json!({"pi": "pi_3abc123XYZ"})).unwrap();
+        let opaque_b64 = crate::protocol::core::base64url_encode(opaque_json.as_bytes());
+        let mut challenge = PaymentChallenge::with_secret_key_full(
+            "my-secret",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+            None,
+            None,
+            None,
+            Some(&opaque_b64),
+        );
+        let tampered_json =
+            serde_json::to_string(&serde_json::json!({"pi": "pi_TAMPERED"})).unwrap();
+        let tampered = crate::protocol::core::base64url_encode(tampered_json.as_bytes());
+        challenge.opaque = Some(tampered);
+        assert!(!challenge.verify("my-secret"));
+    }
+
+    #[test]
+    fn test_opaque_echo_roundtrip() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let opaque_json =
+            serde_json::to_string(&serde_json::json!({"pi": "pi_3abc123XYZ"})).unwrap();
+        let opaque_b64 = crate::protocol::core::base64url_encode(opaque_json.as_bytes());
+        let challenge = PaymentChallenge::with_secret_key_full(
+            "my-secret",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+            None,
+            None,
+            None,
+            Some(&opaque_b64),
+        );
+        let echo = challenge.to_echo();
+        assert_eq!(echo.opaque.as_deref(), Some(opaque_b64.as_str()));
     }
 
     #[test]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -244,6 +244,7 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
         expires: params.get("expires").cloned(),
         description: params.get("description").cloned(),
         digest,
+        opaque: params.get("opaque").cloned(),
     })
 }
 
@@ -298,6 +299,7 @@ pub fn parse_www_authenticate_all<'a>(
 ///     expires: None,
 ///     description: None,
 ///     digest: None,
+///     opaque: None,
 /// };
 /// let header = format_www_authenticate(&challenge).unwrap();
 /// assert!(header.starts_with("Payment id=\"abc123\""));
@@ -336,6 +338,10 @@ pub fn format_www_authenticate(challenge: &PaymentChallenge) -> Result<String> {
         parts.push(format!("digest=\"{}\"", escape_quoted_value(digest)?));
     }
 
+    if let Some(ref opaque) = challenge.opaque {
+        parts.push(format!("opaque=\"{}\"", escape_quoted_value(opaque)?));
+    }
+
     Ok(format!("Payment {}", parts.join(", ")))
 }
 
@@ -358,6 +364,7 @@ pub fn format_www_authenticate(challenge: &PaymentChallenge) -> Result<String> {
 ///     expires: None,
 ///     description: None,
 ///     digest: None,
+///     opaque: None,
 /// };
 /// let headers = format_www_authenticate_many(&[challenge]).unwrap();
 /// assert_eq!(headers.len(), 1);
@@ -463,6 +470,7 @@ mod tests {
             expires: Some("2024-01-01T00:00:00Z".to_string()),
             description: None,
             digest: None,
+            opaque: None,
         }
     }
 

--- a/src/protocol/intents/payment_request.rs
+++ b/src/protocol/intents/payment_request.rs
@@ -134,6 +134,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let request = from_challenge(&challenge).unwrap();
@@ -159,6 +160,7 @@ mod tests {
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         };
 
         let decoded: ChargeRequest = from_challenge_typed(&challenge).unwrap();

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -305,6 +305,7 @@ pub fn charge_challenge_with_options(
         encoded_request.raw(),
         expires,
         None,
+        None,
     );
 
     Ok(PaymentChallenge {
@@ -316,6 +317,7 @@ pub fn charge_challenge_with_options(
         expires: expires.map(|s| s.to_string()),
         description: description.map(|s| s.to_string()),
         digest: None,
+        opaque: None,
     })
 }
 
@@ -351,8 +353,10 @@ pub fn charge_challenge_with_options(
 ///     "eyJhbW91bnQiOiIxMDAwMDAwIn0",
 ///     None,
 ///     None,
+///     None,
 /// );
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn generate_challenge_id(
     secret_key: &str,
     realm: &str,
@@ -361,9 +365,10 @@ pub fn generate_challenge_id(
     request: &str,
     expires: Option<&str>,
     digest: Option<&str>,
+    opaque: Option<&str>,
 ) -> String {
     crate::protocol::core::compute_challenge_id(
-        secret_key, realm, method, intent, request, expires, digest,
+        secret_key, realm, method, intent, request, expires, digest, opaque,
     )
 }
 
@@ -400,8 +405,10 @@ pub fn generate_challenge_id(
 ///     }),
 ///     None,
 ///     None,
+///     None,
 /// ).unwrap();
 /// ```
+#[allow(clippy::too_many_arguments)]
 pub fn generate_challenge_id_from_request(
     secret_key: &str,
     realm: &str,
@@ -410,6 +417,7 @@ pub fn generate_challenge_id_from_request(
     request: &serde_json::Value,
     expires: Option<&str>,
     digest: Option<&str>,
+    opaque: Option<&str>,
 ) -> crate::error::Result<String> {
     use crate::protocol::core::base64url_encode;
 
@@ -424,6 +432,7 @@ pub fn generate_challenge_id_from_request(
         &request_b64,
         expires,
         digest,
+        opaque,
     ))
 }
 
@@ -621,10 +630,11 @@ mod tests {
                 }),
                 None,
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "s0gsoewXwdYI13oPnrtdKTEN4-sIQ-LbQUNV_HttPnA");
+            assert_eq!(id, "XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4");
         }
 
         #[test]
@@ -641,10 +651,11 @@ mod tests {
                 }),
                 Some("2026-01-29T12:00:00Z"),
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "0rMv3trZIudpkJCQxeL2RLQz6uALKTNErWulN07hDLk");
+            assert_eq!(id, "EvqUWMPJjqhoVJVG3mhTYVqCa3Mk7bUVd_OjeJGek1A");
         }
 
         #[test]
@@ -661,10 +672,11 @@ mod tests {
                 }),
                 None,
                 Some("sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="),
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "EAX2sqwdeg8Km8LIKRBFhM5xDQvEgIlbTif9FKBsOiU");
+            assert_eq!(id, "qcJUPoapy4bFLznQjQUutwPLyXW7FvALrWA_sMENgAY");
         }
 
         #[test]
@@ -683,10 +695,11 @@ mod tests {
                 }),
                 Some("2026-02-01T00:00:00Z"),
                 Some("sha-256=abc123def456"),
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "96xfZu2wzXD-f-l-hClS9OgODVgIoPWSCWhUw6a4I1Q");
+            assert_eq!(id, "JYtuAXY3wf1gGVFa4L0MsUOwQ90BQISm7wkepNiHbeM");
         }
 
         #[test]
@@ -703,10 +716,11 @@ mod tests {
                 }),
                 None,
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "UMEn_1WPt2vz3XK8rrkbHET6RwqfwtK8VVNz0Xc2x4A");
+            assert_eq!(id, "_o55RP0duNvJYtw9PXnf44mGyY5ajV_wwGzoGdTFuNs");
         }
 
         #[test]
@@ -719,10 +733,11 @@ mod tests {
                 &json!({}),
                 None,
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "jUTqTVe3kCv5rVizv1XBCs9qKCLg4AZLwBUnk4N3MR8");
+            assert_eq!(id, "MYEC2oq3_B3cHa_My1Lx3NQKn_iUiMfsns6361N0SX0");
         }
 
         #[test]
@@ -740,10 +755,11 @@ mod tests {
                 }),
                 None,
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "76lyru2p7i7Xw6fGTJtWzd9c7Z6mt33LIW7968Mlkz8");
+            assert_eq!(id, "54NwtlhzrjHd2Qox2EaElEA9dl73bZ1Y-rig6Ri8Xy8");
         }
 
         #[test]
@@ -764,10 +780,11 @@ mod tests {
                 }),
                 None,
                 None,
+                None,
             )
             .unwrap();
 
-            assert_eq!(id, "xPIM2fN55BNq6ADKIFvGCR5zB7DhH6YbwDtAqtExwI0");
+            assert_eq!(id, "BdPQxVJ56pvRJnM-r7wh_ppka5hOJH_6XpRK4gM9paI");
         }
     }
 }

--- a/src/protocol/traits/charge.rs
+++ b/src/protocol/traits/charge.rs
@@ -185,6 +185,7 @@ mod tests {
             request: "eyJ0ZXN0IjoidmFsdWUifQ".into(),
             expires: None,
             digest: None,
+            opaque: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
         let request = ChargeRequest {

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -151,6 +151,7 @@ mod tests {
             request: "eyJ0ZXN0IjoidmFsdWUifQ".into(),
             expires: None,
             digest: None,
+            opaque: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
         let request = SessionRequest {

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -346,6 +346,7 @@ where
                 &credential.challenge.request,
                 credential.challenge.expires.as_deref(),
                 credential.challenge.digest.as_deref(),
+                credential.challenge.opaque.as_deref(),
             );
 
             if credential.challenge.id != expected_id {
@@ -392,6 +393,7 @@ where
             encoded.raw(),
             None,
             None,
+            None,
         );
 
         Ok(PaymentChallenge {
@@ -403,6 +405,7 @@ where
             expires: None,
             description: None,
             digest: None,
+            opaque: None,
         })
     }
 
@@ -468,6 +471,7 @@ where
             encoded.raw(),
             options.expires,
             None,
+            None,
         );
 
         Ok(PaymentChallenge {
@@ -479,6 +483,7 @@ where
             expires: options.expires.map(|s| s.to_string()),
             description: options.description.map(|s| s.to_string()),
             digest: None,
+            opaque: None,
         })
     }
 
@@ -502,6 +507,7 @@ where
                 &credential.challenge.request,
                 credential.challenge.expires.as_deref(),
                 credential.challenge.digest.as_deref(),
+                credential.challenge.opaque.as_deref(),
             );
             if credential.challenge.id != expected_id {
                 return Err(crate::protocol::traits::VerificationError::with_code(
@@ -672,6 +678,7 @@ mod tests {
                     request,
                     None,
                     None,
+                    None,
                 )
             }
             #[cfg(not(feature = "tempo"))]
@@ -688,6 +695,7 @@ mod tests {
             request: request.into(),
             expires: None,
             digest: None,
+            opaque: None,
         };
         PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
     }
@@ -861,6 +869,7 @@ mod tests {
                     &raw,
                     None,
                     None,
+                    None,
                 )
             }
             #[cfg(not(feature = "tempo"))]
@@ -877,6 +886,7 @@ mod tests {
             request: raw,
             expires: None,
             digest: None,
+            opaque: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 
@@ -1290,6 +1300,7 @@ mod tests {
             request: "eyJ0ZXN0IjoidmFsdWUifQ".into(),
             expires: None,
             digest: None,
+            opaque: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 


### PR DESCRIPTION
## Summary

Adds an `opaque` field to `PaymentChallenge` and `ChallengeEcho` for server-defined correlation data (e.g. Stripe PaymentIntent IDs), per [mpp-specs#148](https://github.com/ArkEcosystem/mpp-specs/issues/148). Ports the protocol-level support from [wevm/mppx#121](https://github.com/wevm/mppx/pull/121) (TypeScript SDK).

## HMAC Format Change

HMAC input changes from 6 to 7 pipe-delimited slots:

```
realm|method|intent|request_b64|expires|digest|opaque
```

When `opaque` is absent, the 7th slot is empty string. This changes **all** existing golden vectors even when opaque is not used.

The opaque value is a base64url-encoded JSON string that clients MUST echo back verbatim without modification.

## Changes

- `protocol/core/challenge.rs`: `PaymentChallenge` and `ChallengeEcho` get `opaque: Option<String>`, `compute_challenge_id` accepts `opaque`, `with_secret_key_full` accepts `opaque`, `to_echo()` forwards opaque, `verify()` includes opaque
- `protocol/core/headers.rs`: parse/format WWW-Authenticate with opaque roundtrip
- `protocol/methods/tempo/mod.rs`: `generate_challenge_id` and `generate_challenge_id_from_request` forward opaque parameter
- `server/mpp.rs`: verification forwards echoed `opaque` for HMAC check
- All struct literals across tests updated with `opaque: None`
- 4 new opaque-specific tests: affects ID, verify roundtrip, tamper detection, echo roundtrip

## Test Results

229 lib tests + 28 doc tests pass (4 new tests added)

## Cross-SDK Vectors

Key vectors verified against TypeScript PR:
- Required fields only: `X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4`
- Cross-SDK basic charge: `XmJ98SdsAdzwP9Oa-8In322Uh6yweMO6rywdomWk_V4`

## Follow-up

High-level server APIs (`charge_challenge_with_options`, `MppServer::create_charge_challenge`) currently hardcode `opaque: None`. A follow-up PR will add `meta`/`opaque` to the options structs for parity with the Python SDK.

Refs: wevm/mppx#121, mpp-specs#148