### PR TITLE
ci: check examples compile in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - run: cargo test --features tempo,server,client,axum,middleware,tower,utils
       - run: cargo hack check --each-feature --no-dev-deps --skip integration
+      - name: Check examples
+        run: find examples -name Cargo.toml -exec cargo check --manifest-path {} \;
 
   ci-gate:
     name: CI Gate


### PR DESCRIPTION
Adds a CI step that runs `cargo check` on every example `Cargo.toml`. This catches broken imports (like the missing `TempoSessionProvider` re-export fixed in #133) before they reach main.

> **Note:** depends on #133 — the session examples currently fail without that fix.