### PR TITLE
fix(middleware): per-request challenges and safer service call handling

### DIFF
--- a/src/protocol/intents/charge.rs
+++ b/src/protocol/intents/charge.rs
@@ -7,6 +7,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::error::{MppError, Result};
+#[cfg(feature = "evm")]
+use crate::evm::U256;
 
 /// Charge request (for charge intent).
 ///
@@ -93,6 +95,15 @@ impl ChargeRequest {
             .map_err(|_| MppError::InvalidAmount(format!("Invalid amount: {}", self.amount)))
     }
 
+    /// Parse the amount as U256 when EVM support is enabled.
+    ///
+    /// This matches bigint semantics in the TypeScript SDK and avoids the
+    /// `u128` ceiling of [`parse_amount`].
+    #[cfg(feature = "evm")]
+    pub fn parse_amount_u256(&self) -> Result<U256> {
+        crate::evm::parse_amount(&self.amount)
+    }
+
     /// Validate that the charge amount does not exceed a maximum.
     ///
     /// # Arguments
@@ -159,6 +170,18 @@ mod tests {
             ..Default::default()
         };
         assert!(invalid.parse_amount().is_err());
+    }
+
+    #[cfg(feature = "evm")]
+    #[test]
+    fn test_parse_amount_u256() {
+        let req = ChargeRequest {
+            amount: "340282366920938463463374607431768211456".to_string(), // u128::MAX + 1
+            ..Default::default()
+        };
+
+        let parsed = req.parse_amount_u256().unwrap();
+        assert_eq!(parsed.to_string(), "340282366920938463463374607431768211456");
     }
 
     #[test]

--- a/src/protocol/intents/charge.rs
+++ b/src/protocol/intents/charge.rs
@@ -181,7 +181,10 @@ mod tests {
         };
 
         let parsed = req.parse_amount_u256().unwrap();
