### PR TITLE
ci: add CI Gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,18 @@ jobs:
       - run: cargo check ${{ matrix.features }}
       - run: cargo test ${{ matrix.features }}
 
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [lint, test, feature-matrix, integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            exit 1
+          fi
+
   integration-test:
     name: Integration Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a single `CI Gate` job that `needs: [lint, test, feature-matrix, integration-test]` with `if: always()`. This lets branch protection require only `CI Gate` instead of maintaining a list of every individual job name.

After merging, branch protection will be updated to require only `CI Gate`.