### PR TITLE
ci: check examples through a Cargo workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       - run: cargo hack check --each-feature --no-dev-deps --skip integration
       - name: Check examples
-        run: find examples -name Cargo.toml -exec cargo check --manifest-path {} \;
+        run: cargo check --workspace --exclude mpp
 
   ci-gate:
     name: CI Gate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,19 @@ readme = "README.md"
 keywords = ["http", "payments", "402", "authentication"]
 categories = ["web-programming", "authentication", "cryptography"]
 
+[workspace]
+members = [
+  ".",
+  "examples/axum-extractor",
+  "examples/basic",
+  "examples/session/multi-fetch",
+  "examples/session/sse",
+  "examples/stripe",
+]
+default-members = ["."]
+exclude = ["fuzz"]
+resolver = "2"
+
 [features]
 default = ["reqwest-default-tls"]
 

--- a/examples/axum-extractor/src/client.rs
+++ b/examples/axum-extractor/src/client.rs
@@ -35,21 +35,20 @@ async fn main() {
         }
     };
 
-    let rpc_url = std::env::var("RPC_URL")
-        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+    let rpc_url =
+        std::env::var("RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
 
     // Fund via testnet faucet.
     println!("Funding account via faucet...");
-    let rpc_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(rpc_url.parse().unwrap());
+    let rpc_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url.parse().unwrap());
     let _: Vec<B256> = rpc_provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await
         .expect("faucet funding failed");
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-    let provider =
-        TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
+    let provider = TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
 
     let base_url =
         std::env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -14,9 +14,9 @@
 //!
 //! The server listens on `http://localhost:3000`.
 
-use axum::{routing::get, Json, Router};
 use alloy::primitives::B256;
 use alloy::providers::{Provider, ProviderBuilder};
+use axum::{routing::get, Json, Router};
 use mpp::server::axum::{ChargeChallenger, ChargeConfig, MppCharge, WithReceipt};
 use mpp::server::{tempo, Mpp, TempoConfig};
 use mpp::PrivateKeySigner;
@@ -70,12 +70,12 @@ async fn main() {
     let recipient = format!("{}", signer.address());
     println!("Server recipient: {recipient}");
 
-    let rpc_url = std::env::var("RPC_URL")
-        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+    let rpc_url =
+        std::env::var("RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
 
     // Fund the server account via testnet faucet.
-    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(rpc_url.parse().unwrap());
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url.parse().unwrap());
     let _: Vec<B256> = provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await
@@ -126,9 +126,7 @@ async fn fortune(charge: MppCharge<OneCent>) -> WithReceipt<Json<serde_json::Val
     }
 }
 
