### PR TITLE
feat: make reqwest TLS backend configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ keywords = ["http", "payments", "402", "authentication"]
 categories = ["web-programming", "authentication", "cryptography"]
 
 [features]
-default = []
+default = ["reqwest-default-tls"]
 
 # Side selection
-client = ["reqwest"]
+client = ["dep:reqwest"]
 server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
@@ -33,6 +33,10 @@ tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", 
 
 # Axum middleware support (server-side convenience)
 axum = ["dep:axum-core", "server", "http-types"]
+
+reqwest-default-tls = ["reqwest?/default-tls"]
+reqwest-native-tls = ["reqwest?/native-tls"]
+reqwest-rustls-tls = ["reqwest?/rustls-tls"]
 
 # Integration tests (requires a running Tempo localnet)
 integration = ["tempo", "server", "client", "axum"]
@@ -66,7 +70,7 @@ tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
 
 # HTTP client dependencies (optional)
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
@@ -83,7 +87,7 @@ axum-core = { version = "0.5", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8" }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4"
 
 # [patch.crates-io]

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "1.2", features = ["provider-http"] }
 tempo-alloy = "1"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.9"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "1.2", features = ["provider-http"] }
 tempo-alloy = "1"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.9"

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "1.2", features = ["provider-http", "sol-types", "contract"]
 tempo-alloy = "1"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -19,7 +19,7 @@ tempo-alloy = "1"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"


### PR DESCRIPTION
Make the reqwest TLS backend configurable following the same pattern as [alloy-rs/alloy](https://github.com/alloy-rs/alloy/blob/d9440c2dc58059f78dbf395158afe5ed0a115f18/crates/transport-http/Cargo.toml#L52-L53).

## Changes

- Set `reqwest` dependency to `default-features = false` to avoid implicitly pulling in OpenSSL via `default-tls`
- Add three TLS feature flags using `reqwest?/` conditional syntax:
  - `reqwest-default-tls` — OpenSSL (system TLS)
  - `reqwest-native-tls` — platform native TLS
  - `reqwest-rustls-tls` — pure Rust TLS (no C dependency)
- Include `reqwest-default-tls` in `default` features for backward compatibility
- Update examples and dev-dependencies to use `rustls-tls`

## Usage

Users who want to avoid OpenSSL can now:
```toml
mpp = { version = "0.5", default-features = false, features = ["client", "reqwest-rustls-tls"] }
```