### PR TITLE
chore: update moderato escrow contract address

### DIFF
--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -132,10 +132,8 @@ impl PaymentProvider for TempoProvider {
         // Auto-generate an attribution memo when the server doesn't provide one,
         // so MPP transactions are identifiable on-chain via `TransferWithMemo` events.
         if charge.memo().is_none() {
-            let memo = crate::tempo::attribution::encode(
-                &challenge.realm,
-                self.client_id.as_deref(),
-            );
+            let memo =
+                crate::tempo::attribution::encode(&challenge.realm, self.client_id.as_deref());
             charge = charge.with_memo(memo);
         }
 

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -132,8 +132,10 @@ impl PaymentProvider for TempoProvider {
         // Auto-generate an attribution memo when the server doesn't provide one,
         // so MPP transactions are identifiable on-chain via `TransferWithMemo` events.
         if charge.memo().is_none() {
-            let memo =
-                crate::tempo::attribution::encode(&challenge.realm, self.client_id.as_deref());
+            let memo = crate::tempo::attribution::encode(
+                &challenge.realm,
+                self.client_id.as_deref(),
+            );
             charge = charge.with_memo(memo);
         }
 

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -28,7 +28,7 @@ pub fn default_escrow_contract(chain_id: u64) -> Option<Address> {
                 .unwrap(),
         ),
         42431 => Some(
-            "0x542831e3E4Ace07559b7C8787395f4Fb99F70787"
+            "0xe1c4d3dce17bc111181ddf716f75bae49e61a336"
                 .parse()
                 .unwrap(),
         ),
@@ -782,7 +782,7 @@ mod tests {
         let moderato = default_escrow_contract(42431).unwrap();
         assert_eq!(
             moderato,
-            "0x542831e3E4Ace07559b7C8787395f4Fb99F70787"
+            "0xe1c4d3dce17bc111181ddf716f75bae49e61a336"
                 .parse::<Address>()
                 .unwrap()
         );


### PR DESCRIPTION
Update testnet escrow contract to `0xe1c4d3dce17bc111181ddf716f75bae49e61a336`.

Mirrors wevm/mppx#191.