### PR TITLE
fix: relax flaky fee payer test assertion

### DIFF
--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1323,16 +1323,23 @@ async fn test_fee_payer_allows_client_without_gas_buffer() {
         .send_with_payment(&provider)
         .await;
 
-    // Without fee sponsorship, client-side gas estimation reverts because the
-    // account only holds the charge amount (no gas buffer). The payment
-    // provider surfaces this as an error before anything reaches the server.
+    // Without fee sponsorship the client has no gas buffer, so either:
+    //   (a) gas estimation reverts client-side → Err, or
+    //   (b) the payment tx goes through but the transfer fails/reverts and the
+    //       server responds 402 again → Ok(402).
+    // Both outcomes are acceptable; the key invariant is that the client's
+    // balance does NOT decrease (no successful payment was made).
+    let payment_failed = match &result {
+        Err(_) => true,
+        Ok(resp) => resp.status() == reqwest::StatusCode::PAYMENT_REQUIRED,
+    };
     assert!(
-        result.is_err(),
-        "expected client-side failure without fee payer, got: {:?}",
+        payment_failed,
+        "expected payment failure without fee payer, got: {:?}",
         result,
     );
 
-    // The transaction should not have succeeded on-chain; the client should still have the funds.
+    // The client should still hold the original charge amount (no successful payment).
     let client_balance_after_failed = tip20_balance(&provider_http, client_addr).await;
     assert_eq!(client_balance_after_failed, charge_amount);
 


### PR DESCRIPTION
## Problem

`test_fee_payer_allows_client_without_gas_buffer` has been failing on `main` since at least Mar 14. The test asserts that `send_with_payment` returns `Err` when the client has no gas buffer, but the devnet allows the tx through — the transfer reverts and the server responds `402` again, yielding `Ok(402)` instead.

## Fix

Accept both outcomes:
- **`Err`** — client-side gas estimation revert (original expectation)
- **`Ok(402)`** — payment tx reverted on-chain, server re-challenged

The real invariant — that the client's balance does **not** decrease — is still asserted.

Also unblocks #119 which was failing due to this same pre-existing issue.