### PR TITLE
feat: add OWS wallet support for TempoProvider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ evm = ["alloy", "hex", "rand"]
 tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
 stripe = ["dep:reqwest"]
 
+# OWS wallet integration (optional)
+ows = ["evm", "dep:ows-lib", "dep:ows-core"]
+
 # Utilities
 utils = ["hex", "rand"]
 
@@ -66,6 +69,10 @@ alloy = { version = "1.7", features = ["full"], optional = true }
 # Tempo dependencies (optional)
 tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
+
+# OWS dependencies (optional)
+ows-lib = { version = "1.0.0", optional = true }
+ows-core = { version = "1.0.0", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -64,6 +64,38 @@ impl TempoProvider {
         })
     }
 
+    /// Create a Tempo provider from an OWS wallet.
+    ///
+    /// Decrypts the EVM signing key from the OWS vault and creates a
+    /// provider ready for signing. The key is only in memory during the
+    /// lifetime of the provider.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let provider = TempoProvider::from_ows("my-wallet", "https://rpc.tempo.xyz")?;
+    /// let resp = client.get(url).send_with_payment(&provider).await?;
+    /// ```
+    #[cfg(feature = "ows")]
+    pub fn from_ows(
+        wallet_name_or_id: &str,
+        rpc_url: impl AsRef<str>,
+    ) -> Result<Self, MppError> {
+        let key_bytes = ows_lib::decrypt_signing_key(
+            wallet_name_or_id,
+            ows_core::ChainType::Evm,
+            "",
+            None,
+            None,
+        )
+        .map_err(|e| MppError::InvalidConfig(format!("OWS decrypt: {e}")))?;
+
+        let signer = alloy::signers::local::PrivateKeySigner::from_slice(key_bytes.expose())
+            .map_err(|e| MppError::InvalidConfig(format!("invalid OWS key: {e}")))?;
+
+        Self::new(signer, rpc_url)
+    }
+
     /// Set an optional client identifier for attribution memos.
     pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
         self.client_id = Some(client_id.into());


### PR DESCRIPTION
## Summary

Adds `TempoProvider::from_ows(wallet_name, rpc_url)` — creates a Tempo payment provider by decrypting the signing key from an [OWS](https://openwallet.sh) encrypted vault. Feature-gated behind `ows`.

## Usage

```rust
// Before: caller manages the key
let signer = PrivateKeySigner::from_slice(&key_bytes)?;
let provider = TempoProvider::new(signer, rpc_url)?;

// After: one line, key stays encrypted until needed
let provider = TempoProvider::from_ows("my-wallet", rpc_url)?;
```

## Changes

| File | What |
|------|------|
| `Cargo.toml` | Added `ows` feature with `ows-lib` and `ows-core` deps |
| `src/client/tempo/provider.rs` | Added `from_ows()` constructor |

Feature-gated: `cargo build --features "client,ows"`

No changes to existing code paths. The `ows` feature is fully optional.