### PR TITLE
feat: support multi-challenge WWW-Authenticate headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Minor Changes
 
-- Added support for multi-challenge `WWW-Authenticate` headers. `parse_www_authenticate_all` now correctly splits and parses headers containing multiple `Payment` challenges. Added `find_tempo_challenge` helper to extract the first Tempo challenge from multi-challenge headers. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+- Added support for multi-challenge `WWW-Authenticate` headers. `parse_www_authenticate_all` now correctly splits and parses headers containing multiple `Payment` challenges. Non-Payment schemes (e.g. `Bearer`) are silently ignored. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+- Client now matches challenges by `provider.supports(method, intent)` instead of assuming a single challenge, mirroring the mppx TypeScript SDK. Both `PaymentExt` (fetch) and `PaymentMiddleware` parse all challenges and select the first one the provider supports. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+- Added `HttpError::NoSupportedChallenge` variant for when a 402 response contains no challenge matching the provider's supported methods. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
 
-### Patch Changes
+### Breaking Changes
 
-- Moved `find_tempo_challenge` from `protocol::core` to `protocol::methods::tempo` where it belongs. The function is still re-exported from `protocol::core` for backward compatibility. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+- Removed `find_tempo_challenge`. Use `parse_www_authenticate_all` with `provider.supports()` matching instead, or filter challenges manually. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
 
 ## 0.8.2 (2026-03-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.8.3 (2026-03-31)
+
+### Minor Changes
+
+- Added support for multi-challenge `WWW-Authenticate` headers. `parse_www_authenticate_all` now correctly splits and parses headers containing multiple `Payment` challenges. Added `find_tempo_challenge` helper to extract the first Tempo challenge from multi-challenge headers. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+
+### Patch Changes
+
+- Moved `find_tempo_challenge` from `protocol::core` to `protocol::methods::tempo` where it belongs. The function is still re-exported from `protocol::core` for backward compatibility. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
+
 ## 0.8.2 (2026-03-31)
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,8 @@
 
 ### Minor Changes
 
-- Added support for multi-challenge `WWW-Authenticate` headers. `parse_www_authenticate_all` now correctly splits and parses headers containing multiple `Payment` challenges. Non-Payment schemes (e.g. `Bearer`) are silently ignored. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
 - Client now matches challenges by `provider.supports(method, intent)` instead of assuming a single challenge, mirroring the mppx TypeScript SDK. Both `PaymentExt` (fetch) and `PaymentMiddleware` parse all challenges and select the first one the provider supports. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
 - Added `HttpError::NoSupportedChallenge` variant for when a 402 response contains no challenge matching the provider's supported methods. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
