### PR TITLE
feat: add cargo publish to release workflow

### DIFF
--- a/.changelog/rare-eagles-read.md
+++ b/.changelog/rare-eagles-read.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Migrated tempo dependencies (`tempo-alloy`, `tempo-primitives`) from git dependencies to crates.io versioned dependencies, and added `cargo publish` to the release workflow with registry token support.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,3 @@
-# This crate is distributed via GitHub Releases rather than crates.io because
-# it depends on tempo-alloy and tempo-primitives, which are not published to
-# crates.io (they live in the tempoxyz/tempo repo as git dependencies).
-#
-# GitHub Releases are created automatically by changelogs-rs when a "Version
-# Packages" PR is merged.
-#
-# Users consume this crate via git dependency in their Cargo.toml:
-#   mpp = { git = "https://github.com/tempoxyz/mpp-rs", tag = "v0.2.1", features = ["tempo", "client"] }
-
 name: Release
 on:
   push:
@@ -32,5 +22,7 @@ jobs:
         uses: wevm/changelogs-rs@6da79bce8604f650b0a59697ec434a23c168b9de # changelogs@0.6.0
         with:
           conventional-commit: true
+          publish: cargo publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,6 @@ async-stream = { version = "0.3", optional = true }
 alloy = { version = "1.7", features = ["full"], optional = true }
 
 # Tempo dependencies (optional)
-# Note: tempo feature requires git dependency - add to your Cargo.toml:
-#   [patch.crates-io]
-#   tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-#   tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
 tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
 
@@ -90,6 +86,3 @@ axum = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4"
 
-# [patch.crates-io]
-# tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-# tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -23,6 +23,3 @@ serde_json = "1"
 hex = "0.4"
 rand = "0.9"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -23,6 +23,3 @@ serde_json = "1"
 hex = "0.4"
 rand = "0.9"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -24,6 +24,3 @@ serde_json = "1"
 hex = "0.4"
 rand = "0.9"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -28,6 +28,3 @@ futures = "0.3"
 async-stream = "0.3"
 urlencoding = "2"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }


### PR DESCRIPTION
Adds `cargo publish` to the changelogs-rs release action so crates are published to crates.io when an RC PR is merged.

## Changes

- **release.yml**: Added `publish: cargo publish` input to changelogs-rs action and `CARGO_REGISTRY_TOKEN` env var
- **Cargo.toml**: Removed outdated comments about git dependency workarounds and commented-out `[patch.crates-io]` block
- **examples/\*/Cargo.toml**: Removed `[patch.crates-io]` blocks from all 4 example crates (basic, axum-extractor, session/multi-fetch, session/sse) — will resolve from crates.io once tempo crates are published