### PR TITLE
fix: zero-amount proof source DID uses wrong address in keychain mode

### DIFF
--- a/.changelog/fix-keychain-source-did.md
+++ b/.changelog/fix-keychain-source-did.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed `credential.source` DID mismatch between $0 proofs and paid charges in Keychain signing mode. The proof path now uses the wallet address (matching mppx and the paid charge path). Server-side `verify_proof` falls back to an on-chain keychain lookup when the recovered signer differs from the source address.

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -292,15 +292,11 @@ mod tests {
         );
     }
 
-    /// Regression test: zero-amount proof source DID must use the wallet
-    /// address in Keychain mode, not the raw access key address.
-    ///
-    /// Previously the proof path always used `signer.address()`, causing the
-    /// source DID to differ between $0 proofs (access key) and paid charges
-    /// (wallet). Servers that link identity via the source DID during a $0
-    /// proof would then fail to recognize the same user on a paid request.
+    /// Regression: in Keychain mode, the proof source DID must use the wallet
+    /// address (matching mppx and the paid charge path), not the access key.
+    /// Server-side verify_proof handles keychain keys via on-chain lookup.
     #[tokio::test]
-    async fn test_zero_amount_proof_uses_wallet_address_in_keychain_mode() {
+    async fn test_keychain_proof_source_uses_wallet_address() {
         use crate::client::tempo::signing::KeychainVersion;
         use crate::protocol::core::Base64UrlJson;
 
@@ -335,11 +331,11 @@ mod tests {
 
         let credential = provider.pay(&challenge).await.unwrap();
 
-        // Source DID must use the wallet address, NOT the access key address
+        // Source DID must use the wallet address, NOT the access key address.
         let expected_did = PaymentCredential::evm_did(42431, &wallet_address.to_string());
         assert_eq!(credential.source, Some(expected_did));
 
-        // Sanity: the wallet address is NOT the access key address
+        // Sanity: wallet and access key are different addresses.
         assert_ne!(wallet_address, access_key.address());
     }
 

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -130,8 +130,8 @@ impl PaymentProvider for TempoProvider {
 
         if charge.amount().is_zero() {
             let signature = sign_proof(&self.signer, charge.chain_id(), &challenge.id).await?;
-            let source =
-                PaymentCredential::evm_did(charge.chain_id(), &self.signer.address().to_string());
+            let from = self.signing_mode.from_address(self.signer.address());
+            let source = PaymentCredential::evm_did(charge.chain_id(), &from.to_string());
 
             return Ok(PaymentCredential::with_source(
                 challenge.to_echo(),
@@ -290,6 +290,57 @@ mod tests {
                 &signer.address().to_string()
             ))
         );
+    }
+
+    /// Regression test: zero-amount proof source DID must use the wallet
+    /// address in Keychain mode, not the raw access key address.
+    ///
+    /// Previously the proof path always used `signer.address()`, causing the
+    /// source DID to differ between $0 proofs (access key) and paid charges
+    /// (wallet). Servers that link identity via the source DID during a $0
+    /// proof would then fail to recognize the same user on a paid request.
+    #[tokio::test]
+    async fn test_zero_amount_proof_uses_wallet_address_in_keychain_mode() {
+        use crate::client::tempo::signing::KeychainVersion;
+        use crate::protocol::core::Base64UrlJson;
+
+        let access_key = alloy::signers::local::PrivateKeySigner::random();
+        let wallet_address: alloy::primitives::Address =
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+                .parse()
+                .unwrap();
+
+        let provider = TempoProvider::new(access_key.clone(), "https://rpc.example.com")
+            .unwrap()
+            .with_signing_mode(TempoSigningMode::Keychain {
+                wallet: wallet_address,
+                key_authorization: None,
+                version: KeychainVersion::V2,
+            });
+
+        let request = Base64UrlJson::from_value(&serde_json::json!({
+            "amount": "0",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": { "chainId": 42431 }
+        }))
+        .unwrap();
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+        );
+
+        let credential = provider.pay(&challenge).await.unwrap();
+
+        // Source DID must use the wallet address, NOT the access key address
+        let expected_did = PaymentCredential::evm_did(42431, &wallet_address.to_string());
+        assert_eq!(credential.source, Some(expected_did));
+
+        // Sanity: the wallet address is NOT the access key address
+        assert_ne!(wallet_address, access_key.address());
     }
 
     #[test]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -29,7 +29,9 @@ use alloy::providers::Provider;
 use alloy::sol_types::SolCall;
 use std::future::Future;
 use std::sync::Arc;
-use tempo_alloy::contracts::precompiles::{IStablecoinDEX, ITIP20, STABLECOIN_DEX_ADDRESS};
+use tempo_alloy::contracts::precompiles::{
+    IAccountKeychain, IStablecoinDEX, ACCOUNT_KEYCHAIN_ADDRESS, ITIP20, STABLECOIN_DEX_ADDRESS,
+};
 use tempo_alloy::TempoNetwork;
 use tokio::sync::OnceCell;
 
@@ -1066,15 +1068,43 @@ where
                     ));
                 }
 
