### PR TITLE
Use `Signer` trait for channel close signer and fee payer signer

### DIFF
--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -540,7 +540,7 @@ where
                 )
             })?;
 
-            self.cosign_fee_payer_transaction(&tx_bytes, fee_payer_signer, currency)
+            self.cosign_fee_payer_transaction(&tx_bytes, &**fee_payer_signer, currency)
                 .await?
         } else {
             tx_bytes.to_vec()
@@ -590,7 +590,6 @@ where
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::consensus::transaction::SignerRecoverable;
         use alloy::eips::Encodable2718;
-        use alloy::signers::Signer as _;
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         if tx_bytes.is_empty() {
@@ -983,8 +982,8 @@ mod tests {
 
     /// Round-trip: sign 0x78 envelope → cosign_fee_payer_transaction
     /// succeeds and produces a valid co-signed 0x76 transaction.
-    #[test]
-    fn test_fee_payer_round_trip_0x78_envelope() {
+    #[tokio::test]
+    async fn test_fee_payer_round_trip_0x78_envelope() {
         use super::super::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::eips::Decodable2718;
         use alloy::signers::SignerSync;
@@ -1014,11 +1013,13 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let co_signed = result.expect("cosign should succeed for valid 0x78 envelope");
+        let co_signed = result
+            .await
+            .expect("cosign should succeed for valid 0x78 envelope");
 
         // Result should be a valid 0x76 transaction
         assert_eq!(
@@ -1040,8 +1041,8 @@ mod tests {
     }
 
     /// cosign_fee_payer_transaction rejects txs with wrong nonce_key.
-    #[test]
-    fn test_cosign_rejects_wrong_nonce_key() {
+    #[tokio::test]
+    async fn test_cosign_rejects_wrong_nonce_key() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
@@ -1061,11 +1062,11 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject wrong nonce_key");
+        let err = result.await.expect_err("should reject wrong nonce_key");
         assert!(
             err.to_string().contains("expiring nonce key"),
             "error should mention expiring nonce key, got: {err}"
@@ -1073,8 +1074,8 @@ mod tests {
     }
 
     /// cosign_fee_payer_transaction rejects txs without valid_before.
-    #[test]
-    fn test_cosign_rejects_missing_valid_before() {
+    #[tokio::test]
+    async fn test_cosign_rejects_missing_valid_before() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
@@ -1094,11 +1095,13 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject missing valid_before");
+        let err = result
+            .await
+            .expect_err("should reject missing valid_before");
         assert!(
             err.to_string().contains("must include valid_before"),
             "error should mention valid_before, got: {err}"
@@ -1106,8 +1109,8 @@ mod tests {
     }
 
     /// cosign_fee_payer_transaction rejects txs with expired valid_before.
-    #[test]
-    fn test_cosign_rejects_expired_valid_before() {
+    #[tokio::test]
+    async fn test_cosign_rejects_expired_valid_before() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
@@ -1134,11 +1137,13 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &encoded,
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject expired valid_before");
+        let err = result
+            .await
+            .expect_err("should reject expired valid_before");
         assert!(
             err.to_string().contains("expired"),
             "error should mention expiration, got: {err}"
@@ -1146,8 +1151,8 @@ mod tests {
     }
 
     /// cosign_fee_payer_transaction rejects empty input.
-    #[test]
-    fn test_cosign_rejects_empty_input() {
+    #[tokio::test]
+    async fn test_cosign_rejects_empty_input() {
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
@@ -1161,11 +1166,11 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &[],
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject empty input");
+        let err = result.await.expect_err("should reject empty input");
         assert!(
             err.to_string().contains("Empty transaction bytes"),
             "error should mention empty, got: {err}"
@@ -1173,8 +1178,8 @@ mod tests {
     }
 
     /// cosign_fee_payer_transaction rejects non-0x78 type byte.
-    #[test]
-    fn test_cosign_rejects_wrong_type_byte() {
+    #[tokio::test]
+    async fn test_cosign_rejects_wrong_type_byte() {
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
             .parse()
@@ -1188,11 +1193,11 @@ mod tests {
 
         let result = method.cosign_fee_payer_transaction(
             &[0x79, 0xc0], // wrong type byte
-            method.fee_payer_signer.as_ref().unwrap(),
+            &**method.fee_payer_signer.as_ref().unwrap(),
             fee_token,
         );
 
-        let err = result.expect_err("should reject wrong type");
+        let err = result.await.expect_err("should reject wrong type");
         assert!(
             err.to_string()
                 .contains("Expected fee payer envelope (0x78)"),

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -103,7 +103,7 @@ fn parse_b256_hex(s: &str) -> Option<B256> {
 #[derive(Clone)]
 pub struct ChargeMethod<P> {
     provider: Arc<P>,
-    fee_payer_signer: Option<Arc<alloy::signers::local::PrivateKeySigner>>,
+    fee_payer_signer: Option<Arc<dyn alloy::signers::Signer + Send + Sync>>,
     store: Option<Arc<dyn Store>>,
 }
 
@@ -136,7 +136,13 @@ where
     ///
     /// When set, requests with `feePayer: true` will be accepted and
     /// broadcast. Without a fee payer signer, such requests are rejected.
-    pub fn with_fee_payer(mut self, signer: alloy::signers::local::PrivateKeySigner) -> Self {
+    ///
+    /// Accepts any type implementing alloy's [`Signer`](alloy::signers::Signer)
+    /// trait — local private keys, KMS-backed signers, hardware wallets, etc.
+    pub fn with_fee_payer(
+        mut self,
+        signer: impl alloy::signers::Signer + Send + Sync + 'static,
+    ) -> Self {
         self.fee_payer_signer = Some(Arc::new(signer));
         self
     }
@@ -534,7 +540,8 @@ where
                 )
             })?;
 
-            self.cosign_fee_payer_transaction(&tx_bytes, fee_payer_signer, currency)?
+            self.cosign_fee_payer_transaction(&tx_bytes, fee_payer_signer, currency)
+                .await?
         } else {
             tx_bytes.to_vec()
         };
@@ -574,16 +581,16 @@ where
     /// Accepts a `0x78` fee payer envelope, recovers the sender via
     /// ecrecover, validates fee-payer invariants, then co-signs and
     /// returns a complete `0x76` transaction ready for broadcast.
-    fn cosign_fee_payer_transaction(
+    async fn cosign_fee_payer_transaction(
         &self,
         tx_bytes: &[u8],
-        fee_payer_signer: &alloy::signers::local::PrivateKeySigner,
+        fee_payer_signer: &(dyn alloy::signers::Signer + Send + Sync),
         fee_token: Address,
     ) -> Result<Vec<u8>, VerificationError> {
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::consensus::transaction::SignerRecoverable;
         use alloy::eips::Encodable2718;
-        use alloy::signers::SignerSync;
+        use alloy::signers::Signer as _;
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         if tx_bytes.is_empty() {
@@ -660,7 +667,8 @@ where
         // Compute the fee payer signature hash and co-sign
         let fp_hash = tx.fee_payer_signature_hash(sender);
         let fp_sig = fee_payer_signer
-            .sign_hash_sync(&fp_hash)
+            .sign_hash(&fp_hash)
+            .await
             .map_err(|e| VerificationError::new(format!("Failed to co-sign transaction: {e}")))?;
 
         tx.fee_payer_signature = Some(fp_sig);

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -689,7 +689,6 @@ where
         let close_tx_hash = if let Some(ref signer) = self.close_signer {
             use alloy::eips::Encodable2718;
             use alloy::primitives::Bytes;
-            use alloy::signers::Signer as _;
             use alloy::sol_types::SolCall;
             use tempo_primitives::transaction::Call;
             use tempo_primitives::TempoTransaction;

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -210,7 +210,6 @@ pub struct SessionMethod<P> {
     /// Optional signer for submitting on-chain close transactions.
     ///
     /// Accepts any EVM signer (local key, KMS, hardware wallet, etc.).
-    // TODO: abstract signer for Solana sessions
     close_signer: Option<Arc<dyn alloy::signers::Signer + Send + Sync>>,
 }
 

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -208,7 +208,10 @@ pub struct SessionMethod<P> {
     store: Arc<dyn ChannelStore>,
     config: SessionMethodConfig,
     /// Optional signer for submitting on-chain close transactions.
-    close_signer: Option<Arc<alloy::signers::local::PrivateKeySigner>>,
+    ///
+    /// Accepts any EVM signer (local key, KMS, hardware wallet, etc.).
+    // TODO: abstract signer for Solana sessions
+    close_signer: Option<Arc<dyn alloy::signers::Signer + Send + Sync>>,
 }
 
 impl<P> SessionMethod<P> {
@@ -249,7 +252,13 @@ where
     }
 
     /// Set the signer used for submitting on-chain close transactions.
-    pub fn with_close_signer(mut self, signer: alloy::signers::local::PrivateKeySigner) -> Self {
+    ///
+    /// Accepts any type implementing alloy's [`Signer`](alloy::signers::Signer)
+    /// trait — local private keys, KMS-backed signers, hardware wallets, etc.
+    pub fn with_close_signer(
+        mut self,
+        signer: impl alloy::signers::Signer + Send + Sync + 'static,
+    ) -> Self {
         self.close_signer = Some(Arc::new(signer));
         self
     }
@@ -680,7 +689,7 @@ where
         let close_tx_hash = if let Some(ref signer) = self.close_signer {
             use alloy::eips::Encodable2718;
             use alloy::primitives::Bytes;
-            use alloy::signers::SignerSync;
+            use alloy::signers::Signer as _;
             use alloy::sol_types::SolCall;
             use tempo_primitives::transaction::Call;
             use tempo_primitives::TempoTransaction;
@@ -724,7 +733,7 @@ where
             };
 
             let sig_hash = tempo_tx.signature_hash();
-            let signature = signer.sign_hash_sync(&sig_hash).map_err(|e| {
+            let signature = signer.sign_hash(&sig_hash).await.map_err(|e| {
                 VerificationError::network_error(format!("failed to sign close tx: {}", e))
             })?;
             let signed_tx = tempo_tx.into_signed(signature.into());

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -32,7 +32,7 @@ pub struct TempoBuilder {
     pub(crate) decimals: u32,
     pub(crate) fee_payer: bool,
     pub(crate) chain_id: Option<u64>,
-    pub(crate) fee_payer_signer: Option<alloy::signers::local::PrivateKeySigner>,
+    pub(crate) fee_payer_signer: Option<Box<dyn alloy::signers::Signer + Send + Sync>>,
 }
 
 impl TempoBuilder {
@@ -96,8 +96,14 @@ impl TempoBuilder {
     /// When clients send transactions with `feePayer: true`, the server
     /// uses this signer to co-sign and sponsor the transaction gas fees.
     /// The signer's account must have sufficient balance for gas.
-    pub fn fee_payer_signer(mut self, signer: alloy::signers::local::PrivateKeySigner) -> Self {
-        self.fee_payer_signer = Some(signer);
+    ///
+    /// Accepts any type implementing alloy's [`Signer`](alloy::signers::Signer)
+    /// trait — local private keys, KMS-backed signers, hardware wallets, etc.
+    pub fn fee_payer_signer(
+        mut self,
+        signer: impl alloy::signers::Signer + Send + Sync + 'static,
+    ) -> Self {
+        self.fee_payer_signer = Some(Box::new(signer));
         self
     }
 }


### PR DESCRIPTION
## Problem

Server-side Tempo signing (`close_signer` in `SessionMethod`, `fee_payer_signer` in `ChargeMethod`) is hardcoded to `alloy::signers::local::PrivateKeySigner`. This forces operators to supply raw private keys directly, which is unacceptable for production deployments that use KMS (AWS KMS, GCP Cloud KMS), HSMs, or other managed signing infrastructure.

## Why the current implementation is insufficient

`PrivateKeySigner` is a concrete local signer — it holds an in-memory secret key. Every builder method, struct field, and internal call site is typed against it, making it impossible to plug in any alternative signer without forking the crate. The synchronous `sign_hash_sync` calls further restrict compatibility, since most KMS-backed signers are inherently async.

## Solution

Replace all server-side `PrivateKeySigner` references with alloy's `dyn Signer` trait:

- **`SessionMethod::close_signer`** → `Option<Arc<dyn Signer + Send + Sync>>`
- **`ChargeMethod::fee_payer_signer`** → `Option<Arc<dyn Signer + Send + Sync>>`
- **`TempoBuilder::fee_payer_signer`** → `Option<Box<dyn Signer + Send + Sync>>`
- Builder methods accept `impl Signer + Send + Sync + 'static`
- `cosign_fee_payer_transaction` becomes `async fn`; all `sign_hash_sync` calls become `sign_hash().await`

Client-side code (`TempoProvider`, `TempoSessionProvider`) is unchanged — callers still create wallets with `PrivateKeySigner` which satisfies `impl Signer`. Existing usage compiles without modification.