### PR TITLE
chore(ci): add cyclops PR audit workflow

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,10 @@
+name: PR Audit
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  pr-audit:
+    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add reusable PR audit workflow caller
- trigger on PR label events (`pull_request` with `types: [labeled]`)
- use `tempoxyz/gh-actions` shared workflow (default label: `cyclops`)

```yaml
name: PR Audit

on:
  pull_request:
    types: [labeled]

jobs:
  pr-audit:
    uses: tempoxyz/gh-actions/.github/workflows/pr-audit.yml@main
    secrets: inherit
```
