### PR TITLE
ci: suggest changelog entries on PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,10 +2,11 @@ name: Changelog
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize]
 
 jobs:
   changelog:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -14,41 +15,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-      - name: Install changelogs
-        run: curl -sSL https://changelogs.sh | sh
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code
-      - name: Generate changelog
+      - name: Check changelog
+        uses: tempoxyz/changelogs/check@master
+        with:
+          ai: "claude -p"
+          ecosystem: rust
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: |
-          # Skip if only infra/config files changed (no code changes requiring changelog)
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          CODE_CHANGES=$(echo "$CHANGED" | grep -vE '^(\.changelog/|\.github/|\.gitignore|README\.md|AGENTS\.md|RELEASE\.md)' || true)
-          if [ -z "$CODE_CHANGES" ]; then
-            echo "No code changes requiring changelog, skipping"
-            exit 0
-          fi
-          ~/.local/bin/changelogs add --ecosystem rust --ai "claude -p" --ref origin/${{ github.base_ref }}
-      - name: Commit changelog
-        id: commit
-        run: |
-          if [ -n "$(git status --porcelain .changelog/)" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add .changelog/
-            git commit -m "chore: add changelog"
-            git push
-            echo "pushed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-  ci:
-    needs: changelog
-    if: always()
-    permissions:
-      contents: read
-      pull-requests: write
-    uses: ./.github/workflows/ci.yml
-    with:
-      ref: ${{ github.head_ref }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,19 +5,19 @@ This project uses [changelogs-rs](https://github.com/wevm/changelogs-rs) for aut
 ## How It Works
 
 ```
-PR opened → changelog added → PR merged → RC PR created → RC merged → published to crates.io
+PR opened/updated → changelog suggested → PR merged → RC PR created → RC merged → published to crates.io
 ```
 
 ### During Development
 
 1. **Make changes** and open a PR
-2. **Changelog auto-generated** - CI automatically creates a `.changelog/*.md` file and commits it to your PR branch (using AI to summarize your changes)
-3. **Review the changelog** - check the generated file; edit if needed
-4. **Merge the PR** - changelog files are staged in `.changelog/`
+2. **Changelog suggested** - CI comments on the PR with changelog status and, if missing, an AI-generated changelog suggestion you can add with one click
+3. **Review the changelog** - check the suggestion or existing file; edit if needed
+4. **Merge the PR** - changelog files live in `.changelog/`
 
 ### Creating Changelogs Manually
 
-If CI doesn't generate one (e.g., for infra-only changes you want to document), create manually:
+If CI doesn't suggest one or you want to write it yourself, create it manually:
 
 ```bash
 # Interactive prompt
@@ -112,7 +112,7 @@ See [config.toml](./config.toml) for changelog settings:
 
 | Workflow | Trigger | Action |
 |----------|---------|--------|
-| `changelog.yml` | PR opened/updated | Auto-generates changelog via AI |
+| `changelog.yml` | PR opened/updated | Comments on PR with changelog status and AI-generated add link |
 | `release.yml` | Push to main | Creates RC PR or publishes packages |
 
 ## Required Secrets


### PR DESCRIPTION
## Summary
- switch the changelog workflow from auto-generating and pushing bot commits to PR comments/suggestions via `tempoxyz/changelogs/check`
- run the changelog workflow on both PR open and synchronize, matching the `reth` pattern
- update `RELEASE.md` so the documented changelog flow matches the actual workflow behavior
- recreate this change from a fresh dedicated git worktree based on the latest `main`

## Verification
- `actionlint .github/workflows/changelog.yml .github/workflows/ci.yml .github/workflows/release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/changelog.yml"); puts "ok"'`
- `git diff --check https-origin/main...HEAD`