-async fn premium_fortune(
-    charge: MppCharge<OneDollar>,
-) -> WithReceipt<Json<serde_json::Value>> {
+async fn premium_fortune(charge: MppCharge<OneDollar>) -> WithReceipt<Json<serde_json::Value>> {
     let fortune = PREMIUM_FORTUNES
         .choose(&mut rand::rng())
         .unwrap_or(&"The stars are silent.");

--- a/examples/basic/src/client.rs
+++ b/examples/basic/src/client.rs
@@ -42,13 +42,13 @@ async fn main() {
         }
     };
 
-    let rpc_url = std::env::var("RPC_URL")
-        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+    let rpc_url =
+        std::env::var("RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
 
     // Fund the client account via testnet faucet.
     println!("Funding account via faucet...");
-    let rpc_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(rpc_url.parse().unwrap());
+    let rpc_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url.parse().unwrap());
     let _: Vec<B256> = rpc_provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await
@@ -56,8 +56,7 @@ async fn main() {
     // Wait briefly for faucet transactions to confirm.
     tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
-    let provider =
-        TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
+    let provider = TempoProvider::new(signer, &rpc_url).expect("failed to create payment provider");
 
     let args: Vec<String> = std::env::args().skip(1).collect();
 
@@ -100,7 +99,10 @@ async fn main() {
     if let Some(receipt_hdr) = resp.headers().get("payment-receipt") {
         if let Ok(receipt_str) = receipt_hdr.to_str() {
             if let Ok(receipt) = parse_receipt(receipt_str) {
-                println!("Payment tx: https://explore.moderato.tempo.xyz/tx/{}", receipt.reference);
+                println!(
+                    "Payment tx: https://explore.moderato.tempo.xyz/tx/{}",
+                    receipt.reference
+                );
             }
         }
     }

--- a/examples/basic/src/server.rs
+++ b/examples/basic/src/server.rs
@@ -13,6 +13,8 @@
 //!
 //! The server listens on `http://localhost:3000`.
 
+use alloy::primitives::B256;
+use alloy::providers::{Provider, ProviderBuilder};
 use axum::{
     extract::State,
     http::{header, HeaderMap, StatusCode},
@@ -20,8 +22,6 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use alloy::primitives::B256;
-use alloy::providers::{Provider, ProviderBuilder};
 use mpp::server::{tempo, Mpp, TempoChargeMethod, TempoConfig};
 use mpp::{format_www_authenticate, parse_authorization, PrivateKeySigner};
 use rand::seq::IndexedRandom;
@@ -49,12 +49,12 @@ async fn main() {
     let recipient = format!("{}", signer.address());
     println!("Server recipient: {recipient}");
 
-    let rpc_url = std::env::var("RPC_URL")
-        .unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+    let rpc_url =
+        std::env::var("RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
 
     // Fund the server account via testnet faucet.
-    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(rpc_url.parse().unwrap());
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url.parse().unwrap());
     let _: Vec<B256> = provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await
@@ -96,10 +96,7 @@ async fn health() -> impl IntoResponse {
     Json(serde_json::json!({ "status": "ok" }))
 }
 
-async fn ping(
-    State(payment): State<Arc<Payment>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+async fn ping(State(payment): State<Arc<Payment>>, headers: HeaderMap) -> impl IntoResponse {
     if let Some(auth) = headers.get(header::AUTHORIZATION) {
         if let Ok(auth_str) = auth.to_str() {
             if let Ok(credential) = parse_authorization(auth_str) {
@@ -144,10 +141,7 @@ async fn ping(
     }
 }
 
-async fn fortune(
-    State(payment): State<Arc<Payment>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+async fn fortune(State(payment): State<Arc<Payment>>, headers: HeaderMap) -> impl IntoResponse {
     // Check for payment credential in Authorization header
     if let Some(auth) = headers.get(header::AUTHORIZATION) {
         if let Ok(auth_str) = auth.to_str() {

--- a/examples/session/multi-fetch/src/client.rs
+++ b/examples/session/multi-fetch/src/client.rs
@@ -51,8 +51,8 @@ async fn main() {
 
     // Fund the client account via testnet faucet.
     println!("Funding account via faucet...");
-    let faucet_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(RPC_URL.parse().unwrap());
+    let faucet_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(RPC_URL.parse().unwrap());
     let _: Vec<B256> = faucet_provider
         .raw_request("tempo_fundAddress".into(), (signer_address,))
         .await
@@ -94,23 +94,29 @@ async fn main() {
         let url = format!("https://example.com/page/{i}");
         let request_url = format!("{base_url}/api/scrape?url={}", urlencoding(&url));
 
-        let response = client
-            .get(&request_url)
-            .send_with_payment(&session)
-            .await;
+        let response = client.get(&request_url).send_with_payment(&session).await;
 
         match response {
             Ok(resp) => {
                 if !resp.status().is_success() {
-                    eprintln!("Error: {} — {}", resp.status(), resp.text().await.unwrap_or_default());
+                    eprintln!(
+                        "Error: {} — {}",
+                        resp.status(),
+                        resp.text().await.unwrap_or_default()
+                    );
                     return;
                 }
                 if i == 1 {
-                    if let Some(r) = resp.headers().get("payment-receipt")
+                    if let Some(r) = resp
+                        .headers()
+                        .get("payment-receipt")
                         .and_then(|h| h.to_str().ok())
                         .and_then(|s| parse_receipt(s).ok())
                     {
-                        println!("  Open channel tx: https://explore.moderato.tempo.xyz/tx/{}", r.reference);
+                        println!(
+                            "  Open channel tx: https://explore.moderato.tempo.xyz/tx/{}",
+                            r.reference
+                        );
                     }
                 }
                 let _body: serde_json::Value = resp.json().await.unwrap_or_default();
@@ -134,7 +140,10 @@ async fn main() {
     let close_url = format!("{base_url}/api/scrape");
     match session.close(&client, &close_url).await {
         Ok(Some(receipt)) => {
-            println!("  Channel settled: https://explore.moderato.tempo.xyz/tx/{}", receipt.reference);
+            println!(
+                "  Channel settled: https://explore.moderato.tempo.xyz/tx/{}",
+                receipt.reference
+            );
         }
         Ok(None) => {
             println!("  No active channel to close");
@@ -149,8 +158,10 @@ async fn main() {
 
     let balance_after = erc20.balanceOf(signer_address).call().await.unwrap();
     let balance_after_f64 = balance_after.to::<u128>() as f64 / 1e6;
-    let total_spent =
-        balance_before.to::<u128>().saturating_sub(balance_after.to::<u128>()) as f64 / 1e6;
+    let total_spent = balance_before
+        .to::<u128>()
+        .saturating_sub(balance_after.to::<u128>()) as f64
+        / 1e6;
     println!("\n--- Summary ---");
     println!("  Pages scraped:   {PAGE_COUNT}");
     println!("  Voucher total:   {cumulative:.2} pathUSD");

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -9,6 +9,8 @@
 //! cargo run --bin session-server
 //! ```
 
+use alloy::primitives::B256;
+use alloy::providers::{Provider, ProviderBuilder};
 use axum::{
     extract::{Query, State},
     http::{header, HeaderMap, StatusCode},
@@ -16,12 +18,10 @@ use axum::{
     routing::get,
     Router,
 };
-use alloy::primitives::B256;
-use alloy::providers::{Provider, ProviderBuilder};
 use mpp::client::channel_ops::default_escrow_contract;
 use mpp::server::{
-    Mpp, SessionChallengeOptions, SessionChannelStore, SessionMethodConfig,
-    TempoChargeMethod, TempoSessionMethod, tempo, TempoConfig,
+    tempo, Mpp, SessionChallengeOptions, SessionChannelStore, SessionMethodConfig,
+    TempoChargeMethod, TempoConfig, TempoSessionMethod,
 };
 use mpp::{parse_authorization, PaymentCredential, PrivateKeySigner};
 use std::sync::Arc;
@@ -50,8 +50,8 @@ async fn main() {
     println!("Server recipient: {recipient}");
 
     // Fund the server account via testnet faucet.
-    let faucet_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(RPC_URL.parse().unwrap());
+    let faucet_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(RPC_URL.parse().unwrap());
     let _: Vec<B256> = faucet_provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await

--- a/examples/session/sse/src/client.rs
+++ b/examples/session/sse/src/client.rs
@@ -48,8 +48,8 @@ async fn main() {
 
     // Fund the client account via testnet faucet.
     println!("Funding account via faucet...");
-    let faucet_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(RPC_URL.parse().unwrap());
+    let faucet_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(RPC_URL.parse().unwrap());
     let _: Vec<B256> = faucet_provider
         .raw_request("tempo_fundAddress".into(), (signer_address,))
         .await
@@ -67,7 +67,10 @@ async fn main() {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         balance_before = erc20.balanceOf(signer_address).call().await.unwrap();
     }
-    println!("Balance: {} pathUSD", balance_before.to::<u128>() as f64 / 1e6);
+    println!(
+        "Balance: {} pathUSD",
+        balance_before.to::<u128>() as f64 / 1e6
+    );
 
     // Create a session provider with max deposit of 1 pathUSD (1_000_000 base units).
     let provider = TempoSessionProvider::new(signer, RPC_URL)
@@ -109,11 +112,16 @@ async fn main() {
         }
     };
 
-    if let Some(r) = open_resp.headers().get("payment-receipt")
+    if let Some(r) = open_resp
+        .headers()
+        .get("payment-receipt")
         .and_then(|h| h.to_str().ok())
         .and_then(|s| parse_receipt(s).ok())
     {
-        println!("Open channel tx: https://explore.moderato.tempo.xyz/tx/{}", r.reference);
+        println!(
+            "Open channel tx: https://explore.moderato.tempo.xyz/tx/{}",
+            r.reference
+        );
     }
     let open_status = open_resp.status();
     if !open_status.is_success() {
@@ -204,7 +212,10 @@ async fn main() {
     let close_url = format!("{}/api/chat", base_url);
     match provider.close(&client, &close_url).await {
         Ok(Some(receipt)) => {
-            println!("  Channel settled: https://explore.moderato.tempo.xyz/tx/{}", receipt.reference);
+            println!(
+                "  Channel settled: https://explore.moderato.tempo.xyz/tx/{}",
+                receipt.reference
+            );
         }
         Ok(None) => {
             println!("  Close sent (no receipt returned)");
@@ -220,8 +231,10 @@ async fn main() {
     let balance_after = erc20.balanceOf(signer_address).call().await.unwrap();
     let balance_before_f64 = balance_before.to::<u128>() as f64 / 1e6;
     let balance_after_f64 = balance_after.to::<u128>() as f64 / 1e6;
-    let total_spent =
-        balance_before.to::<u128>().saturating_sub(balance_after.to::<u128>()) as f64 / 1e6;
+    let total_spent = balance_before
+        .to::<u128>()
+        .saturating_sub(balance_after.to::<u128>()) as f64
+        / 1e6;
     println!("\n--- Summary ---");
     println!("  Tokens streamed: {token_count}");
     println!("  Voucher total:   {cumulative:.6} pathUSD");

--- a/examples/session/sse/src/server.rs
+++ b/examples/session/sse/src/server.rs
@@ -9,6 +9,8 @@
 //! cargo run --bin sse-server
 //! ```
 
+use alloy::primitives::B256;
+use alloy::providers::{Provider, ProviderBuilder};
 use axum::{
     body::Body,
     extract::{Query, State},
@@ -18,13 +20,11 @@ use axum::{
     Router,
 };
 use futures::stream;
-use mpp::server::{
-    Mpp, SessionChannelStore, SessionChallengeOptions, TempoChargeMethod, TempoSessionMethod,
-    tempo, TempoConfig, SessionMethodConfig,
-};
-use alloy::primitives::B256;
-use alloy::providers::{Provider, ProviderBuilder};
 use mpp::client::channel_ops::default_escrow_contract;
+use mpp::server::{
+    tempo, Mpp, SessionChallengeOptions, SessionChannelStore, SessionMethodConfig,
+    TempoChargeMethod, TempoConfig, TempoSessionMethod,
+};
 use mpp::{parse_authorization, PaymentCredential, PrivateKeySigner};
 use serde::Deserialize;
 use std::sync::Arc;
@@ -63,8 +63,8 @@ async fn main() {
     println!("Server recipient: {}", recipient);
 
     // Fund the server account via testnet faucet.
-    let faucet_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .connect_http(RPC_URL.parse().unwrap());
+    let faucet_provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(RPC_URL.parse().unwrap());
     let _: Vec<B256> = faucet_provider
         .raw_request("tempo_fundAddress".into(), (signer.address(),))
         .await
@@ -159,23 +159,22 @@ async fn chat(
         Ok(r) => r,
         Err(e) => {
             eprintln!("[server] session verification failed: {}", e);
-            return (StatusCode::BAD_REQUEST, format!("Verification failed: {}", e))
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Verification failed: {}", e),
+            )
                 .into_response();
         }
     };
 
     // If management response (open/close/topUp), return it directly.
     if let Some(mgmt) = result.management_response {
-        let receipt_header = result
-            .receipt
-            .to_header()
-            .unwrap_or_else(|_| String::new());
+        let receipt_header = result.receipt.to_header().unwrap_or_else(|_| String::new());
         let body = serde_json::to_string(&mgmt).unwrap_or_else(|_| "{}".to_string());
         let mut response = (StatusCode::OK, body).into_response();
-        response.headers_mut().insert(
-            header::CONTENT_TYPE,
-            "application/json".parse().unwrap(),
-        );
+        response
+            .headers_mut()
+            .insert(header::CONTENT_TYPE, "application/json".parse().unwrap());
         response.headers_mut().insert(
             axum::http::HeaderName::from_static("payment-receipt"),
             axum::http::HeaderValue::from_str(&receipt_header).unwrap(),

--- a/examples/stripe/src/server.rs
+++ b/examples/stripe/src/server.rs
@@ -51,8 +51,7 @@ struct AppState {
 async fn main() {
     let secret_key =
         std::env::var("STRIPE_SECRET_KEY").expect("STRIPE_SECRET_KEY env var required");
-    let network_id =
-        std::env::var("STRIPE_NETWORK_ID").unwrap_or_else(|_| "internal".to_string());
+    let network_id = std::env::var("STRIPE_NETWORK_ID").unwrap_or_else(|_| "internal".to_string());
 
     let payment = Mpp::create_stripe(
         stripe(StripeConfig {
@@ -109,8 +108,10 @@ async fn create_spt(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateSptRequest>,
 ) -> impl IntoResponse {
-    let auth_value =
-        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, format!("{}:", state.stripe_secret_key));
+    let auth_value = base64::Engine::encode(
+        &base64::engine::general_purpose::STANDARD,
+        format!("{}:", state.stripe_secret_key),
+    );
 
     let params = [
         ("payment_method", body.payment_method),
@@ -151,10 +152,7 @@ async fn create_spt(
     }
 }
 
-async fn fortune(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+async fn fortune(State(state): State<Arc<AppState>>, headers: HeaderMap) -> impl IntoResponse {
     // Check for payment credential in Authorization header
     if let Some(auth) = headers.get(header::AUTHORIZATION) {
         if let Ok(auth_str) = auth.to_str() {


### PR DESCRIPTION
## Summary
- add the example crates to a root Cargo workspace
- keep `mpp` as the default workspace member so plain root Cargo commands behave the same
- switch CI example checking from per-manifest `cargo check` calls to a single workspace-aware invocation

## Why
`Check examples` was slow because CI was checking each example as an isolated Cargo project, which re-resolved and recompiled the same Tempo/Alloy dependency graph several times. A workspace lets Cargo share that work across the example crates.