### PR TITLE
chore: bump alloy and tempo dependencies

### DIFF
--- a/.changelog/icy-winds-whisper.md
+++ b/.changelog/icy-winds-whisper.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Bumped `alloy` dependency from 1.7 to 1.8 and `tempo-alloy`/`tempo-primitives` from 1 to 1.5 across the main crate and all examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,11 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "1.7", features = ["full"], optional = true }
+alloy = { version = "1.8", features = ["full"], optional = true }
 
 # Tempo dependencies (optional)
-tempo-alloy = { version = "1", optional = true }
-tempo-primitives = { version = "1", optional = true }
+tempo-alloy = { version = "1.5", optional = true }
+tempo-primitives = { version = "1.5", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
@@ -87,4 +87,3 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4"
-

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -14,12 +14,11 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.9"
-

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -14,12 +14,11 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.9"
-

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http", "sol-types", "contract"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -23,4 +23,3 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.9"
-

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.2", features = ["provider-http"] }
-tempo-alloy = "1"
+alloy = { version = "1.8", features = ["provider-http"] }
+tempo-alloy = "1.5"
 axum = "0.7"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
@@ -27,4 +27,3 @@ rand = "0.9"
 futures = "0.3"
 async-stream = "0.3"
 urlencoding = "2"
-


### PR DESCRIPTION
## Summary
- bump the root crate to `alloy 1.8` and `tempo-alloy` / `tempo-primitives 1.5`
- bump the direct `alloy` / `tempo-alloy` constraints in the standalone example crates to match
- recreate this PR cleanly on top of the latest `main` to avoid the stale merge conflict from the previous branch

## Verification
- `cargo fmt --check`
- `cargo check --all-features`
- `cargo test --all-features --no-run`
- `cargo test --all-features --lib`
- `cargo check` in `examples/basic`
- `cargo check` in `examples/axum-extractor`
- `cargo check` in `examples/session/multi-fetch`
- `cargo check` in `examples/session/sse`