+                let sig_hex = charge_payload.proof_signature().unwrap();
+
+                // Fast path: signer IS the source address (Direct mode).
                 if !proof::verify_proof(
                     expected_chain_id,
                     &credential.challenge.id,
-                    charge_payload.proof_signature().unwrap(),
+                    sig_hex,
                     parsed_source.address,
                 ) {
-                    return Err(VerificationError::new(
-                        "Proof signature does not match source.",
-                    ));
+                    // Keychain fallback: signer may be an access key authorized
+                    // for the source wallet. Recover the signer and check on-chain.
+                    let recovered = proof::recover_proof_signer(
+                        expected_chain_id,
+                        &credential.challenge.id,
+                        sig_hex,
+                    )
+                    .map_err(|_| {
+                        VerificationError::new("Proof signature does not match source.")
+                    })?;
+
+                    let keychain = IAccountKeychain::new(ACCOUNT_KEYCHAIN_ADDRESS, &*this.provider);
+                    let key_info = keychain
+                        .getKey(parsed_source.address, recovered)
+                        .call()
+                        .await
+                        .map_err(|_| {
+                            VerificationError::new("Proof signature does not match source.")
+                        })?;
+                    let now_secs = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    if key_info.expiry == 0 || key_info.isRevoked || key_info.expiry <= now_secs {
+                        return Err(VerificationError::new(
+                            "Proof signature does not match source.",
+                        ));
+                    }
                 }
 
                 Ok(Receipt::success(METHOD_NAME, &credential.challenge.id))

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -116,6 +116,25 @@ pub fn verify_proof(
     }
 }
 
