### PR TITLE
ci: disable tempo lint PR comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,7 +36,7 @@ jobs:
         with:
           language: rust
           path: "."
-          post-comment: true
+          post-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test:
@@ -70,4 +69,3 @@ jobs:
             echo "One or more required jobs failed or were cancelled"
             exit 1
           fi
-


### PR DESCRIPTION
## Summary
- stop `tempoxyz/lints` from posting the recurring "Tempo Lint Results" comment on every PR
- keep the lint step itself enabled so CI still enforces the check
- remove the now-unneeded `pull-requests: write` permission from the lint job

## Verification
- `actionlint .github/workflows/ci.yml .github/workflows/changelog.yml .github/workflows/release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
- `git diff --check https-origin/main...HEAD`