-
-### Breaking Changes
-
-- Removed `find_tempo_challenge`. Use `parse_www_authenticate_all` with `provider.supports()` matching instead, or filter challenges manually. (by @grandizzy, [#185](https://github.com/tempoxyz/mpp-rs/pull/185))
 
 ## 0.8.2 (2026-03-31)
 

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -9,6 +9,9 @@ pub enum HttpError {
     /// Missing WWW-Authenticate header on 402 response
     MissingChallenge,
 
+    /// No challenge in the 402 response matches the provider's supported methods
+    NoSupportedChallenge(String),
+
     /// Failed to parse challenge from WWW-Authenticate header
     InvalidChallenge(String),
 
@@ -31,6 +34,9 @@ impl fmt::Display for HttpError {
         match self {
             Self::MissingChallenge => {
                 write!(f, "402 response missing WWW-Authenticate header")
+            }
+            Self::NoSupportedChallenge(msg) => {
+                write!(f, "no supported challenge: {}", msg)
             }
             Self::InvalidChallenge(msg) => write!(f, "invalid challenge: {}", msg),
             Self::InvalidCredential(msg) => write!(f, "invalid credential: {}", msg),

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -7,7 +7,9 @@ use reqwest::{RequestBuilder, Response, StatusCode};
 
 use super::error::HttpError;
 use super::provider::PaymentProvider;
-use crate::protocol::core::{format_authorization, parse_www_authenticate, AUTHORIZATION_HEADER};
+use crate::protocol::core::{
+    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+};
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -63,17 +65,37 @@ impl PaymentExt for RequestBuilder {
             return Ok(resp);
         }
 
-        let www_auth = resp
+        let www_auth_values: Vec<&str> = resp
             .headers()
-            .get(WWW_AUTHENTICATE)
-            .ok_or(HttpError::MissingChallenge)?
-            .to_str()
-            .map_err(|e| HttpError::InvalidChallenge(e.to_string()))?;
+            .get_all(WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
 
-        let challenge = parse_www_authenticate(www_auth)
-            .map_err(|e| HttpError::InvalidChallenge(e.to_string()))?;
+        if www_auth_values.is_empty() {
+            return Err(HttpError::MissingChallenge);
+        }
 
-        let credential = provider.pay(&challenge).await?;
+        let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
+            .into_iter()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let challenge = challenges
+            .iter()
+            .find(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
+            .ok_or_else(|| {
+                let offered: Vec<_> = challenges
+                    .iter()
+                    .map(|c| format!("{}.{}", c.method, c.intent))
+                    .collect();
+                HttpError::NoSupportedChallenge(format!(
+                    "server offered [{}], but provider does not support any",
+                    offered.join(", ")
+                ))
+            })?;
+
+        let credential = provider.pay(challenge).await?;
 
         let auth_header = format_authorization(&credential)
             .map_err(|e| HttpError::InvalidCredential(e.to_string()))?;
@@ -290,7 +312,7 @@ mod tests {
                 .await
                 .unwrap_err();
 
-            assert!(matches!(err, HttpError::InvalidChallenge(_)));
+            assert!(matches!(err, HttpError::NoSupportedChallenge(_)));
         }
 
         #[tokio::test]

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -367,7 +367,9 @@ mod tests {
 
         impl super::PaymentProvider for SelectiveProvider {
             fn supports(&self, method: &str, intent: &str) -> bool {
-                self.supported.iter().any(|(m, i)| *m == method && *i == intent)
+                self.supported
+                    .iter()
+                    .any(|(m, i)| *m == method && *i == intent)
             }
 
             async fn pay(
@@ -518,17 +520,11 @@ mod tests {
                         if req.headers().get("authorization").is_some() {
                             (AxumStatusCode::OK, "ok").into_response()
                         } else {
-                            let mut resp = (AxumStatusCode::PAYMENT_REQUIRED, "pay up")
-                                .into_response();
+                            let mut resp =
+                                (AxumStatusCode::PAYMENT_REQUIRED, "pay up").into_response();
                             let headers = resp.headers_mut();
-                            headers.append(
-                                WWW_AUTH_NAME,
-                                stripe_header.parse().unwrap(),
-                            );
-                            headers.append(
-                                WWW_AUTH_NAME,
-                                tempo_header.parse().unwrap(),
-                            );
+                            headers.append(WWW_AUTH_NAME, stripe_header.parse().unwrap());
+                            headers.append(WWW_AUTH_NAME, tempo_header.parse().unwrap());
                             resp
                         }
                     }

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -344,5 +344,240 @@ mod tests {
 
             assert!(matches!(err, HttpError::Payment(_)));
         }
+
+        /// Provider that only supports specific method/intent pairs.
+        #[derive(Clone)]
+        struct SelectiveProvider {
+            supported: Vec<(&'static str, &'static str)>,
+            pay_count: Arc<AtomicU32>,
+        }
+
+        impl SelectiveProvider {
+            fn new(supported: Vec<(&'static str, &'static str)>) -> Self {
+                Self {
+                    supported,
+                    pay_count: Arc::new(AtomicU32::new(0)),
+                }
+            }
+
+            fn call_count(&self) -> u32 {
+                self.pay_count.load(Ordering::SeqCst)
+            }
+        }
+
+        impl super::PaymentProvider for SelectiveProvider {
+            fn supports(&self, method: &str, intent: &str) -> bool {
+                self.supported.iter().any(|(m, i)| *m == method && *i == intent)
+            }
+
+            async fn pay(
+                &self,
+                challenge: &PaymentChallenge,
+            ) -> Result<PaymentCredential, MppError> {
+                self.pay_count.fetch_add(1, Ordering::SeqCst);
+                let echo = challenge.to_echo();
+                Ok(PaymentCredential::new(
+                    echo,
+                    PaymentPayload::hash("0xmockhash"),
+                ))
+            }
+        }
+
+        /// Build a challenge header for a specific method and intent.
+        fn challenge_header(id: &str, method: &str, intent: &str) -> String {
+            let request =
+                Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
+            let challenge = PaymentChallenge::new(id, "test.example.com", method, intent, request);
+            format_www_authenticate(&challenge).unwrap()
+        }
+
+        #[tokio::test]
+        async fn test_multi_challenge_selects_supported_method() {
+            // Server offers both stripe and tempo; provider only supports tempo.
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+            let tempo_header = challenge_header("t1", "tempo", "charge");
+            let combined = format!("{}, {}", stripe_header, tempo_header);
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let combined = combined.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, combined)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge")]);
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_multi_challenge_picks_first_supported() {
+            // Server offers tempo then stripe; provider supports both.
+            // Should pick tempo (first match).
+            let tempo_header = challenge_header("t1", "tempo", "charge");
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+            let combined = format!("{}, {}", tempo_header, stripe_header);
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let combined = combined.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, combined)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge"), ("stripe", "charge")]);
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_no_supported_challenge_error() {
+            // Server offers stripe only; provider only supports tempo.
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let stripe_header = stripe_header.clone();
+                    async move {
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, stripe_header)],
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge")]);
+            let client = reqwest::Client::new();
+
+            let err = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(err, HttpError::NoSupportedChallenge(_)));
+        }
+
+        #[tokio::test]
+        async fn test_multiple_www_authenticate_headers() {
+            // Challenges split across separate WWW-Authenticate header instances.
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+            let tempo_header = challenge_header("t1", "tempo", "charge");
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let stripe_header = stripe_header.clone();
+                    let tempo_header = tempo_header.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            let mut resp = (AxumStatusCode::PAYMENT_REQUIRED, "pay up")
+                                .into_response();
+                            let headers = resp.headers_mut();
+                            headers.append(
+                                WWW_AUTH_NAME,
+                                stripe_header.parse().unwrap(),
+                            );
+                            headers.append(
+                                WWW_AUTH_NAME,
+                                tempo_header.parse().unwrap(),
+                            );
+                            resp
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge")]);
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_intent_matching() {
+            // Server offers tempo/session; provider only supports tempo/charge.
+            let session_header = challenge_header("t1", "tempo", "session");
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let session_header = session_header.clone();
+                    async move {
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, session_header)],
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge")]);
+            let client = reqwest::Client::new();
+
+            let err = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(err, HttpError::NoSupportedChallenge(_)));
+        }
     }
 }

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -9,7 +9,9 @@ use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next};
 
 use crate::client::provider::PaymentProvider;
-use crate::protocol::core::{format_authorization, parse_www_authenticate, AUTHORIZATION_HEADER};
+use crate::protocol::core::{
+    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+};
 
 /// Middleware that automatically handles 402 Payment Required responses.
 ///
@@ -66,22 +68,33 @@ where
             .context("request could not be cloned for payment retry")
             .map_err(reqwest_middleware::Error::Middleware)?;
 
-        let www_auth = resp
+        let www_auth_values: Vec<&str> = resp
             .headers()
-            .get(WWW_AUTHENTICATE)
-            .context("402 response missing WWW-Authenticate header")
-            .map_err(reqwest_middleware::Error::Middleware)?
-            .to_str()
-            .context("invalid WWW-Authenticate header")
-            .map_err(reqwest_middleware::Error::Middleware)?;
+            .get_all(WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
 
-        let challenge = parse_www_authenticate(www_auth)
-            .context("invalid challenge")
+        if www_auth_values.is_empty() {
+            return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                "402 response missing WWW-Authenticate header"
+            )));
+        }
+
+        let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
+            .into_iter()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let challenge = challenges
+            .iter()
+            .find(|c| self.provider.supports(c.method.as_str(), c.intent.as_str()))
+            .context("no challenge matches provider's supported methods")
             .map_err(reqwest_middleware::Error::Middleware)?;
 
         let credential = self
             .provider
-            .pay(&challenge)
+            .pay(challenge)
             .await
             .context("payment failed")
             .map_err(reqwest_middleware::Error::Middleware)?;

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -925,7 +925,8 @@ mod tests {
     #[test]
     fn test_split_payment_challenges() {
         // single challenge
-        let single = r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30""#;
+        let single =
+            r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30""#;
         assert_eq!(split_payment_challenges(single).len(), 1);
 
         // two challenges, normal spacing

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -329,38 +329,6 @@ fn split_payment_challenges(header: &str) -> Vec<&str> {
         .collect()
 }
 
-/// Find the first `tempo` method challenge from one or more WWW-Authenticate
-/// header values.
-///
-/// This is a convenience wrapper around [`parse_www_authenticate_all`] that
-/// filters for `method="tempo"` and returns the first match.
-///
-/// # Examples
-///
-/// ```
-/// use mpp::protocol::core::find_tempo_challenge;
-///
-/// let header = concat!(
-///     r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
-///     r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
-/// );
-/// let challenge = find_tempo_challenge(vec![header]).unwrap();
-/// assert_eq!(challenge.id, "a");
-/// assert_eq!(challenge.method.as_str(), "tempo");
-/// ```
-pub fn find_tempo_challenge<'a>(
-    headers: impl IntoIterator<Item = &'a str>,
-) -> Result<PaymentChallenge> {
-    parse_www_authenticate_all(headers)
-        .into_iter()
-        .find(|r| r.as_ref().is_ok_and(|c| c.method.as_str() == "tempo"))
-        .unwrap_or_else(|| {
-            Err(MppError::invalid_challenge_reason(
-                "No Payment challenge with method=\"tempo\" found",
-            ))
-        })
-}
-
 /// Format a PaymentChallenge as a WWW-Authenticate header value.
 ///
 /// Format: `Payment id="<id>", realm="<realm>", method="<method>", intent="<intent>", request="<base64url-json>"`
@@ -993,19 +961,4 @@ mod tests {
         assert_eq!(results[1].as_ref().unwrap().method.as_str(), "stripe");
     }
 
-    #[test]
-    fn test_find_tempo_challenge() {
-        let header = concat!(
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30", "#,
-            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
-        );
-        let c = find_tempo_challenge(vec![header]).unwrap();
-        assert_eq!(c.id, "t1");
-        assert_eq!(c.method.as_str(), "tempo");
-
-        // no tempo challenge → error
-        let other =
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#;
-        assert!(find_tempo_challenge(vec![other]).is_err());
-    }
 }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -960,4 +960,26 @@ mod tests {
         assert_eq!(results[0].as_ref().unwrap().method.as_str(), "tempo");
         assert_eq!(results[1].as_ref().unwrap().method.as_str(), "stripe");
     }
+
+    #[test]
+    fn test_parse_www_authenticate_all_ignores_non_payment_schemes() {
+        // Bearer and other non-Payment schemes should be silently ignored
+        let headers = vec![
+            "Bearer token123",
+            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
+            "Basic dXNlcjpwYXNz",
+        ];
+        let results = parse_www_authenticate_all(headers);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].as_ref().unwrap().method.as_str(), "tempo");
+
+        // Mixed in a single header value: Bearer prefix followed by Payment challenge
+        let mixed = concat!(
+            "Bearer token123, ",
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#,
+        );
+        let results = parse_www_authenticate_all(vec![mixed]);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].as_ref().unwrap().method.as_str(), "stripe");
+    }
 }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -960,5 +960,4 @@ mod tests {
         assert_eq!(results[0].as_ref().unwrap().method.as_str(), "tempo");
         assert_eq!(results[1].as_ref().unwrap().method.as_str(), "stripe");
     }
