### PR TITLE
fix: reject keychain envelope signatures in verify_voucher

### DIFF
--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -1420,7 +1420,7 @@ mod tests {
         assert_eq!(deserialized.channel_id, "0xchannel1");
         assert_eq!(deserialized.deposit, 100_000);
         assert_eq!(deserialized.chain_id, 42431);
-        assert_eq!(deserialized.finalized, false);
+        assert!(!deserialized.finalized);
     }
 
     #[tokio::test]
@@ -1629,6 +1629,52 @@ mod tests {
             .await;
 
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_stale_voucher_with_forged_keychain_envelope_rejected() {
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let store = Arc::new(InMemoryChannelStore::new());
+        let channel_id = format!("0x{}", "ab".repeat(32));
+
+        let mut state = test_channel_state(&channel_id);
+        state.authorized_signer = signer.address();
+        state.highest_voucher_amount = 1_000;
+        state.highest_voucher_signature = Some(vec![0xAA; 65]);
+        state.deposit = 100_000;
+        store.insert(&channel_id, state.clone());
+
+        let method = test_session_method(store);
+
+        // Forge a keychain envelope: 0x03 + authorized_signer address + garbage inner sig.
+        // This previously would have passed verify_voucher because it only checked the
+        // embedded address against expected_signer without verifying the inner signature.
+        let mut forged_envelope = vec![0x03u8];
+        forged_envelope.extend_from_slice(signer.address().as_slice());
+        forged_envelope.extend_from_slice(&[0xBB; 65]);
+        let forged_sig = format!("0x{}", hex::encode(&forged_envelope));
+
+        let result = method
+            .verify_and_accept_voucher(
+                &channel_id,
+                &state,
+                500,          // stale: below highest_voucher_amount of 1000
+                &forged_sig,
+                state.escrow_contract,
+                42431,
+                0,
+                100_000,
+                0,
+                false,
+                0,
+            )
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.code, Some(crate::protocol::traits::ErrorCode::InvalidSignature));
     }
 
     #[tokio::test]

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -1660,7 +1660,7 @@ mod tests {
             .verify_and_accept_voucher(
                 &channel_id,
                 &state,
-                500,          // stale: below highest_voucher_amount of 1000
+                500, // stale: below highest_voucher_amount of 1000
                 &forged_sig,
                 state.escrow_contract,
                 42431,
@@ -1674,7 +1674,10 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert_eq!(err.code, Some(crate::protocol::traits::ErrorCode::InvalidSignature));
+        assert_eq!(
+            err.code,
+            Some(crate::protocol::traits::ErrorCode::InvalidSignature)
+        );
     }
 
     #[tokio::test]

--- a/src/protocol/methods/tempo/voucher.rs
+++ b/src/protocol/methods/tempo/voucher.rs
@@ -132,13 +132,13 @@ pub fn verify_voucher(
 ) -> bool {
     let sig = strip_magic_trailer(signature_bytes);
 
-    // 65 bytes is always a raw secp256k1 ECDSA signature (matches TS SDK behavior
-    // where `size === 65` is checked before the type prefix byte).
-    // For longer signatures starting with 0x03, try keychain envelope parsing.
-    if sig.len() != 65 {
-        if let Some(user_address) = parse_keychain_user_address(sig) {
-            return user_address == expected_signer;
-        }
+    // Reject keychain envelopes — the escrow contract verifies raw ECDSA
+    // signatures against authorizedSigner via ecrecover, not keychain-wrapped
+    // ones. Accepting them with only an address comparison (no inner signature
+    // verification) would allow trivial voucher forgery.
+    // Matches the TS SDK (mppx) behavior which returns false for keychain type.
+    if sig.len() != 65 && parse_keychain_user_address(sig).is_some() {
+        return false;
     }
 
     // Fall through to raw ECDSA signature recovery.
@@ -486,27 +486,16 @@ mod tests {
         envelope.extend_from_slice(user_address.as_slice());
         envelope.extend_from_slice(&[0xAA; 65]); // dummy inner signature
 
-        // Should match the user address
-        assert!(verify_voucher(
-            escrow_contract,
-            chain_id,
-            channel_id,
-            cumulative_amount,
-            &envelope,
-            user_address,
-        ));
-
-        // Should fail for a different expected signer
-        let other: Address = "0x1111111111111111111111111111111111111111"
-            .parse()
-            .unwrap();
+        // Keychain envelopes must be rejected — the escrow contract only
+        // supports raw ECDSA via ecrecover, so accepting keychain envelopes
+        // without verifying the inner signature would allow trivial forgery.
         assert!(!verify_voucher(
             escrow_contract,
             chain_id,
             channel_id,
             cumulative_amount,
             &envelope,
-            other,
+            user_address,
         ));
     }
 
@@ -531,7 +520,8 @@ mod tests {
         envelope.extend_from_slice(&[0xAA; 65]);
         envelope.extend_from_slice(&MAGIC_BYTES);
 
-        assert!(verify_voucher(
+        // Keychain envelopes are rejected even with magic trailer
+        assert!(!verify_voucher(
             escrow_contract,
             chain_id,
             channel_id,


### PR DESCRIPTION
## Summary

`verify_voucher` accepted keychain envelopes (prefix `0x03`) by only comparing the embedded `userAddress` to `expected_signer`, without cryptographically verifying the inner signature. An attacker could trivially forge `0x03 || authorized_signer_address || 65_garbage_bytes` to pass `verify_voucher` for **any** voucher amount — defeating the stale-voucher fix from #130 and enabling arbitrary voucher forgery / channel fund theft.

## Fix

Reject all keychain envelopes in `verify_voucher` (`return false`), matching the TS SDK (`mppx`) behavior at [Voucher.ts L96](https://github.com/wevm/mppx-private/blob/main/src/tempo/session/Voucher.ts#L96). The escrow contract only supports raw ECDSA via `ecrecover`, so keychain envelopes should not be accepted until proper inner-signature + on-chain keychain authorization verification is implemented.

## Changes

- **`voucher.rs`**: `verify_voucher` now returns `false` for any keychain envelope instead of comparing the embedded address
- **`voucher.rs` tests**: Updated `test_verify_voucher_keychain_envelope` and `test_verify_voucher_keychain_with_magic_trailer` to assert rejection
- **`session_method.rs` tests**: Added `test_stale_voucher_with_forged_keychain_envelope_rejected` covering the attack vector end-to-end

## Context

Found during code review of #130. The stale-voucher ECDSA fix is correct, but this pre-existing issue in keychain envelope handling completely bypassed it.