### PR TITLE
fix: use spec-correct paymentauth.org URI for core problem types

### DIFF
--- a/.changelog/easy-goats-wink.md
+++ b/.changelog/easy-goats-wink.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed core problem type base URI to use the canonical `https://paymentauth.org/problems` domain instead of the temporary GitHub Pages URL.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -32,6 +32,7 @@ jobs:
           fi
           ~/.local/bin/changelogs add --ecosystem rust --ai "claude -p" --ref origin/${{ github.base_ref }}
       - name: Commit changelog
+        id: commit
         run: |
           if [ -n "$(git status --porcelain .changelog/)" ]; then
             git config user.name "github-actions[bot]"
@@ -39,4 +40,12 @@ jobs:
             git add .changelog/
             git commit -m "chore: add changelog"
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
+
+  ci:
+    needs: changelog
+    if: always()
+    uses: ./.github/workflows/ci.yml
+    with:
+      ref: ${{ github.head_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -18,6 +23,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -38,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo update -p native-tls

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,7 @@ pub type Result<T> = std::result::Result<T, MppError>;
 // ==================== RFC 9457 Problem Details ====================
 
 /// Base URI for core payment-auth problem types.
-pub const CORE_PROBLEM_TYPE_BASE: &str = "https://tempoxyz.github.io/payment-auth-spec/problems";
+pub const CORE_PROBLEM_TYPE_BASE: &str = "https://paymentauth.org/problems";
 
 /// Base URI for session/channel problem types.
 pub const SESSION_PROBLEM_TYPE_BASE: &str = "https://paymentauth.org/problems/session";
@@ -695,7 +695,7 @@ mod tests {
 
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/test-error"
+            "https://paymentauth.org/problems/test-error"
         );
         assert_eq!(problem.title, "TestError");
         assert_eq!(problem.status, 400);
@@ -755,7 +755,7 @@ mod tests {
         let problem = err.to_problem_details(Some("test-id"));
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/malformed-credential"
+            "https://paymentauth.org/problems/malformed-credential"
         );
         assert_eq!(problem.title, "MalformedCredentialError");
         assert_eq!(problem.challenge_id, Some("test-id".to_string()));
@@ -781,7 +781,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-challenge"
+            "https://paymentauth.org/problems/invalid-challenge"
         );
         assert_eq!(problem.challenge_id, Some("abc123".to_string()));
     }
@@ -800,7 +800,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/verification-failed"
+            "https://paymentauth.org/problems/verification-failed"
         );
         assert_eq!(problem.title, "VerificationFailedError");
     }
@@ -816,7 +816,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/payment-expired"
+            "https://paymentauth.org/problems/payment-expired"
         );
     }
 
@@ -846,7 +846,7 @@ mod tests {
         let problem = err.to_problem_details(Some("chal-id"));
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/payment-required"
+            "https://paymentauth.org/problems/payment-required"
         );
         assert_eq!(problem.challenge_id, Some("chal-id".to_string()));
     }
@@ -862,7 +862,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/bad-request"
+            "https://paymentauth.org/problems/bad-request"
         );
         assert_eq!(problem.title, "BadRequestError");
         assert_eq!(problem.status, 400);
@@ -1012,7 +1012,7 @@ mod tests {
         let problem = err.to_problem_details(None);
         assert_eq!(
             problem.problem_type,
-            "https://tempoxyz.github.io/payment-auth-spec/problems/invalid-payload"
+            "https://paymentauth.org/problems/invalid-payload"
         );
         assert_eq!(problem.title, "InvalidPayloadError");
     }


### PR DESCRIPTION
## Problem

`CORE_PROBLEM_TYPE_BASE` was still pointing to the old development URI (`https://tempoxyz.github.io/payment-auth-spec/problems`). The spec and all other SDKs (mppx, pympp) use `https://paymentauth.org/problems`.

This means all RFC 9457 Problem Details responses from Rust servers had the wrong `type` URI, breaking interop with clients that check the canonical URI.

Note: `SESSION_PROBLEM_TYPE_BASE` was already correct (`https://paymentauth.org/problems/session`).
