### PR TITLE
feat: add expiring nonces option to TempoProvider

### DIFF
--- a/src/client/tempo/charge.rs
+++ b/src/client/tempo/charge.rs
@@ -209,9 +209,12 @@ impl TempoCharge {
             .max_priority_fee_per_gas
             .unwrap_or(resolved.max_priority_fee_per_gas);
 
-        // Fee payer mode: use expiring nonces to avoid nonce collisions
-        // when the server co-signs and broadcasts on the client's behalf.
-        let (nonce, nonce_key, valid_before, gas_limit) = if self.fee_payer {
+        // Use expiring nonces when fee_payer mode or explicitly requested.
+        // Expiring nonces (TIP-1009) avoid nonce collisions by using a
+        // circular buffer keyed by transaction hash instead of sequential nonces.
+        let use_expiring = self.fee_payer || options.expiring_nonces;
+
+        let (nonce, nonce_key, valid_before, gas_limit) = if use_expiring {
             let nonce = options.nonce.unwrap_or(0);
             let nonce_key = options.nonce_key.unwrap_or(EXPIRING_NONCE_KEY);
             let valid_before = options.valid_before.or_else(|| {
@@ -324,6 +327,12 @@ pub struct SignOptions {
     /// bumps gas to replace stuck transactions. Useful for CLI tools and
     /// interactive clients. Default: `false`.
     pub replace_stuck_txs: bool,
+    /// Use expiring nonces (TIP-1009) instead of sequential nonces.
+    ///
+    /// When `true`, transactions use `nonce_key = U256::MAX` with a
+    /// `valid_before` timestamp, avoiding nonce collisions when multiple
+    /// transactions are sent concurrently. Default: `false`.
+    pub expiring_nonces: bool,
 }
 
 /// A signed Tempo charge, ready to be converted into a [`PaymentCredential`].

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -41,6 +41,7 @@ pub struct TempoProvider {
     client_id: Option<String>,
     signing_mode: TempoSigningMode,
     replace_stuck_txs: bool,
+    expiring_nonces: bool,
 }
 
 impl TempoProvider {
@@ -63,6 +64,7 @@ impl TempoProvider {
             client_id: None,
             signing_mode: TempoSigningMode::Direct,
             replace_stuck_txs: false,
+            expiring_nonces: false,
         })
     }
 
@@ -89,6 +91,18 @@ impl TempoProvider {
     /// Default: `false`.
     pub fn with_replace_stuck_transactions(mut self, enabled: bool) -> Self {
         self.replace_stuck_txs = enabled;
+        self
+    }
+
+    /// Use expiring nonces (TIP-1009) for all transactions.
+    ///
+    /// When enabled, transactions use `nonce_key = U256::MAX` with a
+    /// `valid_before` timestamp instead of sequential nonces. This avoids
+    /// nonce collisions when multiple transactions are sent concurrently.
+    ///
+    /// Default: `false`.
+    pub fn with_expiring_nonces(mut self, enabled: bool) -> Self {
+        self.expiring_nonces = enabled;
         self
     }
 
@@ -120,6 +134,7 @@ impl PaymentProvider for TempoProvider {
             rpc_url: Some(self.rpc_url.to_string()),
             signing_mode: Some(self.signing_mode.clone()),
             replace_stuck_txs: self.replace_stuck_txs,
+            expiring_nonces: self.expiring_nonces,
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary

Adds `with_expiring_nonces(true)` to `TempoProvider` and `expiring_nonces` to `SignOptions`.

## Motivation

When Presto (or any client) sends multiple transactions concurrently, sequential nonces collide — the classic "nonce already used" error on fresh runs. Expiring nonces (TIP-1009) avoid this by using `nonce_key=U256::MAX` + `valid_before` timestamp instead of sequential counters.

Previously, expiring nonces were only available in fee-payer mode. This PR makes them usable for standard (non-fee-payer) charge transactions too.

## Changes

- `SignOptions.expiring_nonces: bool` — new field, default `false`
- `TempoProvider::with_expiring_nonces(bool)` — builder method to enable
- `charge.rs`: expiring nonce path now triggered by `fee_payer || options.expiring_nonces`

## Testing

`cargo test` — all 28 tests pass, fmt + clippy clean.

Prompted by: georgios