### PR TITLE
fix: grant `pull-requests:write` permission to reusable CI workflow `changelog.yml` (currently broken)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,6 +46,9 @@ jobs:
   ci:
     needs: changelog
     if: always()
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ github.head_ref }}


### PR DESCRIPTION
Fixes the invalid workflow error in https://github.com/tempoxyz/mpp-rs/actions/workflows/changelog.yml

> The nested job 'lint' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

The `changelog.yml` workflow calls `ci.yml` via `workflow_call`, but the `lint` job in `ci.yml` requests `pull-requests: write` (needed by `tempoxyz/lints` to post comments). Without explicit `permissions` on the caller's job, the reusable workflow inherits `none` for undeclared permissions.

**Security:** Safe — the trigger is `pull_request` (not `pull_request_target`), so fork PRs get a read-only `GITHUB_TOKEN` regardless. Same-repo PRs come from trusted collaborators.