### PR TITLE
fix: handle leading whitespace in split_payment_challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Enforced fail-closed behavior for the `expires` field in `verify_hmac_and_expiry`. Credentials missing the `expires` field are now rejected with a `CredentialMismatch` error instead of being silently accepted. Session challenges now include a default expiry. (by @EvanChipman, [#194](https://github.com/tempoxyz/mpp-rs/pull/194))
 - Fixed busy loop in `serve()` caused by default `wait_for_update()` returning immediately instead of pending. (by @EvanChipman, [#194](https://github.com/tempoxyz/mpp-rs/pull/194))
+- Fixed `split_payment_challenges` to handle leading whitespace in header values. Added tests for merged comma-separated challenges and quoted `"Payment"` boundaries. (by @stevencartavia, [#170](https://github.com/tempoxyz/mpp-rs/pull/170))
 
 ## 0.9.0 (2026-04-07)
 

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -278,6 +278,13 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
 /// ];
 /// let challenges = parse_www_authenticate_all(headers);
 /// assert_eq!(challenges.len(), 2);
+///
+/// // Merged into a single header value
+/// let merged = vec![
+///     "Payment id=\"abc\", realm=\"api\", method=\"tempo\", intent=\"charge\", request=\"e30\", Payment id=\"def\", realm=\"api\", method=\"base\", intent=\"charge\", request=\"e30\"",
+/// ];
+/// let challenges = parse_www_authenticate_all(merged);
+/// assert_eq!(challenges.len(), 2);
 /// ```
 ///
 /// ```
@@ -590,6 +597,37 @@ mod tests {
 
         let second = results[1].as_ref().unwrap();
         assert_eq!(second.id, "b");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_all_merged() {
+        // Two Payment schemes in a single comma-separated header value
+        let merged = r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#;
+        let results = parse_www_authenticate_all(vec![merged]);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].as_ref().unwrap().id, "a");
+        assert_eq!(results[0].as_ref().unwrap().method.as_str(), "tempo");
+        assert_eq!(results[1].as_ref().unwrap().id, "b");
+        assert_eq!(results[1].as_ref().unwrap().method.as_str(), "stripe");
+    }
+
+    #[test]
+    fn test_split_payment_schemes_ignores_quoted() {
+        // "Payment" inside a quoted value should NOT be treated as a boundary
+        let header = r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", description="Payment required""#;
+        let schemes = split_payment_schemes(header);
+        assert_eq!(schemes.len(), 1);
+    }
+
+    #[test]
+    fn test_split_payment_schemes_leading_whitespace() {
+        // Headers with leading whitespace must still be recognized
+        let header =
+            r#"  Payment id="a", realm="api", method="tempo", intent="charge", request="e30""#;
+        let schemes = split_payment_schemes(header);
+        assert_eq!(schemes.len(), 1);
+        let challenge = parse_www_authenticate(schemes[0]).unwrap();
+        assert_eq!(challenge.id, "a");
     }
 
     #[test]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -315,7 +315,9 @@ pub fn parse_www_authenticate_all<'a>(
 /// returns the individual challenge strings.
 fn split_payment_challenges(header: &str) -> Vec<&str> {
     fn is_valid_start(header: &str, pos: usize) -> bool {
-        pos == 0 || header[..pos].bytes().rfind(|b| !b.is_ascii_whitespace()) == Some(b',')
+        pos == 0
+            || header[..pos].bytes().all(|b| b.is_ascii_whitespace())
+            || header[..pos].bytes().rfind(|b| !b.is_ascii_whitespace()) == Some(b',')
     }
 
     let lower = header.to_ascii_lowercase();
@@ -615,7 +617,7 @@ mod tests {
     fn test_split_payment_schemes_ignores_quoted() {
         // "Payment" inside a quoted value should NOT be treated as a boundary
         let header = r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", description="Payment required""#;
-        let schemes = split_payment_schemes(header);
+        let schemes = split_payment_challenges(header);
         assert_eq!(schemes.len(), 1);
     }
 
@@ -624,7 +626,7 @@ mod tests {
         // Headers with leading whitespace must still be recognized
         let header =
             r#"  Payment id="a", realm="api", method="tempo", intent="charge", request="e30""#;
-        let schemes = split_payment_schemes(header);
+        let schemes = split_payment_challenges(header);
         assert_eq!(schemes.len(), 1);
         let challenge = parse_www_authenticate(schemes[0]).unwrap();
         assert_eq!(challenge.id, "a");


### PR DESCRIPTION
Fix `split_payment_challenges` to recognize `Payment` scheme boundaries when the header value has leading whitespace (e.g., `"  Payment id=..."`).