### PR TITLE
fix: update getChannel ABI to match new escrow field order

### DIFF
--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -132,10 +132,8 @@ impl PaymentProvider for TempoProvider {
         // Auto-generate an attribution memo when the server doesn't provide one,
         // so MPP transactions are identifiable on-chain via `TransferWithMemo` events.
         if charge.memo().is_none() {
-            let memo = crate::tempo::attribution::encode(
-                &challenge.realm,
-                self.client_id.as_deref(),
-            );
+            let memo =
+                crate::tempo::attribution::encode(&challenge.realm, self.client_id.as_deref());
             charge = charge.with_memo(memo);
         }
 

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -132,8 +132,10 @@ impl PaymentProvider for TempoProvider {
         // Auto-generate an attribution memo when the server doesn't provide one,
         // so MPP transactions are identifiable on-chain via `TransferWithMemo` events.
         if charge.memo().is_none() {
-            let memo =
-                crate::tempo::attribution::encode(&challenge.realm, self.client_id.as_deref());
+            let memo = crate::tempo::attribution::encode(
+                &challenge.realm,
+                self.client_id.as_deref(),
+            );
             charge = charge.with_memo(memo);
         }
 

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -331,14 +331,14 @@ pub async fn get_on_chain_channel<P: Provider<TempoNetwork>>(
     sol! {
         interface IEscrowRead {
             function getChannel(bytes32 channelId) external view returns (
+                bool finalized,
+                uint64 closeRequestedAt,
                 address payer,
                 address payee,
                 address token,
                 address authorizedSigner,
                 uint128 deposit,
-                uint128 settled,
-                uint64 closeRequestedAt,
-                bool finalized
+                uint128 settled
             );
         }
     }
@@ -362,18 +362,18 @@ pub async fn get_on_chain_channel<P: Provider<TempoNetwork>>(
         .map_err(|e| MppError::Http(format!("failed to read channel: {}", e)))?;
 
     let decoded =
-        <(Address, Address, Address, Address, u128, u128, u64, bool)>::abi_decode(&result)
+        <(bool, u64, Address, Address, Address, Address, u128, u128)>::abi_decode(&result)
             .map_err(|e| MppError::Http(format!("failed to decode channel data: {}", e)))?;
 
     Ok(OnChainChannel {
-        payer: decoded.0,
-        payee: decoded.1,
-        token: decoded.2,
-        authorized_signer: decoded.3,
-        deposit: decoded.4,
-        settled: decoded.5,
-        close_requested_at: decoded.6,
-        finalized: decoded.7,
+        finalized: decoded.0,
+        close_requested_at: decoded.1,
+        payer: decoded.2,
+        payee: decoded.3,
+        token: decoded.4,
+        authorized_signer: decoded.5,
+        deposit: decoded.6,
+        settled: decoded.7,
     })
 }
 

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -153,14 +153,14 @@ async fn get_on_chain_channel<P: Provider<TempoNetwork>>(
         #[sol(rpc)]
         interface IEscrow {
             function getChannel(bytes32 channelId) external view returns (
+                bool finalized,
+                uint64 closeRequestedAt,
                 address payer,
                 address payee,
                 address token,
                 address authorizedSigner,
                 uint128 deposit,
-                uint128 settled,
-                uint64 closeRequestedAt,
-                bool finalized
+                uint128 settled
             );
         }
     }


### PR DESCRIPTION
## Summary

The escrow contract's `getChannel` return type changed field order:

**Old:** `(address payer, address payee, address token, address authorizedSigner, uint128 deposit, uint128 settled, uint64 closeRequestedAt, bool finalized)`

**New:** `(bool finalized, uint64 closeRequestedAt, address payer, address payee, address token, address authorizedSigner, uint128 deposit, uint128 settled)`

## Changes

Updated both call sites that decode `getChannel` responses:

- **`src/client/tempo/session/channel_ops.rs`** — Updated `sol!` block, ABI tuple decode type, and positional field mapping (`decoded.0` through `decoded.7`)
- **`src/protocol/methods/tempo/session_method.rs`** — Updated `sol!` block (uses `#[sol(rpc)]` with named field access, so the struct mapping required no changes)

## Testing

All 231 tests pass.