-
 }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -255,9 +255,14 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
     })
 }
 
-/// Parse all WWW-Authenticate headers that use the Payment scheme.
+/// Parse all Payment challenges from one or more WWW-Authenticate header values.
 ///
-/// Returns a Vec of Results - one for each Payment header found.
+/// Handles both:
+/// - Multiple separate header values (one challenge each)
+/// - A single header value containing multiple comma-separated Payment challenges
+///   (per RFC 9110 §11.6.1)
+///
+/// Returns a Vec of Results - one for each Payment challenge found.
 /// Non-Payment headers are skipped.
 ///
 /// # Examples
@@ -265,6 +270,7 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
 /// ```
 /// use mpp::protocol::core::parse_www_authenticate_all;
 ///
+/// // Separate header values
 /// let headers = vec![
 ///     "Bearer token",
 ///     "Payment id=\"abc\", realm=\"api\", method=\"tempo\", intent=\"charge\", request=\"e30\"",
@@ -273,18 +279,86 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
 /// let challenges = parse_www_authenticate_all(headers);
 /// assert_eq!(challenges.len(), 2);
 /// ```
+///
+/// ```
+/// use mpp::protocol::core::parse_www_authenticate_all;
+///
+/// // Single header with multiple challenges
+/// let header = concat!(
+///     r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
+///     r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
+/// );
+/// let challenges = parse_www_authenticate_all(vec![header]);
+/// assert_eq!(challenges.len(), 2);
+/// ```
 pub fn parse_www_authenticate_all<'a>(
     headers: impl IntoIterator<Item = &'a str>,
 ) -> Vec<Result<PaymentChallenge>> {
     headers
         .into_iter()
-        .filter(|h| {
-            h.trim_start()
-                .get(..8)
-                .is_some_and(|s| s.eq_ignore_ascii_case("payment "))
-        })
+        .flat_map(split_payment_challenges)
         .map(parse_www_authenticate)
         .collect()
+}
+
+/// Split a header value into individual `Payment` challenge slices.
+///
+/// Finds `Payment ` scheme boundaries (case-insensitive per RFC 9110 §11.6.1)
+/// that appear at the start of the header or after a comma separator, and
+/// returns the individual challenge strings.
+fn split_payment_challenges(header: &str) -> Vec<&str> {
+    fn is_valid_start(header: &str, pos: usize) -> bool {
+        pos == 0 || header[..pos].bytes().rfind(|b| !b.is_ascii_whitespace()) == Some(b',')
+    }
+
+    let lower = header.to_ascii_lowercase();
+
+    let starts: Vec<_> = lower
+        .match_indices("payment ")
+        .map(|(pos, _)| pos)
+        .filter(|&pos| is_valid_start(header, pos))
+        .collect();
+
+    starts
+        .iter()
+        .enumerate()
+        .map(|(i, &start)| {
+            let end = starts.get(i + 1).copied().unwrap_or(header.len());
+            header[start..end].trim_end_matches([',', ' '])
+        })
+        .collect()
+}
+
+/// Find the first `tempo` method challenge from one or more WWW-Authenticate
+/// header values.
+///
+/// This is a convenience wrapper around [`parse_www_authenticate_all`] that
+/// filters for `method="tempo"` and returns the first match.
+///
+/// # Examples
+///
+/// ```
+/// use mpp::protocol::core::find_tempo_challenge;
+///
+/// let header = concat!(
+///     r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
+///     r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
+/// );
+/// let challenge = find_tempo_challenge(vec![header]).unwrap();
+/// assert_eq!(challenge.id, "a");
+/// assert_eq!(challenge.method.as_str(), "tempo");
+/// ```
+pub fn find_tempo_challenge<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> Result<PaymentChallenge> {
+    parse_www_authenticate_all(headers)
+        .into_iter()
+        .find(|r| r.as_ref().is_ok_and(|c| c.method.as_str() == "tempo"))
+        .unwrap_or_else(|| {
+            Err(MppError::invalid_challenge_reason(
+                "No Payment challenge with method=\"tempo\" found",
+            ))
+        })
 }
 
 /// Format a PaymentChallenge as a WWW-Authenticate header value.
