### PR TITLE
chore: supply chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.96
       - name: Check changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features -- -D warnings
+      - name: cargo deny
+        uses: EmbarkStudios/cargo-deny-action@44db170f6a7d12a6e90340e9e0fca1f650d34b14 # v2.0.15
+        with:
+          command: check advisories sources bans licenses
       - name: Run Tempo Lints
         uses: tempoxyz/lints@8af5001866a36967523ece2b8cdc33ba719aad84 # main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features -- -D warnings
@@ -59,8 +60,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - run: cargo update -p native-tls
       - uses: taiki-e/install-action@dffee21ba64c128096855f01c56682d6f8a2bd29 # cargo-hack
       - name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,6 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --all-features -- -D warnings
-      - name: cargo deny
-        uses: EmbarkStudios/cargo-deny-action@44db170f6a7d12a6e90340e9e0fca1f650d34b14 # v2.0.15
-        with:
-          command: check advisories sources bans licenses
       - name: Run Tempo Lints
         uses: tempoxyz/lints@8af5001866a36967523ece2b8cdc33ba719aad84 # main
         with:
@@ -77,10 +73,15 @@ jobs:
       - name: Check examples
         run: find examples -name Cargo.toml -exec cargo check --manifest-path {} \;
 
+  deny:
+    uses: tempoxyz/ci/.github/workflows/deny.yml@main
+    permissions:
+      contents: read
+
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [lint, test]
+    needs: [lint, test, deny]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - name: Build docs
         run: cargo doc --no-deps --all-features
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Changelogs
         uses: tempoxyz/changelogs@04ccca87f4785039ced6da0fff27ba29c0dd9f5c # master

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -20,8 +20,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
       - run: cargo update -p native-tls
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/deny.toml
+++ b/deny.toml
@@ -1,16 +1,76 @@
-[graph]
-all-features = true
-
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"
+ignore = [
+    # https://rustsec.org/advisories/RUSTSEC-2024-0388 derivative is unmaintained (transitive dep)
+    "RUSTSEC-2024-0388",
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained (transitive dep)
+    "RUSTSEC-2024-0436",
+]
 
-[sources]
-unknown-registry = "deny"
-unknown-git = "deny"
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
-
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
+# Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
 wildcards = "deny"
+highlight = "all"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = []
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.8
+
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.7 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "MIT-0",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "0BSD",
+    "CC0-1.0",
+    "ISC",
+    "Unlicense",
+    "Unicode-3.0",
+    "Zlib",
+    # https://github.com/rustls/webpki/blob/main/LICENSE ISC Style
+    "LicenseRef-rustls-webpki",
+    "CDLA-Permissive-2.0",
+    "OpenSSL",
+]
+
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = []
+
+[[licenses.clarify]]
+name = "rustls-webpki"
+expression = "LicenseRef-rustls-webpki"
+license-files = [{ path = "LICENSE", hash = 0x001c7e6c }]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,16 @@
+[graph]
+all-features = true
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"


### PR DESCRIPTION
Follow-up to [#197](https://github.com/tempoxyz/mpp-rs/pull/197).

- Update `Swatinem/rust-cache` pin to v2.9.1
- Add `persist-credentials: false` to all `actions/checkout` steps
- Add `deny.toml` with advisory, ban, license, and source policies (aligned with reth/tempo conventions)
- Add `cargo deny` CI job via shared `tempoxyz/ci` reusable workflow
- Add Dependabot cooldown (7 days)

Prompted by: georgen