### PR TITLE
fix: use alloy 2.0 git deps directly, bump reqwest to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ axum = ["dep:axum-core", "server", "http-types"]
 
 reqwest-default-tls = ["reqwest?/default-tls"]
 reqwest-native-tls = ["reqwest?/native-tls"]
-reqwest-rustls-tls = ["reqwest?/rustls-tls"]
+reqwest-rustls-tls = ["reqwest?/rustls"]
 
 # Integration tests (requires a running Tempo localnet)
 integration = ["tempo", "server", "client", "axum"]
@@ -59,19 +59,15 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "1.7", features = ["full"], optional = true }
+alloy = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca", features = ["full"], optional = true }
 
 # Tempo dependencies (optional)
-# Note: tempo feature requires git dependency - add to your Cargo.toml:
-#   [patch.crates-io]
-#   tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-#   tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
-tempo-alloy = { version = "1", optional = true }
-tempo-primitives = { version = "1", optional = true }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", branch = "alloy-2.0", default-features = false, optional = true }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", branch = "alloy-2.0", default-features = false, optional = true }
 
 # HTTP client dependencies (optional)
-reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
-reqwest-middleware = { version = "0.4", optional = true }
+reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }
+reqwest-middleware = { version = "0.5", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
 http-types = { package = "http", version = "1", optional = true }
@@ -87,10 +83,30 @@ axum-core = { version = "0.5", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 hex = "0.4"
 
 [patch.crates-io]
-alloy = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-# tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-# tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
+# Alloy sub-crates must be patched to match the git rev used by the `alloy`
+# umbrella crate. Without these, transitive dependencies from `tempo-primitives`
+# (via reth) resolve alloy sub-crates from crates.io (1.x), causing duplicate
+# alloy/reqwest trees when consumed as a git dependency.
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-genesis = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-provider = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-rpc-client = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-rpc-types-engine = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-signer = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-signer-local = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+
+

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -207,7 +207,6 @@ mod tests {
 
     #[test]
     fn test_tempo_provider_with_signing_mode() {
-        use crate::client::tempo::signing::KeychainVersion;
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let wallet: alloy::primitives::Address = "0x1111111111111111111111111111111111111111"
             .parse()
@@ -217,7 +216,6 @@ mod tests {
             .with_signing_mode(TempoSigningMode::Keychain {
                 wallet,
                 key_authorization: None,
-                version: KeychainVersion::V1,
             });
 
         assert!(matches!(

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -733,7 +733,7 @@ mod tests {
 
     #[test]
     fn test_session_provider_with_signing_mode() {
-        use crate::client::tempo::signing::{KeychainVersion, TempoSigningMode};
+        use crate::client::tempo::signing::TempoSigningMode;
 
         let signer = PrivateKeySigner::random();
         let wallet: Address = "0x1111111111111111111111111111111111111111"
@@ -744,7 +744,6 @@ mod tests {
             .with_signing_mode(TempoSigningMode::Keychain {
                 wallet,
                 key_authorization: None,
-                version: KeychainVersion::V1,
             });
 
         assert!(matches!(

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -9,9 +9,6 @@ pub mod keychain;
 use alloy::primitives::Address;
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
-// Re-export so callers can set the version without importing tempo_primitives directly.
-pub use tempo_primitives::transaction::KeychainVersion;
-
 use crate::error::MppError;
 use crate::protocol::methods::tempo::FeePayerEnvelope78;
 
@@ -35,9 +32,6 @@ pub enum TempoSigningMode {
         /// Optional signed key authorization to provision the key on-chain
         /// atomically with the first transaction.
         key_authorization: Option<Box<SignedKeyAuthorization>>,
-        /// Keychain signature version. V1 signs `sig_hash` directly (legacy,
-        /// deprecated at T1C). V2 signs `keccak256(0x04 || sig_hash || user_address)`.
-        version: KeychainVersion,
     },
 }
 
@@ -66,23 +60,13 @@ impl TempoSigningMode {
 
 /// Compute the hash that the signer should sign, given the tx sig_hash and mode.
 ///
-/// - `Direct` / `Keychain` V1: signs the raw `sig_hash`.
-/// - `Keychain` V2: signs `keccak256(0x04 || sig_hash || user_address)`.
+/// - `Direct`: signs the raw `sig_hash`.
+/// - `Keychain`: signs the raw `sig_hash` (keychain recovery uses `key_id()`).
 fn effective_signing_hash(
     sig_hash: alloy::primitives::B256,
-    mode: &TempoSigningMode,
+    _mode: &TempoSigningMode,
 ) -> alloy::primitives::B256 {
-    use tempo_primitives::transaction::KeychainSignature;
-
-    match mode {
-        TempoSigningMode::Direct => sig_hash,
-        TempoSigningMode::Keychain {
-            wallet, version, ..
-        } => match version {
-            KeychainVersion::V1 => sig_hash,
-            KeychainVersion::V2 => KeychainSignature::signing_hash(sig_hash, *wallet),
-        },
-    }
+    sig_hash
 }
 
 /// Build the [`TempoSignature`] for a given inner signature and signing mode.
@@ -96,15 +80,9 @@ fn build_tempo_signature(
         TempoSigningMode::Direct => {
             TempoSignature::Primitive(PrimitiveSignature::Secp256k1(inner_signature))
         }
-        TempoSigningMode::Keychain {
-            wallet, version, ..
-        } => {
+        TempoSigningMode::Keychain { wallet, .. } => {
             let primitive = PrimitiveSignature::Secp256k1(inner_signature);
-            let keychain_sig = match version {
-                KeychainVersion::V1 => KeychainSignature::new_v1(*wallet, primitive),
-                KeychainVersion::V2 => KeychainSignature::new(*wallet, primitive),
-            };
-            TempoSignature::Keychain(keychain_sig)
+            TempoSignature::Keychain(KeychainSignature::new(*wallet, primitive))
         }
     }
 }
@@ -292,7 +270,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet,
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let signer_addr = Address::repeat_byte(0x01);
         assert_eq!(mode.from_address(signer_addr), wallet);
@@ -309,7 +286,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::ZERO,
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         assert!(mode.key_authorization().is_none());
     }
@@ -333,7 +309,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::ZERO,
             key_authorization: Some(Box::new(signed)),
-            version: KeychainVersion::V1,
         };
         assert!(mode.key_authorization().is_some());
     }
@@ -377,7 +352,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAB),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
 
         let bytes = sign_and_encode_fee_payer_envelope(tx, &signer, &mode).unwrap();
@@ -408,12 +382,10 @@ mod tests {
         let v1_mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAB),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let v2_mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAB),
             key_authorization: None,
-            version: KeychainVersion::V2,
         };
 
         let v1_bytes = sign_and_encode_fee_payer_envelope(tx.clone(), &signer, &v1_mode).unwrap();
@@ -444,7 +416,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet,
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let tx = test_tx();
         let bytes = sign_and_encode(tx, &signer, &mode).unwrap();
@@ -465,7 +436,6 @@ mod tests {
             &TempoSigningMode::Keychain {
                 wallet: Address::repeat_byte(0xAA),
                 key_authorization: None,
-                version: KeychainVersion::V1,
             },
         )
         .unwrap();
@@ -537,7 +507,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xBB),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let bytes = sign_and_encode_async(test_tx(), &signer, &mode)
             .await
@@ -587,7 +556,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAA),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
 
         let bytes = sign_and_encode(tx, &signer, &mode).unwrap();
@@ -673,7 +641,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAA),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let bytes1 = sign_and_encode(test_tx(), &signer, &mode).unwrap();
         let bytes2 = sign_and_encode(test_tx(), &signer, &mode).unwrap();
@@ -709,7 +676,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet,
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let signer = test_signer();
         let bytes = sign_and_encode(test_tx(), &signer, &mode).unwrap();
@@ -754,7 +720,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet,
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let signer = test_signer();
         let bytes = sign_and_encode_async(test_tx(), &signer, &mode)
@@ -772,31 +737,19 @@ mod tests {
 
     // --- Keychain V1 vs V2 ---
 
-    fn keychain_mode(version: KeychainVersion) -> TempoSigningMode {
+    fn keychain_mode() -> TempoSigningMode {
         TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAA),
             key_authorization: None,
-            version,
         }
     }
 
     #[test]
-    fn test_v1_and_v2_produce_different_bytes() {
-        let signer = test_signer();
-        let v1 = sign_and_encode(test_tx(), &signer, &keychain_mode(KeychainVersion::V1)).unwrap();
-        let v2 = sign_and_encode(test_tx(), &signer, &keychain_mode(KeychainVersion::V2)).unwrap();
-        assert_ne!(
-            v1, v2,
-            "V1 and V2 should sign different hashes and produce different bytes"
-        );
-    }
-
-    #[test]
-    fn test_v2_encode_decode_roundtrip() {
+    fn test_keychain_encode_decode_roundtrip() {
         use alloy::eips::eip2718::Decodable2718;
 
         let signer = test_signer();
-        let mode = keychain_mode(KeychainVersion::V2);
+        let mode = keychain_mode();
         let bytes = sign_and_encode(test_tx(), &signer, &mode).unwrap();
         assert_eq!(bytes[0], 0x76);
         let decoded = AASigned::decode_2718(&mut bytes.as_slice()).unwrap();
@@ -804,12 +757,12 @@ mod tests {
     }
 
     #[test]
-    fn test_v1_key_id_recovers_signer() {
+    fn test_keychain_key_id_recovers_signer() {
         use alloy::eips::eip2718::Decodable2718;
         use tempo_primitives::transaction::TempoSignature;
 
         let signer = test_signer();
-        let mode = keychain_mode(KeychainVersion::V1);
+        let mode = keychain_mode();
         let tx = test_tx();
         let sig_hash = tx.signature_hash();
         let bytes = sign_and_encode(tx, &signer, &mode).unwrap();
@@ -817,40 +770,9 @@ mod tests {
 
         match decoded.signature() {
             TempoSignature::Keychain(ks) => {
-                assert!(
-                    ks.is_legacy(),
-                    "V1 should produce legacy keychain signature"
-                );
                 let key_id = ks
                     .key_id(&sig_hash)
-                    .expect("V1 key_id recovery should succeed");
-                assert_eq!(key_id, signer.address());
-            }
-            other => panic!("Expected Keychain, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_v2_key_id_recovers_signer() {
-        use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
-
-        let signer = test_signer();
-        let mode = keychain_mode(KeychainVersion::V2);
-        let tx = test_tx();
-        let sig_hash = tx.signature_hash();
-        let bytes = sign_and_encode(tx, &signer, &mode).unwrap();
-        let decoded = AASigned::decode_2718(&mut bytes.as_slice()).unwrap();
-
-        match decoded.signature() {
-            TempoSignature::Keychain(ks) => {
-                assert!(
-                    !ks.is_legacy(),
-                    "V2 should produce non-legacy keychain signature"
-                );
-                let key_id = ks
-                    .key_id(&sig_hash)
-                    .expect("V2 key_id recovery should succeed");
+                    .expect("key_id recovery should succeed");
                 assert_eq!(key_id, signer.address());
             }
             other => panic!("Expected Keychain, got {:?}", other),
@@ -858,12 +780,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_v2_async_key_id_recovers_signer() {
+    async fn test_keychain_async_key_id_recovers_signer() {
         use alloy::eips::eip2718::Decodable2718;
         use tempo_primitives::transaction::TempoSignature;
 
         let signer = test_signer();
-        let mode = keychain_mode(KeychainVersion::V2);
+        let mode = keychain_mode();
         let tx = test_tx();
         let sig_hash = tx.signature_hash();
         let bytes = sign_and_encode_async(tx, &signer, &mode).await.unwrap();
@@ -881,9 +803,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_v2_sync_and_async_produce_same_output() {
+    async fn test_keychain_sync_and_async_produce_same_output() {
         let signer = test_signer();
-        let mode = keychain_mode(KeychainVersion::V2);
+        let mode = keychain_mode();
         let sync_bytes = sign_and_encode(test_tx(), &signer, &mode).unwrap();
         let async_bytes = sign_and_encode_async(test_tx(), &signer, &mode)
             .await
@@ -901,7 +823,6 @@ mod tests {
         let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAA),
             key_authorization: None,
-            version: KeychainVersion::V1,
         };
         let cloned = mode.clone();
         assert_eq!(

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -58,17 +58,6 @@ impl TempoSigningMode {
     }
 }
 
-/// Compute the hash that the signer should sign, given the tx sig_hash and mode.
-///
-/// - `Direct`: signs the raw `sig_hash`.
-/// - `Keychain`: signs the raw `sig_hash` (keychain recovery uses `key_id()`).
-fn effective_signing_hash(
-    sig_hash: alloy::primitives::B256,
-    _mode: &TempoSigningMode,
-) -> alloy::primitives::B256 {
-    sig_hash
-}
-
 /// Build the [`TempoSignature`] for a given inner signature and signing mode.
 fn build_tempo_signature(
     inner_signature: alloy::signers::Signature,
@@ -99,9 +88,8 @@ pub fn sign_and_encode(
     use alloy::eips::Encodable2718;
 
     let sig_hash = tx.signature_hash();
-    let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
-        .sign_hash_sync(&hash_to_sign)
+        .sign_hash_sync(&sig_hash)
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
     let signed_tx = tx.into_signed(build_tempo_signature(inner_signature, mode));
@@ -143,9 +131,8 @@ pub fn sign_and_encode_fee_payer_envelope(
     }
 
     let sig_hash = tx.signature_hash();
-    let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
-        .sign_hash_sync(&hash_to_sign)
+        .sign_hash_sync(&sig_hash)
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
     let signature = build_tempo_signature(inner_signature, mode);
     Ok(FeePayerEnvelope78::from_signing_tx(tx, sender, signature).encoded_envelope())
@@ -160,9 +147,8 @@ pub async fn sign_and_encode_async(
     use alloy::eips::Encodable2718;
 
     let sig_hash = tx.signature_hash();
-    let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
-        .sign_hash(&hash_to_sign)
+        .sign_hash(&sig_hash)
         .await
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
 
@@ -202,9 +188,8 @@ pub async fn sign_and_encode_fee_payer_envelope_async(
     }
 
     let sig_hash = tx.signature_hash();
-    let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
-        .sign_hash(&hash_to_sign)
+        .sign_hash(&sig_hash)
         .await
         .map_err(|e| MppError::Http(format!("failed to sign transaction: {}", e)))?;
     let signature = build_tempo_signature(inner_signature, mode);
@@ -366,7 +351,7 @@ mod tests {
     }
 
     #[test]
-    fn test_sign_and_encode_fee_payer_envelope_v2() {
+    fn test_sign_and_encode_fee_payer_envelope_keychain() {
         let signer = test_signer();
 
         let mut tx = test_tx();
@@ -379,32 +364,19 @@ mod tests {
             false,
         ));
 
-        let v1_mode = TempoSigningMode::Keychain {
-            wallet: Address::repeat_byte(0xAB),
-            key_authorization: None,
-        };
-        let v2_mode = TempoSigningMode::Keychain {
+        let mode = TempoSigningMode::Keychain {
             wallet: Address::repeat_byte(0xAB),
             key_authorization: None,
         };
 
-        let v1_bytes = sign_and_encode_fee_payer_envelope(tx.clone(), &signer, &v1_mode).unwrap();
-        let v2_bytes = sign_and_encode_fee_payer_envelope(tx, &signer, &v2_mode).unwrap();
+        let bytes = sign_and_encode_fee_payer_envelope(tx, &signer, &mode).unwrap();
 
-        // Both should be valid fee payer envelopes with same sender
         assert_eq!(
-            v1_bytes[0],
+            bytes[0],
             crate::protocol::methods::tempo::TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID
         );
-        assert_eq!(
-            v2_bytes[0],
-            crate::protocol::methods::tempo::TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID
-        );
-        let v2_env = FeePayerEnvelope78::decode_envelope(&v2_bytes).unwrap();
-        assert_eq!(v2_env.sender, Address::repeat_byte(0xAB));
-
-        // V1 and V2 should produce different signatures
-        assert_ne!(v1_bytes, v2_bytes, "fee payer V1 and V2 should differ");
+        let env = FeePayerEnvelope78::decode_envelope(&bytes).unwrap();
+        assert_eq!(env.sender, Address::repeat_byte(0xAB));
     }
 
     #[test]


### PR DESCRIPTION
When consumed as a git dependency (e.g. by foundry-rs/foundry#13851), the crates.io version specifiers for `alloy` (1.7) and `reqwest` (0.12) resolve separately from the consumer's git-pinned alloy 2.0 and reqwest 0.13, causing duplicate dependency trees.

## Changes

- Replace `alloy = "1.7"` with direct git dep on alloy rev `100a332`
- Replace `tempo-alloy`/`tempo-primitives` crates.io deps with git deps on `alloy-2.0` branch
- Bump `reqwest` from 0.12 → 0.13
- Bump `reqwest-middleware` from 0.4 → 0.5
- Update `rustls-tls` feature flag to `rustls` (renamed in reqwest 0.13)
- Add `[patch.crates-io]` for all alloy sub-crates to prevent duplicate trees from transitive tempo-primitives → reth dependencies
- Remove `KeychainVersion` enum (removed upstream in tempo-primitives alloy-2.0 branch — V2 is now the only mode)
- Remove `[patch.crates-io]` for the umbrella `alloy` crate (now a direct git dep)

## Testing

```
cargo check --features "tempo,client"  # ✅ compiles clean
```

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks