### PR TITLE
fix: re-export TempoSessionProvider and channel_ops from client module

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -40,6 +40,8 @@ pub use middleware::PaymentMiddleware;
 
 // Re-export Tempo types at client level for convenience
 #[cfg(feature = "tempo")]
+pub use tempo::session::{channel_ops, TempoSessionProvider};
+#[cfg(feature = "tempo")]
 pub use tempo::{AutoswapConfig, TempoClientError, TempoProvider};
 #[cfg(feature = "tempo")]
 pub use tempo_alloy::TempoNetwork;


### PR DESCRIPTION
Re-export `TempoSessionProvider` and `channel_ops` from `mpp::client` so the session examples (`examples/session/sse` and `examples/session/multi-fetch`) compile.

These types are defined at `mpp::client::tempo::session::` but the examples import them via `mpp::client::`, which was missing the re-export.