@@ -878,5 +952,60 @@ mod tests {
         let wire = "eyJtZXRob2QiOiJ0ZW1wbyIsInJlZmVyZW5jZSI6IjB4YWJjIiwic3RhdHVzIjoic3VjY2VzcyIsInRpbWVzdGFtcCI6IkphbiAyOSAyMDI2IDEyOjAwIn0";
         let err = parse_receipt(wire).unwrap_err();
         assert!(err.to_string().contains("timestamp"));
+    }
+
+    #[test]
+    fn test_split_payment_challenges() {
+        // single challenge
+        let single = r#"Payment id="a", realm="r", method="tempo", intent="charge", request="e30""#;
+        assert_eq!(split_payment_challenges(single).len(), 1);
+
+        // two challenges, normal spacing
+        let two = concat!(
+            r#"Payment id="a", realm="r", method="tempo", intent="charge", request="e30", "#,
+            r#"Payment id="b", realm="r", method="stripe", intent="charge", request="e30""#,
+        );
+        let parts = split_payment_challenges(two);
+        assert_eq!(parts.len(), 2);
+        assert!(parts[0].contains(r#"id="a""#));
+        assert!(parts[1].contains(r#"id="b""#));
+
+        // no whitespace after comma, mixed case scheme
+        let compact = concat!(
+            r#"PAYMENT id="a", realm="r", method="tempo", intent="charge", request="e30","#,
+            r#"payment id="b", realm="r", method="stripe", intent="charge", request="e30""#,
+        );
+        assert_eq!(split_payment_challenges(compact).len(), 2);
+
+        // non-Payment scheme is dropped
+        assert!(split_payment_challenges("Bearer token123").is_empty());
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_all_multi_challenge() {
+        let header = concat!(
+            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30", "#,
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#,
+        );
+        let results = parse_www_authenticate_all(vec![header]);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].as_ref().unwrap().method.as_str(), "tempo");
+        assert_eq!(results[1].as_ref().unwrap().method.as_str(), "stripe");
+    }
+
+    #[test]
+    fn test_find_tempo_challenge() {
+        let header = concat!(
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30", "#,
+            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
+        );
+        let c = find_tempo_challenge(vec![header]).unwrap();
+        assert_eq!(c.id, "t1");
+        assert_eq!(c.method.as_str(), "tempo");
+
+        // no tempo challenge → error
+        let other =
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#;
+        assert!(find_tempo_challenge(vec![other]).is_err());
     }
 }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -925,13 +925,13 @@ mod tests {
     #[test]
     fn test_split_payment_challenges() {
         // single challenge
-        let single = r#"Payment id="a", realm="r", method="tempo", intent="charge", request="e30""#;
+        let single = r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30""#;
         assert_eq!(split_payment_challenges(single).len(), 1);
 
         // two challenges, normal spacing
         let two = concat!(
-            r#"Payment id="a", realm="r", method="tempo", intent="charge", request="e30", "#,
-            r#"Payment id="b", realm="r", method="stripe", intent="charge", request="e30""#,
+            r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
+            r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
         );
         let parts = split_payment_challenges(two);
         assert_eq!(parts.len(), 2);
@@ -940,8 +940,8 @@ mod tests {
 
         // no whitespace after comma, mixed case scheme
         let compact = concat!(
-            r#"PAYMENT id="a", realm="r", method="tempo", intent="charge", request="e30","#,
-            r#"payment id="b", realm="r", method="stripe", intent="charge", request="e30""#,
+            r#"PAYMENT id="a", realm="api", method="tempo", intent="charge", request="e30","#,
+            r#"payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
         );
         assert_eq!(split_payment_challenges(compact).len(), 2);
 
@@ -952,8 +952,8 @@ mod tests {
     #[test]
     fn test_parse_www_authenticate_all_multi_challenge() {
         let header = concat!(
-            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30", "#,
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#,
+            r#"Payment id="t1", realm="api", method="tempo", intent="charge", request="e30", "#,
+            r#"Payment id="s1", realm="api", method="stripe", intent="charge", request="e30""#,
         );
         let results = parse_www_authenticate_all(vec![header]);
         assert_eq!(results.len(), 2);
@@ -966,7 +966,7 @@ mod tests {
         // Bearer and other non-Payment schemes should be silently ignored
         let headers = vec![
             "Bearer token123",
-            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
+            r#"Payment id="t1", realm="api", method="tempo", intent="charge", request="e30""#,
             "Basic dXNlcjpwYXNz",
         ];
         let results = parse_www_authenticate_all(headers);
@@ -976,7 +976,7 @@ mod tests {
         // Mixed in a single header value: Bearer prefix followed by Payment challenge
         let mixed = concat!(
             "Bearer token123, ",
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#,
+            r#"Payment id="s1", realm="api", method="stripe", intent="charge", request="e30""#,
         );
         let results = parse_www_authenticate_all(vec![mixed]);
         assert_eq!(results.len(), 1);

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -78,10 +78,10 @@ pub use challenge::{
     PaymentPayload, Receipt,
 };
 pub use headers::{
-    extract_payment_scheme, format_authorization, format_receipt, format_www_authenticate,
-    format_www_authenticate_many, parse_authorization, parse_receipt, parse_www_authenticate,
-    parse_www_authenticate_all, AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME,
-    WWW_AUTHENTICATE_HEADER,
+    extract_payment_scheme, find_tempo_challenge, format_authorization, format_receipt,
+    format_www_authenticate, format_www_authenticate_many, parse_authorization, parse_receipt,
+    parse_www_authenticate, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+    PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
 };
 pub use types::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -85,7 +85,7 @@ pub use headers::{
 };
 
 /// Re-export from [`crate::protocol::methods::tempo`] for backward compatibility.
-#[cfg(any(feature = "server", feature = "tempo"))]
+#[cfg(feature = "tempo")]
 pub use crate::protocol::methods::tempo::find_tempo_challenge;
 pub use types::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -85,6 +85,7 @@ pub use headers::{
 };
 
 /// Re-export from [`crate::protocol::methods::tempo`] for backward compatibility.
+#[cfg(any(feature = "server", feature = "tempo"))]
 pub use crate::protocol::methods::tempo::find_tempo_challenge;
 pub use types::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -78,11 +78,14 @@ pub use challenge::{
     PaymentPayload, Receipt,
 };
 pub use headers::{
-    extract_payment_scheme, find_tempo_challenge, format_authorization, format_receipt,
-    format_www_authenticate, format_www_authenticate_many, parse_authorization, parse_receipt,
-    parse_www_authenticate, parse_www_authenticate_all, AUTHORIZATION_HEADER,
-    PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
+    extract_payment_scheme, format_authorization, format_receipt, format_www_authenticate,
+    format_www_authenticate_many, parse_authorization, parse_receipt, parse_www_authenticate,
+    parse_www_authenticate_all, AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME,
+    WWW_AUTHENTICATE_HEADER,
 };
+
+/// Re-export from [`crate::protocol::methods::tempo`] for backward compatibility.
+pub use crate::protocol::methods::tempo::find_tempo_challenge;
 pub use types::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,
     PaymentProtocol, ReceiptStatus,

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -84,9 +84,6 @@ pub use headers::{
     WWW_AUTHENTICATE_HEADER,
 };
 
-/// Re-export from [`crate::protocol::methods::tempo`] for backward compatibility.
-#[cfg(feature = "tempo")]
-pub use crate::protocol::methods::tempo::find_tempo_challenge;
 pub use types::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,
     PaymentProtocol, ReceiptStatus,

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -172,39 +172,6 @@ pub const DEFAULT_EXPIRES_MINUTES: u64 = 5;
 /// Payment method name for Tempo.
 pub const METHOD_NAME: &str = "tempo";
 
-/// Find the first `tempo` method challenge from one or more WWW-Authenticate
-/// header values.
-///
-/// This is a convenience wrapper around
-/// [`parse_www_authenticate_all`](crate::protocol::core::parse_www_authenticate_all)
-/// that filters for `method="tempo"` and returns the first match.
-///
-/// # Examples
-///
-/// ```
-/// use mpp::protocol::methods::tempo::find_tempo_challenge;
-///
-/// let header = concat!(
-///     r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
-///     r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
-/// );
-/// let challenge = find_tempo_challenge(vec![header]).unwrap();
-/// assert_eq!(challenge.id, "a");
-/// assert_eq!(challenge.method.as_str(), "tempo");
-/// ```
-pub fn find_tempo_challenge<'a>(
-    headers: impl IntoIterator<Item = &'a str>,
-) -> crate::error::Result<crate::protocol::core::PaymentChallenge> {
-    crate::protocol::core::parse_www_authenticate_all(headers)
-        .into_iter()
-        .find(|r| r.as_ref().is_ok_and(|c| c.method.as_str() == "tempo"))
-        .unwrap_or_else(|| {
-            Err(crate::error::MppError::invalid_challenge_reason(
-                "No Payment challenge with method=\"tempo\" found",
-            ))
-        })
-}
-
 /// Charge intent name (re-exported from [`crate::protocol::intents`]).
 pub use crate::protocol::intents::INTENT_CHARGE;
 
@@ -808,21 +775,5 @@ mod tests {
 
             assert_eq!(id, "BdPQxVJ56pvRJnM-r7wh_ppka5hOJH_6XpRK4gM9paI");
         }
-    }
-
-    #[test]
-    fn test_find_tempo_challenge() {
-        let header = concat!(
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30", "#,
-            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
-        );
-        let c = find_tempo_challenge(vec![header]).unwrap();
-        assert_eq!(c.id, "t1");
-        assert_eq!(c.method.as_str(), "tempo");
-
-        // no tempo challenge → error
-        let other =
-            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#;
-        assert!(find_tempo_challenge(vec![other]).is_err());
     }
 }

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -172,6 +172,39 @@ pub const DEFAULT_EXPIRES_MINUTES: u64 = 5;
 /// Payment method name for Tempo.
 pub const METHOD_NAME: &str = "tempo";
 
+/// Find the first `tempo` method challenge from one or more WWW-Authenticate
+/// header values.
+///
+/// This is a convenience wrapper around
+/// [`parse_www_authenticate_all`](crate::protocol::core::parse_www_authenticate_all)
+/// that filters for `method="tempo"` and returns the first match.
+///
+/// # Examples
+///
+/// ```
+/// use mpp::protocol::methods::tempo::find_tempo_challenge;
+///
+/// let header = concat!(
+///     r#"Payment id="a", realm="api", method="tempo", intent="charge", request="e30", "#,
+///     r#"Payment id="b", realm="api", method="stripe", intent="charge", request="e30""#,
+/// );
+/// let challenge = find_tempo_challenge(vec![header]).unwrap();
+/// assert_eq!(challenge.id, "a");
+/// assert_eq!(challenge.method.as_str(), "tempo");
+/// ```
+pub fn find_tempo_challenge<'a>(
+    headers: impl IntoIterator<Item = &'a str>,
+) -> crate::error::Result<crate::protocol::core::PaymentChallenge> {
+    crate::protocol::core::parse_www_authenticate_all(headers)
+        .into_iter()
+        .find(|r| r.as_ref().is_ok_and(|c| c.method.as_str() == "tempo"))
+        .unwrap_or_else(|| {
+            Err(crate::error::MppError::invalid_challenge_reason(
+                "No Payment challenge with method=\"tempo\" found",
+            ))
+        })
+}
+
 /// Charge intent name (re-exported from [`crate::protocol::intents`]).
 pub use crate::protocol::intents::INTENT_CHARGE;
 
@@ -775,5 +808,21 @@ mod tests {
 
             assert_eq!(id, "BdPQxVJ56pvRJnM-r7wh_ppka5hOJH_6XpRK4gM9paI");
         }
+    }
+
+    #[test]
+    fn test_find_tempo_challenge() {
+        let header = concat!(
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30", "#,
+            r#"Payment id="t1", realm="r", method="tempo", intent="charge", request="e30""#,
+        );
+        let c = find_tempo_challenge(vec![header]).unwrap();
+        assert_eq!(c.id, "t1");
+        assert_eq!(c.method.as_str(), "tempo");
+
+        // no tempo challenge → error
+        let other =
+            r#"Payment id="s1", realm="r", method="stripe", intent="charge", request="e30""#;
+        assert!(find_tempo_challenge(vec![other]).is_err());
     }
 }


### PR DESCRIPTION
Client now matches challenges by `provider.supports(method, intent)` instead of assuming a single challenge, mirroring the mppx TypeScript SDK.

**Changes:**
- `split_payment_challenges`: splits a combined header into individual Payment challenge slices
- `parse_www_authenticate_all`: handles both separate headers and combined multi-challenge headers
- Client (`PaymentExt` + `PaymentMiddleware`) iterates all challenges and selects the first one the provider supports
- `HttpError::NoSupportedChallenge` for when no offered challenge matches

Prompted by: georgen