### PR TITLE
feat(client): add autoswap via Tempo Stablecoin DEX

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,6 +40,6 @@ pub use middleware::PaymentMiddleware;
 
 // Re-export Tempo types at client level for convenience
 #[cfg(feature = "tempo")]
-pub use tempo::{TempoClientError, TempoProvider};
+pub use tempo::{AutoswapConfig, TempoClientError, TempoProvider};
 #[cfg(feature = "tempo")]
 pub use tempo_alloy::TempoNetwork;

--- a/src/client/tempo/abi.rs
+++ b/src/client/tempo/abi.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides encode functions for TIP-20 transfers.
 
-use alloy::primitives::{Address, Bytes, U256};
+use alloy::primitives::{address, Address, Bytes, U256};
 use alloy::sol;
 use alloy::sol_types::SolCall;
 
@@ -18,6 +18,37 @@ sol! {
         function balanceOf(address account) external view returns (uint256);
         function approve(address spender, uint256 amount) external returns (bool);
     }
+}
+
+sol! {
+    /// Stablecoin DEX interface for swap operations.
+    #[sol(rpc)]
+    interface IStablecoinDEX {
+        function swapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut, uint128 maxAmountIn) external returns (uint128 amountIn);
+        function quoteSwapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut) external view returns (uint128 amountIn);
+    }
+}
+
+/// Stablecoin DEX precompile address on Tempo.
+pub const DEX_ADDRESS: Address = address!("0xdec0000000000000000000000000000000000000");
+
+/// Encode a `swapExactAmountOut` call for the Stablecoin DEX.
+///
+/// Swaps `token_in` for exactly `amount_out` of `token_out`, with a maximum
+/// input amount of `max_amount_in` to protect against slippage.
+pub fn encode_swap_exact_amount_out(
+    token_in: Address,
+    token_out: Address,
+    amount_out: u128,
+    max_amount_in: u128,
+) -> Bytes {
+    let call = IStablecoinDEX::swapExactAmountOutCall {
+        tokenIn: token_in,
+        tokenOut: token_out,
+        amountOut: amount_out,
+        maxAmountIn: max_amount_in,
+    };
+    Bytes::from(call.abi_encode())
 }
 
 /// Encode a token transfer call, optionally with memo.

