### PR TITLE
fix(mpp-rs): require secret key and tighten core parsing

### DIFF
--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -64,7 +64,11 @@ async fn main() {
     let mut builder = tempo(TempoConfig {
         recipient: &recipient,
     })
-    .rpc_url(&rpc_url);
+    .rpc_url(&rpc_url)
+    // Keep the demo runnable out-of-the-box while honoring required secret key semantics.
+    .secret_key(
+        &std::env::var("MPP_SECRET_KEY").unwrap_or_else(|_| "basic-example-secret".to_string()),
+    );
 
     if let Ok(id) = std::env::var("CHAIN_ID") {
         builder = builder.chain_id(id.parse().expect("CHAIN_ID must be a number"));

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -217,13 +217,14 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
         ));
     }
     let realm = require_param!(params, "realm").clone();
-    let method = MethodName::new(require_param!(params, "method"));
-    if !method.is_valid() {
+    let method_raw = require_param!(params, "method").clone();
+    if method_raw.is_empty() || !method_raw.chars().all(|c| c.is_ascii_lowercase()) {
         return Err(MppError::invalid_challenge_reason(format!(
             "Invalid method: \"{}\". Must match method-name ABNF.",
-            method.as_str()
+            method_raw
         )));
     }
+    let method = MethodName::new(method_raw);
     let intent = IntentName::new(require_param!(params, "intent"));
     let request_b64 = require_param!(params, "request").clone();
 
@@ -832,6 +833,14 @@ mod tests {
     fn test_parse_www_authenticate_rejects_invalid_method_name_digit_prefix() {
         let header =
             r#"Payment id="abc", realm="api", method="1tempo", intent="charge", request="e30""#;
+        let err = parse_www_authenticate(header).unwrap_err();
+        assert!(err.to_string().contains("Invalid method"));
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_rejects_mixed_case_method_name() {
+        let header =
+            r#"Payment id="abc", realm="api", method="Tempo", intent="charge", request="e30""#;
         let err = parse_www_authenticate(header).unwrap_err();
         assert!(err.to_string().contains("Invalid method"));
     }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -218,6 +218,12 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
     }
     let realm = require_param!(params, "realm").clone();
     let method = MethodName::new(require_param!(params, "method"));
+    if !method.is_valid() {
+        return Err(MppError::invalid_challenge_reason(format!(
+            "Invalid method: \"{}\". Must match method-name ABNF.",
+            method.as_str()
+        )));
+    }
     let intent = IntentName::new(require_param!(params, "intent"));
     let request_b64 = require_param!(params, "request").clone();
 
@@ -812,6 +818,22 @@ mod tests {
             r#"Payment id="", realm="api", method="tempo", intent="charge", request="e30""#;
         let err = parse_www_authenticate(header).unwrap_err();
         assert!(err.to_string().contains("Empty 'id'"));
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_rejects_invalid_method_name_dash() {
+        let header =
+            r#"Payment id="abc", realm="api", method="tempo-v2", intent="charge", request="e30""#;
+        let err = parse_www_authenticate(header).unwrap_err();
+        assert!(err.to_string().contains("Invalid method"));
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_rejects_invalid_method_name_digit_prefix() {
+        let header =
+            r#"Payment id="abc", realm="api", method="1tempo", intent="charge", request="e30""#;
+        let err = parse_www_authenticate(header).unwrap_err();
+        assert!(err.to_string().contains("Invalid method"));
     }
 
     #[test]

--- a/src/protocol/intents/mod.rs
+++ b/src/protocol/intents/mod.rs
@@ -48,6 +48,12 @@ pub use session::SessionRequest;
 /// - `parse_units("100", 6)` → `"100000000"`
 /// - `parse_units("0.001", 18)` → `"1000000000000000"`
 pub fn parse_units(amount: &str, decimals: u8) -> crate::error::Result<String> {
+    if amount.is_empty() {
+        return Err(crate::error::MppError::InvalidAmount(
+            "Amount cannot be empty".to_string(),
+        ));
+    }
+
     let parts: Vec<&str> = amount.split('.').collect();
     if parts.len() > 2 {
         return Err(crate::error::MppError::InvalidAmount(format!(
@@ -118,5 +124,10 @@ mod tests {
     #[test]
     fn test_parse_units_no_integer_part() {
         assert_eq!(parse_units("0.5", 6).unwrap(), "500000");
+    }
+
+    #[test]
+    fn test_parse_units_empty_string() {
+        assert!(parse_units("", 6).is_err());
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -116,7 +116,7 @@ impl TempoBuilder {
         self
     }
 
-    /// Override the secret key (default: reads `MPP_SECRET_KEY` env var or generates UUID).
+    /// Override the secret key (default: reads `MPP_SECRET_KEY` env var).
     pub fn secret_key(mut self, key: &str) -> Self {
         self.secret_key = Some(key.to_string());
         self
@@ -189,7 +189,7 @@ pub struct ChargeOptions<'a> {
 /// - **realm**: auto-detected from `MPP_REALM`, `FLY_APP_NAME`, `HEROKU_APP_NAME`,
 ///   `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`,
 ///   `VERCEL_URL`, `WEBSITE_HOSTNAME` — falling back to `"MPP Payment"`
-/// - **secret_key**: reads `MPP_SECRET_KEY` env var, or generates a random UUID
+/// - **secret_key**: reads `MPP_SECRET_KEY` env var; required if not explicitly set
 /// - **currency**: pathUSD (`0x20c0000000000000000000000000000000000000`)
 /// - **decimals**: `6` (for pathUSD / standard stablecoins)
 /// - **expires**: `now + 5 minutes`

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -616,6 +616,13 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
         let secret_key = builder
             .secret_key
             .or_else(|| std::env::var(SECRET_KEY_ENV_VAR).ok())
+            .and_then(|value| {
+                if value.trim().is_empty() {
+                    None
+                } else {
+                    Some(value)
+                }
+            })
             .ok_or_else(|| {
                 crate::error::MppError::InvalidConfig(format!(
                     "Missing secret key. Set {} environment variable or pass .secret_key(...).",
@@ -878,6 +885,26 @@ mod tests {
         }));
         match result {
             Ok(_) => panic!("missing secret key should fail creation"),
+            Err(err) => assert!(err.to_string().contains("Missing secret key")),
+        }
+
+        unsafe { std::env::set_var(SECRET_KEY_ENV_VAR, "   ") };
+        let whitespace_env = Mpp::create(tempo(TempoConfig {
+            recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+        }));
+        match whitespace_env {
+            Ok(_) => panic!("whitespace-only env secret key should fail creation"),
+            Err(err) => assert!(err.to_string().contains("Missing secret key")),
+        }
+
+        let whitespace_builder = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .secret_key(""),
+        );
+        match whitespace_builder {
+            Ok(_) => panic!("empty builder secret key should fail creation"),
             Err(err) => assert!(err.to_string().contains("Missing secret key")),
         }
     }

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -613,9 +613,15 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
     /// let challenge = mpp.charge("1.00")?;
     /// ```
     pub fn create(builder: super::TempoBuilder) -> Result<Self> {
-        let secret_key = builder.secret_key.unwrap_or_else(|| {
-            std::env::var(SECRET_KEY_ENV_VAR).unwrap_or_else(|_| uuid::Uuid::new_v4().to_string())
-        });
+        let secret_key = builder
+            .secret_key
+            .or_else(|| std::env::var(SECRET_KEY_ENV_VAR).ok())
+            .ok_or_else(|| {
+                crate::error::MppError::InvalidConfig(format!(
+                    "Missing secret key. Set {} environment variable or pass .secret_key(...).",
+                    SECRET_KEY_ENV_VAR
+                ))
+            })?;
 
         let provider = super::tempo_provider(&builder.rpc_url)?;
         let mut method = crate::protocol::methods::tempo::ChargeMethod::new(provider);
@@ -848,6 +854,32 @@ mod tests {
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2")
         );
         assert_eq!(mpp.decimals(), 6);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_mpp_create_requires_secret_key() {
+        struct EnvGuard(Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                if let Some(value) = &self.0 {
+                    unsafe { std::env::set_var(SECRET_KEY_ENV_VAR, value) };
+                } else {
+                    unsafe { std::env::remove_var(SECRET_KEY_ENV_VAR) };
+                }
+            }
+        }
+
+        let _guard = EnvGuard(std::env::var(SECRET_KEY_ENV_VAR).ok());
+        unsafe { std::env::remove_var(SECRET_KEY_ENV_VAR) };
+
+        let result = Mpp::create(tempo(TempoConfig {
+            recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+        }));
+        match result {
+            Ok(_) => panic!("missing secret key should fail creation"),
+            Err(err) => assert!(err.to_string().contains("Missing secret key")),
+        }
     }
 
     #[cfg(feature = "tempo")]


### PR DESCRIPTION
Summary:
- require explicit secret key via builder or MPP_SECRET_KEY env 
- reject empty parse_units input and add regression test
- enforce method-name ABNF at challenge parse time and add invalid-name tests 
- update server docs to reflect required secret behavior