### PR TITLE
fix: prevent busy loop in default `wait_for_update` impl

### DIFF
--- a/.changelog/fix-wait-for-update-busy-loop.md
+++ b/.changelog/fix-wait-for-update-busy-loop.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed busy loop in `serve()` caused by default `wait_for_update()` returning immediately instead of pending.

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -88,7 +88,7 @@ pub trait ChannelStore: Send + Sync {
         &self,
         _channel_id: &str,
     ) -> std::pin::Pin<Box<dyn Future<Output = ()> + Send + '_>> {
-        Box::pin(async {})
+        Box::pin(std::future::pending())
     }
 }
 
@@ -2768,5 +2768,54 @@ mod tests {
             "expected token mismatch error, got: {}",
             err.message
         );
+    }
+
+    #[tokio::test]
+    async fn test_default_wait_for_update_does_not_complete_immediately() {
+        use std::time::Duration;
+        // A minimal ChannelStore that only implements required methods,
+        // relying on the default wait_for_update
+        struct PollOnlyStore;
+        impl ChannelStore for PollOnlyStore {
+            fn get_channel(
+                &self,
+                _channel_id: &str,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn Future<Output = Result<Option<ChannelState>, VerificationError>>
+                        + Send
+                        + '_,
+                >,
+            > {
+                unimplemented!()
+            }
+
+            fn update_channel(
+                &self,
+                _channel_id: &str,
+                _updater: Box<
+                    dyn FnOnce(
+                            Option<ChannelState>,
+                        )
+                            -> Result<Option<ChannelState>, VerificationError>
+                        + Send,
+                >,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn Future<Output = Result<Option<ChannelState>, VerificationError>>
+                        + Send
+                        + '_,
+                >,
+            > {
+                unimplemented!()
+            }
+        }
+
+        let store = PollOnlyStore;
+        let result =
+            tokio::time::timeout(Duration::from_millis(50), store.wait_for_update("any")).await;
+
+        // Should timeout. The default must not return immediately
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
The default `wait_for_update()` on `ChannelStore` returns immediately (`Box::pin(async {})`), which causes the `tokio::select!` in `serve()` to never hit the sleep branch, resulting in a busy loop instead of 100ms polling.

This PR fixes this by changing the default to `std::future::pending()`, which never completes, so the sleep branch always wins the `select!`.

Closes issue #193