--- a/src/client/tempo/autoswap.rs
+++ b/src/client/tempo/autoswap.rs
@@ -1,0 +1,262 @@
+//! Autoswap support for Tempo MPP payments.
+//!
+//! When a payment challenge requires a currency the client doesn't hold,
+//! this module prepends a DEX swap call to the transaction so the user
+//! automatically acquires the required token via the Tempo Stablecoin DEX.
+//!
+//! # How it works
+//!
+//! 1. Check the client's balance of the challenge currency
+//! 2. If balance >= amount, no swap needed — proceed normally
+//! 3. If balance < amount, compute the deficit and query the DEX for a quote
+//! 4. Prepend a `swapExactAmountOut` call to the transaction's call list
+//!    so the swap and transfer execute atomically in a single AA transaction
+//!
+//! # Example
+//!
+//! ```ignore
+//! use mpp::client::TempoProvider;
+//!
+//! let provider = TempoProvider::new(signer, "https://rpc.moderato.tempo.xyz")?
+//!     .with_autoswap(AutoswapConfig {
+//!         token_in: "0x20C000000000000000000000b9537d11c60E8b50".parse()?,
+//!         slippage_bps: 100, // 1%
+//!     });
+//! ```
+
+use alloy::primitives::{Address, Bytes, TxKind, U256};
+use alloy::sol_types::{SolCall, SolType};
+use tempo_primitives::transaction::Call;
+
+use super::abi::{self, IStablecoinDEX, ITIP20};
+use crate::error::MppError;
+
+/// Maximum allowed slippage in basis points (50% = 5000 bps).
+const MAX_SLIPPAGE_BPS: u16 = 5_000;
+
+/// Configuration for automatic token swaps.
+#[derive(Debug, Clone)]
+pub struct AutoswapConfig {
+    /// The token to swap from (the token the user holds).
+    pub token_in: Address,
+    /// Slippage tolerance in basis points (e.g., 100 = 1%).
+    /// Applied on top of the quoted `amountIn` to protect against price movement.
+    pub slippage_bps: u16,
+}
+
+impl AutoswapConfig {
+    /// Create a new autoswap config with the given input token and slippage.
+    pub fn new(token_in: Address, slippage_bps: u16) -> Self {
+        Self {
+            token_in,
+            slippage_bps,
+        }
+    }
+}
+
+/// Default slippage: 1% (100 basis points).
+pub const DEFAULT_SLIPPAGE_BPS: u16 = 100;
+
+/// Query the user's balance of `currency` and determine if a swap is needed.
+///
+/// Returns `Some(deficit)` if the user needs more tokens, `None` if balance is sufficient.
+pub async fn check_balance_deficit<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
+    provider: &P,
+    owner: Address,
+    currency: Address,
+    amount: U256,
+) -> Result<Option<U256>, MppError> {
+    let balance_call = ITIP20::balanceOfCall { account: owner }.abi_encode();
+    let result = provider
+        .call(
+            alloy::rpc::types::TransactionRequest::default()
+                .to(currency)
+                .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
+                    balance_call,
+                )))
+                .into(),
+        )
+        .await
+        .map_err(|e| MppError::Http(format!("failed to query balance: {e}")))?;
+
+    let balance = <alloy::sol_types::sol_data::Uint<256>>::abi_decode(&result)
+        .map_err(|e| MppError::Http(format!("failed to decode balance: {e}")))?;
+    if balance >= amount {
+        Ok(None)
+    } else {
+        Ok(Some(amount - balance))
+    }
+}
+
+/// Quote the DEX for the `amountIn` required to receive `amount_out` of `token_out`.
+pub async fn quote_swap<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
+    provider: &P,
+    token_in: Address,
+    token_out: Address,
+    amount_out: u128,
+) -> Result<u128, MppError> {
+    let quote_call = IStablecoinDEX::quoteSwapExactAmountOutCall {
+        tokenIn: token_in,
+        tokenOut: token_out,
+        amountOut: amount_out,
+    }
+    .abi_encode();
+
+    let result = provider
+        .call(
+            alloy::rpc::types::TransactionRequest::default()
+                .to(abi::DEX_ADDRESS)
+                .input(alloy::rpc::types::TransactionInput::new(Bytes::from(
+                    quote_call,
+                )))
+                .into(),
+        )
+        .await
+        .map_err(|e| MppError::Http(format!("DEX quote failed: {e}")))?;
+
+    let amount_in = <alloy::sol_types::sol_data::Uint<128>>::abi_decode(&result)
+        .map_err(|e| MppError::Http(format!("failed to decode DEX quote: {e}")))?;
+    Ok(amount_in)
+}
+
+/// Build the swap call to prepend to the transaction.
+///
+/// Applies slippage tolerance to the quoted `amount_in` to compute `max_amount_in`.
+pub fn build_swap_call(
+    token_in: Address,
+    token_out: Address,
+    amount_out: u128,
+    quoted_amount_in: u128,
+    slippage_bps: u16,
+) -> Call {
+    // max_amount_in = quoted_amount_in * (10000 + slippage_bps) / 10000
+    let max_amount_in = quoted_amount_in.saturating_mul(10_000 + slippage_bps as u128) / 10_000;
+
+    let swap_data =
+        abi::encode_swap_exact_amount_out(token_in, token_out, amount_out, max_amount_in);
+
+    Call {
+        to: TxKind::Call(abi::DEX_ADDRESS),
+        value: U256::ZERO,
+        input: swap_data,
+    }
+}
+
+/// Resolve autoswap: check balance, quote, and return the swap call if needed.
+///
+/// Returns `Ok(Some(call))` if a swap is needed, `Ok(None)` if balance is sufficient.
+///
+/// Validates that:
+/// 1. The slippage tolerance is within bounds
+/// 2. The user has sufficient `token_in` balance to cover `max_amount_in`
+pub async fn resolve_autoswap<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
+    provider: &P,
+    owner: Address,
+    currency: Address,
+    amount: U256,
+    config: &AutoswapConfig,
+) -> Result<Option<Call>, MppError> {
+    if config.slippage_bps > MAX_SLIPPAGE_BPS {
+        return Err(MppError::InvalidConfig(format!(
+            "autoswap slippage {}bps exceeds maximum {}bps",
+            config.slippage_bps, MAX_SLIPPAGE_BPS
+        )));
+    }
+
+    if config.token_in == currency {
+        // Already holding the right token — no swap needed.
+        return Ok(None);
+    }
+
+    let deficit = match check_balance_deficit(provider, owner, currency, amount).await? {
+        Some(d) => d,
+        None => return Ok(None),
+    };
+
+    // Convert deficit to u128 for the DEX call (TIP-20 tokens use u128 amounts).
+    let deficit_u128: u128 = deficit
+        .try_into()
+        .map_err(|_| MppError::InvalidAmount(format!("deficit {} exceeds u128", deficit)))?;
+
+    let quoted_amount_in = quote_swap(provider, config.token_in, currency, deficit_u128).await?;
+
+    // Compute max_amount_in with slippage and verify the user can cover it.
+    let max_amount_in =
+        quoted_amount_in.saturating_mul(10_000 + config.slippage_bps as u128) / 10_000;
+    let token_in_balance =
+        check_balance_deficit(provider, owner, config.token_in, U256::from(max_amount_in)).await?;
+    if token_in_balance.is_some() {
+        return Err(MppError::from(
+            crate::client::tempo::TempoClientError::InsufficientBalance {
+                token: format!("{}", config.token_in),
+                available: String::new(),
+                required: format!("{}", max_amount_in),
+            },
+        ));
+    }
+
+    Ok(Some(build_swap_call(
+        config.token_in,
+        currency,
+        deficit_u128,
+        quoted_amount_in,
+        config.slippage_bps,
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    #[test]
+    fn test_autoswap_config_new() {
+        let token = address!("0x20C000000000000000000000b9537d11c60E8b50");
+        let config = AutoswapConfig::new(token, 50);
+        assert_eq!(config.token_in, token);
+        assert_eq!(config.slippage_bps, 50);
+    }
+
+    #[test]
+    fn test_build_swap_call_slippage() {
+        let token_in = address!("0x20C000000000000000000000b9537d11c60E8b50");
+        let token_out = address!("0x20c0000000000000000000000000000000000000");
+
+        let call = build_swap_call(token_in, token_out, 1_000_000, 1_000_000, 100);
+
+        // max_amount_in = 1_000_000 * 10100 / 10000 = 1_010_000
+        assert_eq!(call.to, TxKind::Call(abi::DEX_ADDRESS));
+        assert_eq!(call.value, U256::ZERO);
+
+        // Verify the encoded call data decodes correctly.
+        let decoded =
+            IStablecoinDEX::swapExactAmountOutCall::abi_decode_raw(&call.input[4..]).unwrap();
+        assert_eq!(decoded.tokenIn, token_in);
+        assert_eq!(decoded.tokenOut, token_out);
+        assert_eq!(decoded.amountOut, 1_000_000);
+        assert_eq!(decoded.maxAmountIn, 1_010_000);
+    }
+
+    #[test]
+    fn test_build_swap_call_zero_slippage() {
+        let token_in = address!("0x20C000000000000000000000b9537d11c60E8b50");
+        let token_out = address!("0x20c0000000000000000000000000000000000000");
+
+        let call = build_swap_call(token_in, token_out, 500_000, 500_000, 0);
+        let decoded =
+            IStablecoinDEX::swapExactAmountOutCall::abi_decode_raw(&call.input[4..]).unwrap();
+        assert_eq!(decoded.maxAmountIn, 500_000);
+    }
+
+    #[test]
+    fn test_build_swap_call_high_slippage() {
+        let token_in = address!("0x20C000000000000000000000b9537d11c60E8b50");
+        let token_out = address!("0x20c0000000000000000000000000000000000000");
+
+        // 5% slippage
+        let call = build_swap_call(token_in, token_out, 1_000_000, 1_000_000, 500);
+        let decoded =
+            IStablecoinDEX::swapExactAmountOutCall::abi_decode_raw(&call.input[4..]).unwrap();
+        assert_eq!(decoded.maxAmountIn, 1_050_000);
+    }
+}

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -128,6 +128,24 @@ impl TempoCharge {
         self.fee_payer
     }
 
+    /// Prepend a call to the transaction's call list.
+    ///
+    /// Used by autoswap to insert a DEX swap call before the transfer call.
+    /// The swap and transfer then execute atomically in a single AA transaction.
+    pub fn with_prepended_call(mut self, call: Call) -> Self {
+        let calls = self.calls.get_or_insert_with(|| {
+            let transfer_data =
+                crate::client::tempo::abi::encode_transfer(self.recipient, self.amount, self.memo);
+            vec![Call {
+                to: TxKind::Call(self.currency),
+                value: U256::ZERO,
+                input: transfer_data,
+            }]
+        });
+        calls.insert(0, call);
+        self
+    }
+
     /// Sign the charge with default options.
     ///
     /// This is the simple path — resolves the RPC provider from chain_id,

--- a/src/client/tempo/mod.rs
+++ b/src/client/tempo/mod.rs
@@ -4,12 +4,14 @@
 //! signing strategies, charge builder, and channel operations.
 
 pub mod abi;
+pub mod autoswap;
 pub mod charge;
 mod error;
 mod provider;
 pub mod session;
 pub mod signing;
 
+pub use autoswap::AutoswapConfig;
 pub use error::TempoClientError;
 pub use provider::TempoProvider;
 

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -3,6 +3,7 @@
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 
+use super::autoswap::AutoswapConfig;
 use super::charge::SignOptions;
 use super::signing::TempoSigningMode;
 use crate::client::PaymentProvider;
@@ -40,6 +41,7 @@ pub struct TempoProvider {
     rpc_url: reqwest::Url,
     client_id: Option<String>,
     signing_mode: TempoSigningMode,
+    autoswap: Option<AutoswapConfig>,
 }
 
 impl TempoProvider {
@@ -61,6 +63,7 @@ impl TempoProvider {
             rpc_url: url,
             client_id: None,
             signing_mode: TempoSigningMode::Direct,
+            autoswap: None,
         })
     }
 
@@ -76,6 +79,30 @@ impl TempoProvider {
     pub fn with_signing_mode(mut self, mode: TempoSigningMode) -> Self {
         self.signing_mode = mode;
         self
+    }
+
+    /// Enable autoswap: if the client doesn't hold enough of the challenge
+    /// currency, automatically swap from `config.token_in` via the Tempo
+    /// Stablecoin DEX before paying.
+    ///
+    /// The swap and payment execute atomically in a single AA transaction.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use mpp::client::tempo::autoswap::AutoswapConfig;
+    ///
+    /// let provider = TempoProvider::new(signer, "https://rpc.moderato.tempo.xyz")?
+    ///     .with_autoswap(AutoswapConfig::new(usdc_address, 100)); // 1% slippage
+    /// ```
+    pub fn with_autoswap(mut self, config: AutoswapConfig) -> Self {
+        self.autoswap = Some(config);
+        self
+    }
+
+    /// Get the autoswap configuration, if set.
+    pub fn autoswap(&self) -> Option<&AutoswapConfig> {
+        self.autoswap.as_ref()
     }
 
     /// Get the signing mode.
@@ -100,7 +127,28 @@ impl PaymentProvider for TempoProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
-        let charge = super::charge::TempoCharge::from_challenge(challenge)?;
+        let mut charge = super::charge::TempoCharge::from_challenge(challenge)?;
+
+        // If autoswap is enabled, check balance and prepend a swap call if needed.
+        if let Some(autoswap_config) = &self.autoswap {
+            let from = self.signing_mode.from_address(self.signer.address());
+            let rpc_url: reqwest::Url = self.rpc_url.clone();
+            let provider =
+                alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
+
+            if let Some(swap_call) = super::autoswap::resolve_autoswap(
+                &provider,
+                from,
+                charge.currency(),
+                charge.amount(),
+                autoswap_config,
+            )
+            .await?
+            {
+                charge = charge.with_prepended_call(swap_call);
+            }
+        }
+
         let options = SignOptions {
             rpc_url: Some(self.rpc_url.to_string()),
             signing_mode: Some(self.signing_mode.clone()),


### PR DESCRIPTION
When a payment challenge requires a currency the client doesn't hold, the provider now queries the user's balance, gets a DEX quote, and prepends a `swapExactAmountOut` call so the swap and payment execute atomically in a single AA transaction.

## Changes

- Added `client::tempo::autoswap` module with balance checking, DEX quoting, and swap call building
- Added `IStablecoinDEX` ABI + `DEX_ADDRESS` constant + `encode_swap_exact_amount_out` helper to `abi.rs`
- Added `TempoProvider::with_autoswap(AutoswapConfig)` to opt-in to autoswap
- Added `TempoCharge::with_prepended_call` for inserting calls before the transfer
- Validates slippage bounds (max 5000 bps) and verifies `token_in` balance covers `max_amount_in`

## Usage

```rust
use mpp::client::{AutoswapConfig, TempoProvider};

let provider = TempoProvider::new(signer, "https://rpc.moderato.tempo.xyz")?
    .with_autoswap(AutoswapConfig::new(usdc_address, 100)); // 1% slippage

// If user holds USDC but challenge requires pathUSD, the provider
// automatically swaps USDC → pathUSD via the Stablecoin DEX
let resp = client.get(url).send_with_payment(&provider).await?;
```

## Testing

```
cargo fmt --all --check
cargo clippy --features "tempo,client,middleware,utils" -- -D warnings
cargo test --features "tempo,client,middleware,utils"
```

All pass. E2E integration tests require a running localnet (`cargo test --features integration`).

Prompted by: onbjerg