### PR TITLE
feat: add OnChallenge callback

### DIFF
--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -21,6 +21,9 @@ pub enum HttpError {
     /// Request could not be cloned (required for retry)
     CloneFailed,
 
+    /// Payment was declined by the on_challenge callback
+    PaymentDeclined,
+
     /// Payment provider error
     Payment(MppError),
 
@@ -41,6 +44,7 @@ impl fmt::Display for HttpError {
             Self::InvalidChallenge(msg) => write!(f, "invalid challenge: {}", msg),
             Self::InvalidCredential(msg) => write!(f, "invalid credential: {}", msg),
             Self::CloneFailed => write!(f, "request could not be cloned for retry"),
+            Self::PaymentDeclined => write!(f, "payment declined by on_challenge callback"),
             Self::Payment(e) => write!(f, "payment failed: {}", e),
             #[cfg(feature = "client")]
             Self::Request(e) => write!(f, "HTTP request failed: {}", e),

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -5,7 +5,6 @@
 use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use std::future::Future;
-use std::pin::Pin;
 
 use super::error::HttpError;
 use super::provider::PaymentProvider;
@@ -29,45 +28,48 @@ pub enum ChallengeAction {
     Decline,
 }
 
-/// Callback invoked when a 402 challenge is received, before executing payment.
+/// Hook invoked when a 402 challenge is received, before executing payment.
 ///
-/// The callback receives the parsed [`PaymentChallenge`] and returns a
-/// [`ChallengeAction`] controlling how to proceed.
+/// Returns a [`ChallengeAction`] controlling how to proceed.
 ///
-/// # Examples
+/// Implement this trait on a custom type, or use closures directly:
 ///
 /// ```ignore
-/// use mpp::client::{Fetch, OnChallenge, ChallengeAction};
+/// use mpp::client::{Fetch, ChallengeAction};
 ///
-/// // Simple approval gate
-/// let on_challenge: OnChallenge = Box::new(|challenge| {
-///     Box::pin(async move {
-///         if approve_payment(challenge).await {
-///             ChallengeAction::Approve
-///         } else {
-///             ChallengeAction::Decline
-///         }
-///     })
-/// });
-///
-/// // Or supply a credential directly (e.g. after gathering user input)
-/// let on_challenge: OnChallenge = Box::new(|challenge| {
-///     Box::pin(async move {
-///         let credential = create_credential_with_extra_context(challenge).await;
-///         ChallengeAction::Credential(Box::new(credential))
-///     })
-/// });
-///
+/// let gate = |_challenge| async { ChallengeAction::Approve };
 /// let resp = client
 ///     .get("https://api.example.com/paid")
-///     .send_with_payment_opts(&provider, Some(&on_challenge))
+///     .send_with_payment_opts(&provider, &gate)
 ///     .await?;
 /// ```
-pub type OnChallenge = Box<
-    dyn Fn(&PaymentChallenge) -> Pin<Box<dyn Future<Output = ChallengeAction> + Send + '_>>
-        + Send
-        + Sync,
->;
+pub trait OnChallenge: Send + Sync {
+    /// Decide how to handle a 402 payment challenge.
+    fn on_challenge<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+    ) -> impl Future<Output = ChallengeAction> + Send + 'a;
+}
+
+/// No-op [`OnChallenge`] that always approves. Used as the default by
+/// [`send_with_payment`](PaymentExt::send_with_payment).
+pub struct ApproveChallenge;
+
+impl OnChallenge for ApproveChallenge {
+    async fn on_challenge(&self, _challenge: &PaymentChallenge) -> ChallengeAction {
+        ChallengeAction::Approve
+    }
+}
+
+impl<F, Fut> OnChallenge for F
+where
+    F: Fn(&PaymentChallenge) -> Fut + Send + Sync,
+    Fut: Future<Output = ChallengeAction> + Send + 'static,
+{
+    async fn on_challenge(&self, challenge: &PaymentChallenge) -> ChallengeAction {
+        (self)(challenge).await
+    }
+}
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -110,16 +112,16 @@ pub trait PaymentExt {
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 
     /// Like [`send_with_payment`](PaymentExt::send_with_payment), but with an
-    /// optional [`OnChallenge`] callback invoked before payment execution.
+    /// [`OnChallenge`] hook invoked before payment execution.
     ///
-    /// The callback returns a [`ChallengeAction`] controlling how to proceed:
+    /// The hook returns a [`ChallengeAction`] controlling how to proceed:
     /// - [`ChallengeAction::Approve`] — auto-pay via the provider
     /// - [`ChallengeAction::Credential`] — use the provided credential directly
     /// - [`ChallengeAction::Decline`] — abort with [`HttpError::PaymentDeclined`]
-    fn send_with_payment_opts<P: PaymentProvider>(
+    fn send_with_payment_opts<P: PaymentProvider, H: OnChallenge>(
         self,
         provider: &P,
-        on_challenge: Option<&OnChallenge>,
+        on_challenge: &H,
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 }
 
@@ -128,13 +130,14 @@ impl PaymentExt for RequestBuilder {
         self,
         provider: &P,
     ) -> Result<Response, HttpError> {
-        self.send_with_payment_opts(provider, None).await
+        self.send_with_payment_opts(provider, &ApproveChallenge)
+            .await
     }
 
-    async fn send_with_payment_opts<P: PaymentProvider>(
+    async fn send_with_payment_opts<P: PaymentProvider, H: OnChallenge>(
         self,
         provider: &P,
-        on_challenge: Option<&OnChallenge>,
+        on_challenge: &H,
     ) -> Result<Response, HttpError> {
         let retry_builder = self.try_clone().ok_or(HttpError::CloneFailed)?;
 
@@ -174,14 +177,10 @@ impl PaymentExt for RequestBuilder {
                 ))
             })?;
 
-        let credential = if let Some(cb) = on_challenge {
-            match cb(challenge).await {
-                ChallengeAction::Approve => provider.pay(challenge).await?,
-                ChallengeAction::Credential(c) => *c,
-                ChallengeAction::Decline => return Err(HttpError::PaymentDeclined),
-            }
-        } else {
-            provider.pay(challenge).await?
+        let credential = match on_challenge.on_challenge(challenge).await {
+            ChallengeAction::Approve => provider.pay(challenge).await?,
+            ChallengeAction::Credential(c) => *c,
+            ChallengeAction::Decline => return Err(HttpError::PaymentDeclined),
         };
 
         let auth_header = format_authorization(&credential)
@@ -692,12 +691,11 @@ mod tests {
             let base_url = spawn_server(app).await;
             let provider = MockProvider::new();
 
-            let on_challenge: super::OnChallenge =
-                Box::new(|_challenge| Box::pin(async { super::ChallengeAction::Approve }));
+            let approve = |_: &PaymentChallenge| async { super::ChallengeAction::Approve };
 
             let resp = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .send_with_payment_opts(&provider, &approve)
                 .await
                 .unwrap();
 
@@ -713,17 +711,17 @@ mod tests {
             let provider = MockProvider::new();
 
             let echo = challenge.to_echo();
-            let on_challenge: super::OnChallenge = Box::new(move |_challenge| {
+            let on_challenge = move |_challenge: &PaymentChallenge| {
                 let echo = echo.clone();
-                Box::pin(async move {
+                async move {
                     let cred = PaymentCredential::new(echo, PaymentPayload::hash("0xcustom"));
                     super::ChallengeAction::Credential(Box::new(cred))
-                })
-            });
+                }
+            };
 
             let resp = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .send_with_payment_opts(&provider, &on_challenge)
                 .await
                 .unwrap();
 
@@ -738,12 +736,11 @@ mod tests {
             let base_url = spawn_server(app).await;
             let provider = MockProvider::new();
 
-            let on_challenge: super::OnChallenge =
-                Box::new(|_challenge| Box::pin(async { super::ChallengeAction::Decline }));
+            let decline = |_: &PaymentChallenge| async { super::ChallengeAction::Decline };
 
             let err = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .send_with_payment_opts(&provider, &decline)
                 .await
                 .unwrap_err();
 

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -4,12 +4,70 @@
 
 use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{RequestBuilder, Response, StatusCode};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::error::HttpError;
 use super::provider::PaymentProvider;
 use crate::protocol::core::{
-    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+    format_authorization, parse_www_authenticate_all, PaymentChallenge, PaymentCredential,
+    AUTHORIZATION_HEADER,
 };
+
+/// Result of an [`OnChallenge`] callback, mirroring mppx's 3-way return type.
+///
+/// - `Approve` — proceed with automatic payment via the provider (mppx: `undefined`)
+/// - `Credential(c)` — use this pre-built credential, skip the provider (mppx: `string`)
+/// - `Decline` — abort with [`HttpError::PaymentDeclined`] (mppx: `throw`)
+#[derive(Debug)]
+pub enum ChallengeAction {
+    /// Proceed with automatic payment via the provider.
+    Approve,
+    /// Use this credential directly, skipping the provider.
+    Credential(Box<PaymentCredential>),
+    /// Decline the payment.
+    Decline,
+}
+
+/// Callback invoked when a 402 challenge is received, before executing payment.
+///
+/// The callback receives the parsed [`PaymentChallenge`] and returns a
+/// [`ChallengeAction`] controlling how to proceed.
+///
+/// # Examples
+///
+/// ```ignore
+/// use mpp::client::{Fetch, OnChallenge, ChallengeAction};
+///
+/// // Simple approval gate
+/// let on_challenge: OnChallenge = Box::new(|challenge| {
+///     Box::pin(async move {
+///         if approve_payment(challenge).await {
+///             ChallengeAction::Approve
+///         } else {
+///             ChallengeAction::Decline
+///         }
+///     })
+/// });
+///
+/// // Or supply a credential directly (e.g. after gathering user input)
+/// let on_challenge: OnChallenge = Box::new(|challenge| {
+///     Box::pin(async move {
+///         let credential = create_credential_with_extra_context(challenge).await;
+///         ChallengeAction::Credential(Box::new(credential))
+///     })
+/// });
+///
+/// let resp = client
+///     .get("https://api.example.com/paid")
+///     .send_with_payment_opts(&provider, Some(&on_challenge))
+///     .await?;
+/// ```
+pub type OnChallenge = Box<
+    dyn Fn(&PaymentChallenge) -> Pin<Box<dyn Future<Output = ChallengeAction> + Send + '_>>
+        + Send
+        + Sync,
+>;
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -50,12 +108,33 @@ pub trait PaymentExt {
         self,
         provider: &P,
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
+
+    /// Like [`send_with_payment`](PaymentExt::send_with_payment), but with an
+    /// optional [`OnChallenge`] callback invoked before payment execution.
+    ///
+    /// The callback returns a [`ChallengeAction`] controlling how to proceed:
+    /// - [`ChallengeAction::Approve`] — auto-pay via the provider
+    /// - [`ChallengeAction::Credential`] — use the provided credential directly
+    /// - [`ChallengeAction::Decline`] — abort with [`HttpError::PaymentDeclined`]
+    fn send_with_payment_opts<P: PaymentProvider>(
+        self,
+        provider: &P,
+        on_challenge: Option<&OnChallenge>,
+    ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 }
 
 impl PaymentExt for RequestBuilder {
     async fn send_with_payment<P: PaymentProvider>(
         self,
         provider: &P,
+    ) -> Result<Response, HttpError> {
+        self.send_with_payment_opts(provider, None).await
+    }
+
+    async fn send_with_payment_opts<P: PaymentProvider>(
+        self,
+        provider: &P,
+        on_challenge: Option<&OnChallenge>,
     ) -> Result<Response, HttpError> {
         let retry_builder = self.try_clone().ok_or(HttpError::CloneFailed)?;
 
@@ -95,7 +174,15 @@ impl PaymentExt for RequestBuilder {
                 ))
             })?;
 
-        let credential = provider.pay(challenge).await?;
+        let credential = if let Some(cb) = on_challenge {
+            match cb(challenge).await {
+                ChallengeAction::Approve => provider.pay(challenge).await?,
+                ChallengeAction::Credential(c) => *c,
+                ChallengeAction::Decline => return Err(HttpError::PaymentDeclined),
+            }
+        } else {
+            provider.pay(challenge).await?
+        };
 
         let auth_header = format_authorization(&credential)
             .map_err(|e| HttpError::InvalidCredential(e.to_string()))?;
@@ -574,6 +661,94 @@ mod tests {
                 .unwrap_err();
 
             assert!(matches!(err, HttpError::NoSupportedChallenge(_)));
+        }
+
+        /// Helper: build a 402 server that accepts payment on retry.
+        fn paid_app(www_auth: String) -> Router {
+            Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let www_auth = www_auth.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            )
+        }
+
+        #[tokio::test]
+        async fn test_on_challenge_approve() {
+            let (_, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+
+            let on_challenge: super::OnChallenge =
+                Box::new(|_challenge| Box::pin(async { super::ChallengeAction::Approve }));
+
+            let resp = reqwest::Client::new()
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_on_challenge_credential() {
+            let (challenge, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+
+            let echo = challenge.to_echo();
+            let on_challenge: super::OnChallenge = Box::new(move |_challenge| {
+                let echo = echo.clone();
+                Box::pin(async move {
+                    let cred = PaymentCredential::new(echo, PaymentPayload::hash("0xcustom"));
+                    super::ChallengeAction::Credential(Box::new(cred))
+                })
+            });
+
+            let resp = reqwest::Client::new()
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 0); // provider was NOT called
+        }
+
+        #[tokio::test]
+        async fn test_on_challenge_decline() {
+            let (_, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+
+            let on_challenge: super::OnChallenge =
+                Box::new(|_challenge| Box::pin(async { super::ChallengeAction::Decline }));
+
+            let err = reqwest::Client::new()
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_opts(&provider, Some(&on_challenge))
+                .await
+                .unwrap_err();
+
+            assert!(matches!(err, HttpError::PaymentDeclined));
+            assert_eq!(provider.call_count(), 0);
         }
     }
 }

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -40,7 +40,7 @@ pub enum ChallengeAction {
 /// let gate = |_challenge| async { ChallengeAction::Approve };
 /// let resp = client
 ///     .get("https://api.example.com/paid")
-///     .send_with_payment_opts(&provider, &gate)
+///     .send_with_payment_opts(&provider, gate)
 ///     .await?;
 /// ```
 pub trait OnChallenge: Send + Sync {
@@ -121,7 +121,7 @@ pub trait PaymentExt {
     fn send_with_payment_opts<P: PaymentProvider, H: OnChallenge>(
         self,
         provider: &P,
-        on_challenge: &H,
+        on_challenge: H,
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 }
 
@@ -130,14 +130,14 @@ impl PaymentExt for RequestBuilder {
         self,
         provider: &P,
     ) -> Result<Response, HttpError> {
-        self.send_with_payment_opts(provider, &ApproveChallenge)
+        self.send_with_payment_opts(provider, ApproveChallenge)
             .await
     }
 
     async fn send_with_payment_opts<P: PaymentProvider, H: OnChallenge>(
         self,
         provider: &P,
-        on_challenge: &H,
+        on_challenge: H,
     ) -> Result<Response, HttpError> {
         let retry_builder = self.try_clone().ok_or(HttpError::CloneFailed)?;
 
@@ -695,7 +695,7 @@ mod tests {
 
             let resp = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, &approve)
+                .send_with_payment_opts(&provider, approve)
                 .await
                 .unwrap();
 
@@ -721,7 +721,7 @@ mod tests {
 
             let resp = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, &on_challenge)
+                .send_with_payment_opts(&provider, on_challenge)
                 .await
                 .unwrap();
 
@@ -740,7 +740,7 @@ mod tests {
 
             let err = reqwest::Client::new()
                 .get(format!("{}/paid", base_url))
-                .send_with_payment_opts(&provider, &decline)
+                .send_with_payment_opts(&provider, decline)
                 .await
                 .unwrap_err();
 

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -8,7 +8,7 @@ use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next};
 
-use crate::client::fetch::{ChallengeAction, OnChallenge};
+use crate::client::fetch::{ApproveChallenge, ChallengeAction, OnChallenge};
 use crate::client::provider::PaymentProvider;
 use crate::protocol::core::{
     format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
@@ -36,9 +36,9 @@ use crate::protocol::core::{
 /// // All requests through this client automatically handle 402
 /// let resp = client.get("https://api.example.com/paid").send().await?;
 /// ```
-pub struct PaymentMiddleware<P> {
+pub struct PaymentMiddleware<P, H = ApproveChallenge> {
     provider: P,
-    on_challenge: Option<OnChallenge>,
+    on_challenge: H,
 }
 
 impl<P> PaymentMiddleware<P> {
@@ -46,26 +46,31 @@ impl<P> PaymentMiddleware<P> {
     pub fn new(provider: P) -> Self {
         Self {
             provider,
-            on_challenge: None,
+            on_challenge: ApproveChallenge,
         }
     }
+}
 
-    /// Set an [`OnChallenge`] callback invoked before payment execution.
+impl<P, H> PaymentMiddleware<P, H> {
+    /// Set an [`OnChallenge`] hook invoked before payment execution.
     ///
-    /// The callback returns a [`ChallengeAction`] controlling how to proceed:
+    /// The hook returns a [`ChallengeAction`] controlling how to proceed:
     /// - [`ChallengeAction::Approve`] — auto-pay via the provider
     /// - [`ChallengeAction::Credential`] — use the provided credential directly
     /// - [`ChallengeAction::Decline`] — abort with a middleware error
-    pub fn with_on_challenge(mut self, on_challenge: OnChallenge) -> Self {
-        self.on_challenge = Some(on_challenge);
-        self
+    pub fn with_on_challenge<H2: OnChallenge>(self, on_challenge: H2) -> PaymentMiddleware<P, H2> {
+        PaymentMiddleware {
+            provider: self.provider,
+            on_challenge,
+        }
     }
 }
 
 #[async_trait]
-impl<P> Middleware for PaymentMiddleware<P>
+impl<P, H> Middleware for PaymentMiddleware<P, H>
 where
     P: PaymentProvider + 'static,
+    H: OnChallenge + 'static,
 {
     async fn handle(
         &self,
@@ -108,27 +113,19 @@ where
             .context("no challenge matches provider's supported methods")
             .map_err(reqwest_middleware::Error::Middleware)?;
 
-        let credential = if let Some(ref cb) = self.on_challenge {
-            match cb(challenge).await {
-                ChallengeAction::Approve => self
-                    .provider
-                    .pay(challenge)
-                    .await
-                    .context("payment failed")
-                    .map_err(reqwest_middleware::Error::Middleware)?,
-                ChallengeAction::Credential(c) => *c,
-                ChallengeAction::Decline => {
-                    return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
-                        "payment declined by on_challenge callback"
-                    )))
-                }
-            }
-        } else {
-            self.provider
+        let credential = match self.on_challenge.on_challenge(challenge).await {
+            ChallengeAction::Approve => self
+                .provider
                 .pay(challenge)
                 .await
                 .context("payment failed")
-                .map_err(reqwest_middleware::Error::Middleware)?
+                .map_err(reqwest_middleware::Error::Middleware)?,
+            ChallengeAction::Credential(c) => *c,
+            ChallengeAction::Decline => {
+                return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "payment declined by on_challenge callback"
+                )))
+            }
         };
 
         let auth_header = format_authorization(&credential)
@@ -416,11 +413,10 @@ mod tests {
             let base_url = spawn_server(app).await;
             let provider = TestProvider::new();
 
-            let on_challenge: OnChallenge =
-                Box::new(|_challenge| Box::pin(async { ChallengeAction::Approve }));
+            let approve = |_: &PaymentChallenge| async { ChallengeAction::Approve };
 
             let client = ClientBuilder::new(reqwest::Client::new())
-                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
+                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(approve))
                 .build();
 
             let resp = client
@@ -441,13 +437,13 @@ mod tests {
             let provider = TestProvider::new();
 
             let echo = challenge.to_echo();
-            let on_challenge: OnChallenge = Box::new(move |_challenge| {
+            let on_challenge = move |_challenge: &PaymentChallenge| {
                 let echo = echo.clone();
-                Box::pin(async move {
+                async move {
                     let cred = PaymentCredential::new(echo, PaymentPayload::hash("0xcustom"));
                     ChallengeAction::Credential(Box::new(cred))
-                })
-            });
+                }
+            };
 
             let client = ClientBuilder::new(reqwest::Client::new())
                 .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
@@ -470,11 +466,10 @@ mod tests {
             let base_url = spawn_server(app).await;
             let provider = TestProvider::new();
 
-            let on_challenge: OnChallenge =
-                Box::new(|_challenge| Box::pin(async { ChallengeAction::Decline }));
+            let decline = |_: &PaymentChallenge| async { ChallengeAction::Decline };
 
             let client = ClientBuilder::new(reqwest::Client::new())
-                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
+                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(decline))
                 .build();
 
             let err = client

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -8,6 +8,7 @@ use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next};
 
+use crate::client::fetch::{ChallengeAction, OnChallenge};
 use crate::client::provider::PaymentProvider;
 use crate::protocol::core::{
     format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
@@ -37,12 +38,27 @@ use crate::protocol::core::{
 /// ```
 pub struct PaymentMiddleware<P> {
     provider: P,
+    on_challenge: Option<OnChallenge>,
 }
 
 impl<P> PaymentMiddleware<P> {
     /// Create a new payment middleware with the given provider.
     pub fn new(provider: P) -> Self {
-        Self { provider }
+        Self {
+            provider,
+            on_challenge: None,
+        }
+    }
+
+    /// Set an [`OnChallenge`] callback invoked before payment execution.
+    ///
+    /// The callback returns a [`ChallengeAction`] controlling how to proceed:
+    /// - [`ChallengeAction::Approve`] — auto-pay via the provider
+    /// - [`ChallengeAction::Credential`] — use the provided credential directly
+    /// - [`ChallengeAction::Decline`] — abort with a middleware error
+    pub fn with_on_challenge(mut self, on_challenge: OnChallenge) -> Self {
+        self.on_challenge = Some(on_challenge);
+        self
     }
 }
 
@@ -92,12 +108,28 @@ where
             .context("no challenge matches provider's supported methods")
             .map_err(reqwest_middleware::Error::Middleware)?;
 
-        let credential = self
-            .provider
-            .pay(challenge)
-            .await
-            .context("payment failed")
-            .map_err(reqwest_middleware::Error::Middleware)?;
+        let credential = if let Some(ref cb) = self.on_challenge {
+            match cb(challenge).await {
+                ChallengeAction::Approve => self
+                    .provider
+                    .pay(challenge)
+                    .await
+                    .context("payment failed")
+                    .map_err(reqwest_middleware::Error::Middleware)?,
+                ChallengeAction::Credential(c) => *c,
+                ChallengeAction::Decline => {
+                    return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                        "payment declined by on_challenge callback"
+                    )))
+                }
+            }
+        } else {
+            self.provider
+                .pay(challenge)
+                .await
+                .context("payment failed")
+                .map_err(reqwest_middleware::Error::Middleware)?
+        };
 
         let auth_header = format_authorization(&credential)
             .context("failed to format credential")
@@ -353,6 +385,110 @@ mod tests {
                 "expected payment failure, got: {}",
                 err
             );
+        }
+
+        /// Helper: build a 402 server that accepts payment on retry.
+        fn paid_app(www_auth: String) -> Router {
+            Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let www_auth = www_auth.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            )
+        }
+
+        #[tokio::test]
+        async fn test_middleware_on_challenge_approve() {
+            let (_, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+
+            let on_challenge: OnChallenge =
+                Box::new(|_challenge| Box::pin(async { ChallengeAction::Approve }));
+
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_on_challenge_credential() {
+            let (challenge, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+
+            let echo = challenge.to_echo();
+            let on_challenge: OnChallenge = Box::new(move |_challenge| {
+                let echo = echo.clone();
+                Box::pin(async move {
+                    let cred = PaymentCredential::new(echo, PaymentPayload::hash("0xcustom"));
+                    ChallengeAction::Credential(Box::new(cred))
+                })
+            });
+
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            assert_eq!(provider.call_count(), 0); // provider was NOT called
+        }
+
+        #[tokio::test]
+        async fn test_middleware_on_challenge_decline() {
+            let (_, www_auth) = test_challenge();
+            let app = paid_app(www_auth);
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+
+            let on_challenge: OnChallenge =
+                Box::new(|_challenge| Box::pin(async { ChallengeAction::Decline }));
+
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_on_challenge(on_challenge))
+                .build();
+
+            let err = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap_err();
+
+            assert!(
+                err.to_string().contains("payment declined"),
+                "expected payment declined error, got: {}",
+                err
+            );
+            assert_eq!(provider.call_count(), 0);
         }
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,7 @@ pub use error::HttpError;
 pub use provider::{MultiProvider, PaymentProvider};
 
 #[cfg(feature = "client")]
-pub use fetch::PaymentExt as Fetch;
+pub use fetch::{ChallengeAction, OnChallenge, PaymentExt as Fetch};
 
 #[cfg(feature = "middleware")]
 pub use middleware::PaymentMiddleware;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -33,7 +33,7 @@ pub use error::HttpError;
 pub use provider::{MultiProvider, PaymentProvider};
 
 #[cfg(feature = "client")]
-pub use fetch::{ChallengeAction, OnChallenge, PaymentExt as Fetch};
+pub use fetch::{ApproveChallenge, ChallengeAction, OnChallenge, PaymentExt as Fetch};
 
 #[cfg(feature = "middleware")]
 pub use middleware::PaymentMiddleware;


### PR DESCRIPTION
Adds an OnChallenge callback to both the fetch and middleware payment paths, letting callers approve, supply a credential directly, or decline when a 402 is received.