-        assert_eq!(parsed.to_string(), "340282366920938463463374607431768211456");
+        assert_eq!(
+            parsed.to_string(),
+            "340282366920938463463374607431768211456"
+        );
     }
 
     #[test]

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -258,7 +258,7 @@ impl PaymentVerifier for ChargeVerifier {
 impl PaymentLayer<ChargeVerifier> {
     /// Create a payment layer that charges a dollar amount per request.
     ///
-    /// This generates a fresh challenge for each request and verifies each
+    /// Generates a fresh challenge for each request and verifies each
     /// incoming credential against the provided `Mpp` instance.
     ///
     /// # Example

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -156,10 +156,10 @@ where
 
     fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
         let verifier = Arc::clone(&self.verifier);
-        let mut inner = self.inner.clone();
-        // Swap so the clone (which is ready) is used for this call,
-        // and self retains the original for the next poll_ready cycle.
-        std::mem::swap(&mut self.inner, &mut inner);
+        // Keep a clone in `self` for future poll_ready cycles and call the
+        // currently-ready service instance moved out of `self`.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
             // Extract the Authorization header.
@@ -232,8 +232,8 @@ fn error_response<B: Default>(status: StatusCode, _message: &str) -> Response<B>
 /// Created via [`PaymentLayer::charge()`].
 #[allow(clippy::type_complexity)]
 struct ChargeVerifier {
-    /// Pre-formatted `WWW-Authenticate` header value.
-    challenge_header: String,
+    /// Builds a fresh `WWW-Authenticate` header value per request.
+    challenge_fn: Box<dyn Fn() -> Result<String, String> + Send + Sync>,
     /// Shared mpp instance for verification (type-erased).
     verify_fn: Box<
         dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
@@ -244,7 +244,7 @@ struct ChargeVerifier {
 
 impl PaymentVerifier for ChargeVerifier {
     fn challenge(&self) -> Result<String, String> {
-        Ok(self.challenge_header.clone())
+        (self.challenge_fn)()
     }
 
     fn verify(
@@ -258,8 +258,8 @@ impl PaymentVerifier for ChargeVerifier {
 impl PaymentLayer<ChargeVerifier> {
     /// Create a payment layer that charges a dollar amount per request.
     ///
-    /// This pre-generates the challenge at construction time and verifies
-    /// each incoming credential against the provided `Mpp` instance.
+    /// This generates a fresh challenge for each request and verifies each
+    /// incoming credential against the provided `Mpp` instance.
     ///
     /// # Example
     ///
@@ -274,29 +274,30 @@ impl PaymentLayer<ChargeVerifier> {
         M: crate::protocol::traits::ChargeMethod + Clone + Send + Sync + 'static,
         S: Clone + Send + Sync + 'static,
     {
-        let challenge = mpp.charge(amount)?;
-        let challenge_header = format_www_authenticate(&challenge).map_err(|e| {
-            crate::error::MppError::InvalidConfig(format!("Failed to format challenge: {}", e))
-        })?;
+        let mpp_for_challenge = mpp.clone();
+        let charge_amount = amount.to_string();
+        let challenge_fn = Box::new(move || {
+            let challenge = mpp_for_challenge
+                .charge(&charge_amount)
+                .map_err(|e| format!("Failed to generate challenge: {}", e))?;
+            format_www_authenticate(&challenge).map_err(|e| {
+                format!("Failed to format challenge: {}", e)
+            })
+        });
 
-        // Extract expected request from the challenge for cross-route validation
-        let expected_request: crate::protocol::intents::ChargeRequest =
-            crate::protocol::core::Base64UrlJson::from_raw(challenge.request.raw().to_string())
-                .decode()
-                .map_err(|e| {
-                    crate::error::MppError::InvalidConfig(format!(
-                        "Failed to decode charge request: {}",
-                        e
-                    ))
-                })?;
-
-        let mpp = mpp.clone();
+        let mpp_for_verify = mpp.clone();
         let verify_fn = Box::new(move |credential_str: String| -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
-            let mpp = mpp.clone();
-            let expected_request = expected_request.clone();
+            let mpp = mpp_for_verify.clone();
             Box::pin(async move {
                 let credential = parse_authorization(&credential_str)
                     .map_err(|e| format!("Invalid credential: {}", e))?;
+
+                let expected_request: crate::protocol::intents::ChargeRequest =
+                    crate::protocol::core::Base64UrlJson::from_raw(
+                        credential.challenge.request.clone(),
+                    )
+                    .decode()
+                    .map_err(|e| format!("Failed to decode challenge request: {}", e))?;
 
                 let receipt = mpp
                     .verify_credential_with_expected_request(&credential, &expected_request)
@@ -308,7 +309,7 @@ impl PaymentLayer<ChargeVerifier> {
         });
 
         Ok(Self::new(ChargeVerifier {
-            challenge_header,
+            challenge_fn,
             verify_fn,
         }))
     }

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -280,9 +280,8 @@ impl PaymentLayer<ChargeVerifier> {
             let challenge = mpp_for_challenge
                 .charge(&charge_amount)
                 .map_err(|e| format!("Failed to generate challenge: {}", e))?;
-            format_www_authenticate(&challenge).map_err(|e| {
-                format!("Failed to format challenge: {}", e)
-            })
+            format_www_authenticate(&challenge)
+                .map_err(|e| format!("Failed to format challenge: {}", e))
         });
 
         let mpp_for_verify = mpp.clone();

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -274,6 +274,21 @@ impl PaymentLayer<ChargeVerifier> {
         M: crate::protocol::traits::ChargeMethod + Clone + Send + Sync + 'static,
         S: Clone + Send + Sync + 'static,
     {
+        // Capture route-scoped expected request once so credential verification
+        // compares against endpoint configuration, not echoed credential data.
+        let expected_challenge = mpp.charge(amount)?;
+        let expected_request: crate::protocol::intents::ChargeRequest =
+            crate::protocol::core::Base64UrlJson::from_raw(
+                expected_challenge.request.raw().to_string(),
+            )
+            .decode()
+            .map_err(|e| {
+                crate::error::MppError::InvalidConfig(format!(
+                    "Failed to decode route charge request: {}",
+                    e
+                ))
+            })?;
+
         let mpp_for_challenge = mpp.clone();
         let charge_amount = amount.to_string();
         let challenge_fn = Box::new(move || {
@@ -287,16 +302,10 @@ impl PaymentLayer<ChargeVerifier> {
         let mpp_for_verify = mpp.clone();
         let verify_fn = Box::new(move |credential_str: String| -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
             let mpp = mpp_for_verify.clone();
+            let expected_request = expected_request.clone();
             Box::pin(async move {
                 let credential = parse_authorization(&credential_str)
                     .map_err(|e| format!("Invalid credential: {}", e))?;
-
-                let expected_request: crate::protocol::intents::ChargeRequest =
-                    crate::protocol::core::Base64UrlJson::from_raw(
-                        credential.challenge.request.clone(),
-                    )
-                    .decode()
-                    .map_err(|e| format!("Failed to decode challenge request: {}", e))?;
 
                 let receipt = mpp
                     .verify_credential_with_expected_request(&credential, &expected_request)


### PR DESCRIPTION
## Summary
- generate fresh challenge headers per request in `PaymentLayer::charge`
- remove construction-time challenge reuse
- adjust service call handling to move the ready service instance out and keep a clone for future readiness cycles
- add `parse_amount_u256()` for charge requests under `evm` feature with regression test

## Files
- src/server/middleware.rs
- src/protocol/intents/charge.rs
