### PR TITLE
fix: cargo publish not working in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
         uses: wevm/changelogs-rs@6da79bce8604f650b0a59697ec434a23c168b9de # changelogs@0.6.0
         with:
           conventional-commit: true
-          publish: cargo publish
+          crate-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The `changelogs-rs` action doesn't accept `publish` as an input — it was being silently ignored:

```
##[warning]Unexpected input(s) 'publish', valid inputs are ['ecosystem', 'crate-token', 'pypi-token', 'commit', 'conventional-commit', 'branch', 'github-token']
```

And `CARGO_REGISTRY_TOKEN` as an env var wasn't being picked up either, leading to:

```
No packages published (no token), but 1 git tag(s) created
```

Fix: pass the token via the `crate-token` input, which is the correct interface for this action.