### PR TITLE
chore: remove revm-database-interface pin and tempo git patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
 evm = ["alloy", "hex", "rand"]
-tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid", "revm-database-interface"]
+tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
 
 # Utilities
 utils = ["hex", "rand"]
@@ -65,9 +65,6 @@ alloy = { version = "1.2", features = ["full"], optional = true }
 tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
 
-# Pin: revm-database-interface 9.0.1 bumps revm-state to v10, breaking revm v34 (still on v9)
-revm-database-interface = { version = ">=9.0.0, <9.0.1", optional = true }
-
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", features = ["json"], optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
@@ -89,6 +86,6 @@ axum = { version = "0.8" }
 reqwest = { version = "0.12", features = ["json"] }
 hex = "0.4"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
+# [patch.crates-io]
+# tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+# tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }


### PR DESCRIPTION
The `revm-database-interface` version pin was a workaround for v9.0.1 bumping `revm-state` to v10, which broke `revm v34`. Upstream has since moved to compatible versions, so the pin is no longer needed.

The `tempo-alloy` and `tempo-primitives` git patches can also be dropped — the published crates.io releases (v1.4.0) work and notably don't pull in reth transitive dependencies, significantly reducing the dependency tree for the `tempo` feature.