### PR TITLE
feat: auto-generate MPP attribution memo in TempoProvider

### DIFF
--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -123,6 +123,18 @@ impl TempoCharge {
         self.memo
     }
 
+    /// Set the memo bytes, overriding any memo from the challenge.
+    ///
+    /// This is a no-op if the charge already has a server-provided memo.
+    /// Use this to inject auto-generated attribution memos when the server
+    /// does not provide one.
+    pub fn with_auto_memo(mut self, memo: [u8; 32]) -> Self {
+        if self.memo.is_none() {
+            self.memo = Some(memo);
+        }
+        self
+    }
+
     /// Whether fee sponsorship is requested.
     pub fn fee_payer(&self) -> bool {
         self.fee_payer
@@ -440,6 +452,40 @@ mod tests {
         let charge = TempoCharge::from_challenge(&challenge).unwrap();
 
         assert!(charge.memo.is_some());
+    }
+
+    #[test]
+    fn test_with_auto_memo_sets_memo_when_none() {
+        let challenge = test_challenge();
+        let charge = TempoCharge::from_challenge(&challenge).unwrap();
+        assert!(charge.memo().is_none());
+
+        let memo = [0xAB; 32];
+        let charge = charge.with_auto_memo(memo);
+        assert_eq!(charge.memo(), Some(memo));
+    }
+
+    #[test]
+    fn test_with_auto_memo_preserves_server_memo() {
+        let request_json = serde_json::json!({
+            "amount": "1000000",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": {
+                "chainId": 42431,
+                "memo": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            }
+        });
+        let request = Base64UrlJson::from_value(&request_json).unwrap();
+        let challenge =
+            PaymentChallenge::new("test-id", "api.example.com", "tempo", "charge", request);
+        let charge = TempoCharge::from_challenge(&challenge).unwrap();
+        let server_memo = charge.memo().unwrap();
+
+        let auto_memo = [0xAB; 32];
+        let charge = charge.with_auto_memo(auto_memo);
+        assert_eq!(charge.memo(), Some(server_memo));
+        assert_ne!(charge.memo(), Some(auto_memo));
     }
 
     #[test]

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -101,6 +101,17 @@ impl PaymentProvider for TempoProvider {
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
         let charge = super::charge::TempoCharge::from_challenge(challenge)?;
+
+        // Auto-generate an MPP attribution memo when the server doesn't provide one.
+        // This makes MPP transactions identifiable on-chain via transferWithMemo.
+        let charge = if charge.memo().is_none() {
+            let memo =
+                crate::tempo::attribution::encode(&challenge.realm, self.client_id.as_deref());
+            charge.with_auto_memo(memo)
+        } else {
+            charge
+        };
+
         let options = SignOptions {
             rpc_url: Some(self.rpc_url.to_string()),
             signing_mode: Some(self.signing_mode.clone()),
@@ -197,6 +208,16 @@ mod tests {
         assert!(!provider.supports("stripe", "charge"));
         assert!(!provider.supports("", ""));
         assert!(!provider.supports("TEMPO", "charge"));
+    }
+
+    #[test]
+    fn test_auto_generated_memo_includes_client_id() {
+        let memo_with = crate::tempo::attribution::encode("api.example.com", Some("tempo-cli"));
+        let memo_without = crate::tempo::attribution::encode("api.example.com", None);
+        assert!(crate::tempo::attribution::is_mpp_memo(&memo_with));
+        assert!(crate::tempo::attribution::is_mpp_memo(&memo_without));
+        // Client fingerprint bytes differ when client_id is present
+        assert_ne!(memo_with[15..25], memo_without[15..25]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
When the server challenge doesn't include a memo, `TempoProvider::pay()` now auto-generates an MPP attribution memo using `challenge.realm` as `server_id` and an optional `client_id`. This ensures all MPP charge transactions use `transferWithMemo` for on-chain identifiability.

## Motivation
MPP transactions from the Tempo wallet CLI were using plain `transfer()` instead of `transferWithMemo()` when the server didn't provide a memo. This made them indistinguishable from regular transfers on-chain. The attribution module (`tempo::attribution`) already existed but wasn't wired into the payment flow.

## Changes
- Added `TempoCharge::with_auto_memo()` — sets memo only when the challenge doesn't already include one (`src/client/tempo/charge/mod.rs`)
- Updated `TempoProvider::pay()` to auto-generate an attribution memo using `challenge.realm` + `self.client_id` (`src/client/tempo/provider.rs`)
- Added tests for both behaviors (auto-memo injection + server-memo preservation)

## Testing
```bash
cargo test -p mpp --features 'tempo,client' -- 'with_auto_memo'     # 2 passed
cargo test -p mpp --features 'tempo,client' -- 'auto_generated_memo' # 2 passed
cargo test -p mpp --features 'tempo,client'                          # 48 passed
cargo clippy -p mpp --features 'tempo,client' -- -D warnings         # clean
```

Co-Authored-By: Alex Risch <23103150+alexrisch@users.noreply.github.com>

Prompted by: alex