### PR TITLE
perf: use eth_sendRawTransactionSync instead of polling for receipt

### DIFF
--- a/.changelog/send-raw-transaction-sync.md
+++ b/.changelog/send-raw-transaction-sync.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Use `eth_sendRawTransactionSync` (EIP-7966) instead of `eth_sendRawTransaction` + polling for receipt. The Tempo node returns the full receipt in a single blocking call, eliminating the client-side polling loop and reducing broadcast latency from 0.5–7.5s to ~500ms.

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -812,9 +812,7 @@ where
             .provider
             .raw_request("eth_sendRawTransactionSync".into(), [raw_hex])
             .await
-            .map_err(|e| {
-                VerificationError::network_error(format!("Failed to broadcast: {}", e))
-            })?;
+            .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
 
         if !receipt.status() {
             return Err(VerificationError::transaction_failed(format!(

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -803,16 +803,18 @@ where
                 .map_err(|e| VerificationError::new(format!("Failed to record tx: {e}")))?;
         }
 
-        let pending = self
+        // Use eth_sendRawTransactionSync (EIP-7966) for single-call broadcast +
+        // receipt. The Tempo node holds the connection open until the transaction
+        // is mined/pre-confirmed and returns the full receipt, avoiding the
+        // client-side polling loop of send_raw_transaction + get_receipt.
+        let raw_hex = format!("0x{}", alloy::primitives::hex::encode(&final_tx_bytes));
+        let receipt: <TempoNetwork as alloy::network::Network>::ReceiptResponse = self
             .provider
-            .send_raw_transaction(&final_tx_bytes)
+            .raw_request("eth_sendRawTransactionSync".into(), [raw_hex])
             .await
-            .map_err(|e| VerificationError::network_error(format!("Failed to broadcast: {}", e)))?;
-
-        // Wait for transaction to be mined
-        let receipt = pending.get_receipt().await.map_err(|e| {
-            VerificationError::network_error(format!("Failed to get receipt: {}", e))
-        })?;
+            .map_err(|e| {
+                VerificationError::network_error(format!("Failed to broadcast: {}", e))
+            })?;
 
         if !receipt.status() {
             return Err(VerificationError::transaction_failed(format!(


### PR DESCRIPTION
## Problem

`broadcast_transaction()` uses a two-step flow:
1. `eth_sendRawTransaction` → returns tx hash immediately
2. `pending.get_receipt().await` → alloy polls `eth_getTransactionReceipt` in a loop until mined

Relevant mppx code: [`src/tempo/server/Charge.ts`](https://github.com/wevm/mppx/blob/main/src/tempo/server/Charge.ts) — `sendRawTransactionSync(client, { serializedTransaction })`