+/// Recover the signer address from a zero-amount charge proof.
+///
+/// Returns `Ok(address)` on success, or `Err` if the signature is malformed.
+#[cfg(feature = "evm")]
+pub fn recover_proof_signer(
+    chain_id: u64,
+    challenge_id: &str,
+    signature_hex: &str,
+) -> Result<Address, crate::error::MppError> {
+    let signature_bytes: alloy::primitives::Bytes = signature_hex
+        .parse()
+        .map_err(|_| crate::error::MppError::invalid_payload("invalid proof signature hex"))?;
+    let signature = alloy::signers::Signature::try_from(signature_bytes.as_ref())
+        .map_err(|_| crate::error::MppError::invalid_payload("invalid proof signature"))?;
+    signature
+        .recover_address_from_prehash(&signing_hash(chain_id, challenge_id))
+        .map_err(|_| crate::error::MppError::invalid_payload("proof signature recovery failed"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1499,13 +1499,12 @@ async fn test_fee_payer_allows_client_without_gas_buffer() {
 }
 
 /// Regression: when using Keychain signing mode (access key acting on behalf of
-/// a wallet), the `credential.source` DID must be the same wallet address for
-/// both $0 identity proofs and paid charges.
+/// a wallet), the `credential.source` DID must use the wallet address for both
+/// $0 identity proofs and paid charges (matching mppx behavior).
 ///
-/// Previously the zero-amount proof path used the raw access key address while
-/// paid charges correctly used the wallet address, causing servers that link
-/// user identity via the source DID to see two different "users" for the same
-/// wallet.
+/// Previously the proof path used the access key address while the paid charge
+/// path used the wallet address, causing servers that link user identity via the
+/// source DID to see two different "users" for the same wallet.
 #[tokio::test]
 async fn test_keychain_source_did_consistent_across_proof_and_paid() {
     use mpp::client::tempo::signing::{KeychainVersion, TempoSigningMode};
@@ -1600,11 +1599,12 @@ async fn test_keychain_source_did_consistent_across_proof_and_paid() {
          proof={identity_source}, paid={paid_source}"
     );
 
-    // Both must use the wallet address, not the access key address.
+    // Both must use the wallet address, matching mppx behavior.
+    // Server-side verify_proof handles keychain keys via on-chain lookup.
     let expected_did = format!("did:pkh:eip155:{}:{}", chain_id, wallet_signer.address());
     assert_eq!(
         identity_source, expected_did,
-        "source DID should use the wallet address, not the access key address"
+        "source DID should use the wallet address"
     );
 
     // Sanity: the wallet and access key addresses are different.

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1498,6 +1498,122 @@ async fn test_fee_payer_allows_client_without_gas_buffer() {
     let _ = handle.await;
 }
 
+/// Regression: when using Keychain signing mode (access key acting on behalf of
+/// a wallet), the `credential.source` DID must be the same wallet address for
+/// both $0 identity proofs and paid charges.
+///
+/// Previously the zero-amount proof path used the raw access key address while
+/// paid charges correctly used the wallet address, causing servers that link
+/// user identity via the source DID to see two different "users" for the same
+/// wallet.
+#[tokio::test]
+async fn test_keychain_source_did_consistent_across_proof_and_paid() {
+    use mpp::client::tempo::signing::{KeychainVersion, TempoSigningMode};
+
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let wallet_signer = PrivateKeySigner::random();
+    let access_key_signer = PrivateKeySigner::random();
+
+    // Fund the wallet address (access key signs on its behalf).
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, wallet_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("keychain-did-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(access_key_signer.clone(), &rpc)
+        .expect("failed to create TempoProvider")
+        .with_signing_mode(TempoSigningMode::Keychain {
+            wallet: wallet_signer.address(),
+            key_authorization: None,
+            version: KeychainVersion::V2,
+        });
+
+    // ---- $0 identity proof ----
+    let identity_resp = Client::new()
+        .get(format!("{url}/identity"))
+        .send()
+        .await
+        .expect("identity request failed");
+    assert_eq!(identity_resp.status(), 402);
+
+    let www_auth = identity_resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let identity_challenge =
+        mpp::parse_www_authenticate(www_auth).expect("failed to parse identity challenge");
+
+    let identity_credential = provider
+        .pay(&identity_challenge)
+        .await
+        .expect("failed to create proof credential");
+    let identity_source = identity_credential
+        .source
+        .as_deref()
+        .expect("proof credential must have a source DID");
+
+    // ---- Paid charge ----
+    let paid_resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send()
+        .await
+        .expect("paid request failed");
+    assert_eq!(paid_resp.status(), 402);
+
+    let www_auth = paid_resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let paid_challenge =
+        mpp::parse_www_authenticate(www_auth).expect("failed to parse paid challenge");
+
+    let paid_credential = provider
+        .pay(&paid_challenge)
+        .await
+        .expect("failed to create paid credential");
+    let paid_source = paid_credential
+        .source
+        .as_deref()
+        .expect("paid credential must have a source DID");
+
+    // ---- Core assertion: source DIDs must match ----
+    assert_eq!(
+        identity_source, paid_source,
+        "source DID mismatch between $0 proof and paid charge: \
+         proof={identity_source}, paid={paid_source}"
+    );
+
+    // Both must use the wallet address, not the access key address.
+    let expected_did = format!("did:pkh:eip155:{}:{}", chain_id, wallet_signer.address());
+    assert_eq!(
+        identity_source, expected_did,
+        "source DID should use the wallet address, not the access key address"
+    );
+
+    // Sanity: the wallet and access key addresses are different.
+    assert_ne!(wallet_signer.address(), access_key_signer.address());
+
+    handle.abort();
+    let _ = handle.await;
+}
+
 /// Fee-payer-enabled server handles premium ($1) charges correctly.
 #[tokio::test]
 async fn test_e2e_fee_payer_premium_charge() {


### PR DESCRIPTION
In Keychain signing mode, the proof path used the access key address for `credential.source` while paid charges used the wallet address. Servers linking identity via the source DID saw different users for the same wallet.

**Fix (client):** proof source DID now uses the wallet address via `signing_mode.from_address()`, matching mppx and the paid charge path.

**Fix (server):** `verify_proof` now falls back to an on-chain keychain lookup when the recovered signer differs from the source address, validating that the signer is an authorized access key for the wallet. This matches mppx behavior where viem's smart account signing produces wallet-verifiable signatures.

**Tests:**
- Unit: `test_keychain_proof_source_uses_wallet_address`
- Integration: `test_keychain_source_did_consistent_across_proof_and_paid`