### PR TITLE
chore: add missing changelog entries for PRs #171, #169, #162

### DIFF
--- a/.changelog/brave-foxes-guard.md
+++ b/.changelog/brave-foxes-guard.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed multiple payment bypass and griefing vulnerabilities (GHSA-fxc9-7j2w-vx54).

--- a/.changelog/quiet-birds-rest.md
+++ b/.changelog/quiet-birds-rest.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Disabled tempo lint PR comments while keeping the lint CI check enforced.

--- a/.changelog/swift-rivers-flow.md
+++ b/.changelog/swift-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added `fee_payer()` and `chain_id()` getters to `Mpp`.


### PR DESCRIPTION
Adds changelog entries for PRs that were merged without them:

- **#171** (patch) — fix: multiple payment bypass and griefing vulnerabilities
- **#169** (patch) — ci: disable tempo lint PR comments
- **#162** (minor) — feat: add `fee_payer` & `chain_id` getters for `Mpp`

Once merged, the release bot should update PR #150 with these entries.