### PR TITLE
refactor: consolidate expires into challenge auth-param only

### DIFF
--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -244,8 +244,8 @@ impl PaymentChallenge {
 
     /// Get the effective expiration time for this payment challenge.
     ///
-    /// Returns `challenge.expires` if set. Callers should also check
-    /// the intent-specific request (e.g., `ChargeRequest.expires`).
+    /// Returns `challenge.expires` if set. Expiry is a property of
+    /// the challenge lifecycle, not the payment request content.
     pub fn effective_expires(&self) -> Option<&str> {
         self.expires.as_deref()
     }

--- a/src/protocol/intents/charge.rs
+++ b/src/protocol/intents/charge.rs
@@ -25,7 +25,6 @@ use crate::evm::U256;
 ///     currency: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
 ///     decimals: None,
 ///     recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string()),
-///     expires: None,
 ///     description: Some("API access".to_string()),
 ///     external_id: None,
 ///     method_details: None,
@@ -52,10 +51,6 @@ pub struct ChargeRequest {
     /// Recipient address (optional, server may be recipient)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recipient: Option<String>,
-
-    /// Request expiration (ISO 8601)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires: Option<String>,
 
     /// Human-readable description
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,7 +133,6 @@ mod tests {
             amount: "10000".to_string(),
             currency: "0x123".to_string(),
             recipient: Some("0x456".to_string()),
-            expires: Some("2024-01-01T00:00:00Z".to_string()),
             description: None,
             external_id: None,
             method_details: Some(serde_json::json!({

--- a/src/protocol/methods/tempo/charge.rs
+++ b/src/protocol/methods/tempo/charge.rs
@@ -134,7 +134,6 @@ mod tests {
             amount: "1000000".to_string(),
             currency: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48".to_string(),
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string()),
-            expires: Some("2024-01-01T00:00:00Z".to_string()),
             description: None,
             external_id: None,
             method_details: Some(serde_json::json!({

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -34,7 +34,7 @@ use crate::protocol::core::{PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
 use crate::protocol::traits::{ChargeMethod as ChargeMethodTrait, VerificationError};
 
-use super::{parse_iso8601_timestamp, TempoChargeExt, CHAIN_ID, INTENT_CHARGE, METHOD_NAME};
+use super::{TempoChargeExt, CHAIN_ID, INTENT_CHARGE, METHOD_NAME};
 
 /// TIP-20 Transfer event topic: keccak256("Transfer(address,address,uint256)")
 /// TIP-20 is Tempo's token standard (compatible with ERC-20 Transfer events).
@@ -335,27 +335,6 @@ where
                 expected_amount, currency, expected_recipient
             )))
         }
-    }
-
-    fn check_expiration(&self, expires: &str) -> Result<(), VerificationError> {
-        use std::time::{SystemTime, UNIX_EPOCH};
-
-        let expires_ts = parse_iso8601_timestamp(expires)
-            .ok_or_else(|| VerificationError::new("Invalid expires timestamp"))?;
-
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        if now > expires_ts {
-            return Err(VerificationError::expired(format!(
-                "Request expired at {}",
-                expires
-            )));
-        }
-
-        Ok(())
     }
 
     /// Validate that a transaction contains the expected payment call.
@@ -715,10 +694,6 @@ where
                     "Intent mismatch: expected {}, got {}",
                     INTENT_CHARGE, credential.challenge.intent
                 )));
-            }
-
-            if let Some(ref expires) = request.expires {
-                this.check_expiration(expires)?;
             }
 
             let expected_chain_id = request.chain_id().unwrap_or(CHAIN_ID);

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -68,7 +68,7 @@
 //!
 //! # let req = ChargeRequest {
 //! #     amount: "1000".into(), currency: "0x".into(), recipient: None,
-//! #     expires: None, description: None, external_id: None,
+//! #     description: None, external_id: None,
 //! #     decimals: None,
 //! #     method_details: Some(serde_json::json!({
 //! #         "feePayer": true
@@ -434,17 +434,6 @@ pub fn generate_challenge_id_from_request(
         digest,
         opaque,
     ))
-}
-
-/// Parse an ISO 8601 timestamp string (e.g. "2024-01-15T12:00:00Z") to Unix timestamp.
-#[cfg(feature = "server")]
-pub(crate) fn parse_iso8601_timestamp(s: &str) -> Option<u64> {
-    use time::format_description::well_known::Iso8601;
-    use time::OffsetDateTime;
-
-    OffsetDateTime::parse(s.trim(), &Iso8601::DEFAULT)
-        .ok()
-        .map(|dt| dt.unix_timestamp() as u64)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Remove `expires` from `ChargeRequest` — expiry is a property of the challenge lifecycle, not the payment request content. The request describes *what* to pay; the challenge controls *how long* you have to pay it.

## Changes

- **Remove `expires` field from `ChargeRequest`** — no longer part of the charge request schema
- **Remove `check_expiration` on `request.expires`** in `ChargeMethod::verify` — expiry is already validated at the challenge level in `verify_hmac_and_expiry` (reading `challenge.expires`)
- **Remove unused `parse_iso8601_timestamp`** helper (was only used by the removed check)
- **Update doc comments and tests** to reflect the change

## How expiry works now

The challenge-level `expires` auth-param (set with a 5-minute default in `charge_challenge_with_options`) is the **single source of truth** for expiration. This was already the case for:
- HMAC challenge ID computation (uses `challenge.expires`)
- Challenge expiry validation in `verify_hmac_and_expiry` (uses `challenge.expires`)
- WWW-Authenticate header serialization (serializes `challenge.expires`)

The `request.expires` was a redundant second check that created ambiguity.

## Breaking Change

`ChargeRequest.expires` field is removed. Code that was setting `request.expires` should pass `expires` to `charge_challenge_with_options()` or `ChargeOptions::expires` instead. Code reading `challenge.request.expires` should read `challenge.expires`.

## Cross-SDK

Mirrors:
- **TypeScript (mppx)**: wevm/mppx#161
- **Spec**: tempoxyz/mpp-specs#165
- **Python (pympp)**: pending