### PR TITLE
fix: downgrade split payments to patch release (0.8.3)

### DIFF
--- a/.changelog/tidy-geese-dance.md
+++ b/.changelog/tidy-geese-dance.md
@@ -1,5 +1,5 @@
 ---
-mpp: minor
+mpp: patch
 ---
 
 Added split payments support to Tempo charge verification and transaction building. Extended `TempoCharge` and `TempoChargeExt` to parse and propagate split recipients from `methodDetails`, and refactored transfer call construction and verification to handle multiple transfers using order-insensitive matching.


### PR DESCRIPTION
Changes the split payments changelog entry from `minor` to `patch` so the next release is **0.8.3** instead of 0.9.0.

Supersedes #186.