### PR TITLE
chore: bump alloy and tempo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ server = ["tokio", "futures-core", "async-stream"]
 
 # Method implementations
 evm = ["alloy", "hex", "rand"]
-tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid", "revm-database-interface"]
+tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
 
 # Utilities
 utils = ["hex", "rand"]
@@ -65,9 +65,6 @@ alloy = { version = "1.2", features = ["full"], optional = true }
 tempo-alloy = { version = "1", optional = true }
 tempo-primitives = { version = "1", optional = true }
 
-# Pin: revm-database-interface 9.0.1 bumps revm-state to v10, breaking revm v34 (still on v9)
-revm-database-interface = { version = ">=9.0.0, <9.0.1", optional = true }
-
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", features = ["json"], optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
@@ -89,6 +86,6 @@ axum = { version = "0.8" }
 reqwest = { version = "0.12", features = ["json"] }
 hex = "0.4"
 
-[patch.crates-io]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
+# [patch.crates-io]
+# tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+# tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,15 +55,15 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "1.2", features = ["full"], optional = true }
+alloy = { version = "1.8", features = ["full"], optional = true }
 
 # Tempo dependencies (optional)
 # Note: tempo feature requires git dependency - add to your Cargo.toml:
 #   [patch.crates-io]
 #   tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
 #   tempo-primitives = { git = "https://github.com/tempoxyz/tempo" }
-tempo-alloy = { version = "1", optional = true }
-tempo-primitives = { version = "1", optional = true }
+tempo-alloy = { version = "1.5", optional = true }
+tempo-primitives = { version = "1.5", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", features = ["json"], optional = true }

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http", "sol-types", "contract"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -7,6 +7,7 @@
 //! - [`PaymentProvider`]: Trait for payment providers
 //! - [`Fetch`]: Extension trait for reqwest with `.send_with_payment()` method
 //! - [`TempoProvider`]: Tempo blockchain provider (requires `tempo`)
+//! - [`TempoSessionProvider`]: Tempo session/channel provider (requires `tempo`)
 //!
 //! # Example
 //!
@@ -39,6 +40,8 @@ pub use fetch::PaymentExt as Fetch;
 pub use middleware::PaymentMiddleware;
 
 // Re-export Tempo types at client level for convenience
+#[cfg(feature = "tempo")]
+pub use tempo::session::{channel_ops, TempoSessionProvider};
 #[cfg(feature = "tempo")]
 pub use tempo::{AutoswapConfig, TempoClientError, TempoProvider};
 #[cfg(feature = "tempo")]


### PR DESCRIPTION
## Summary
- bump `alloy` to `1.8` and `tempo-alloy` / `tempo-primitives` to `1.5` in the root crate
- bump the direct example crate `alloy` / `tempo-alloy` constraints to match
- restore `mpp::client::{TempoSessionProvider, channel_ops}` re-exports so the session examples continue to compile against the documented client API

## Verification
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo test --all-features --no-run`
- `cargo test --all-features --lib`
- `cargo check` in `examples/basic`
- `cargo check` in `examples/axum-extractor`
- `cargo check` in `examples/session/multi-fetch`
- `cargo check` in `examples/session/sse`