### PR TITLE
chore(deps): bump alloy from 1.8 to 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.0", features = ["full"], optional = true }
 
-# Tempo dependencies (optional)
-tempo-alloy = { version = "1.5", optional = true }
-tempo-primitives = { version = "1.5", optional = true }
+# Tempo dependencies (optional, git until tempo-alloy/tempo-primitives publish alloy 2.0 compat)
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", optional = true }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", default-features = false, features = ["std", "serde"], optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.0", features = ["full"], optional = true }
 
-# Tempo dependencies (optional, git until tempo-alloy/tempo-primitives publish alloy 2.0 compat)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", optional = true }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", default-features = false, features = ["std", "serde"], optional = true }
+# Tempo dependencies (optional)
+tempo-alloy = { version = "1.6.0", optional = true }
+tempo-primitives = { version = "1.6.0", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.0", features = ["full"], optional = true }
 
 # Tempo dependencies (optional, git until tempo-alloy/tempo-primitives publish alloy 2.0 compat)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", optional = true }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", default-features = false, features = ["std", "serde"], optional = true }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", optional = true }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", default-features = false, features = ["std", "serde"], optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "1.8", features = ["full"], optional = true }
+alloy = { version = "2.0", features = ["full"], optional = true }
 
 # Tempo dependencies (optional)
 tempo-alloy = { version = "1.5", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -15,11 +15,7 @@ ignore = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-# Temporarily set to warn while tempo-alloy/tempo-primitives use git deps
-# (git deps are wildcards by nature, revert to deny once crates.io versions are published)
-wildcards = "warn"
-# Allow wildcard versions for path/git dependencies in private crates
-allow-wildcard-paths = true
+wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []
@@ -75,7 +71,4 @@ unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/tempoxyz/tempo",
-    "https://github.com/paradigmxyz/reth",
-]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,9 @@ ignore = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-wildcards = "deny"
+# Temporarily set to warn while tempo-alloy/tempo-primitives use git deps
+# (git deps are wildcards by nature, revert to deny once crates.io versions are published)
+wildcards = "warn"
 # Allow wildcard versions for path/git dependencies in private crates
 allow-wildcard-paths = true
 highlight = "all"

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,6 @@
 [advisories]
 yanked = "warn"
 ignore = [
-    # https://rustsec.org/advisories/RUSTSEC-2024-0388 derivative is unmaintained (transitive dep)
-    "RUSTSEC-2024-0388",
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained (transitive dep)
     "RUSTSEC-2024-0436",
 ]
@@ -18,6 +16,10 @@ ignore = [
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
+# Allow wildcard for git deps (no version field in Cargo.toml)
+allow-wildcard-paths = [
+    "https://github.com/tempoxyz/tempo",
+]
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []
@@ -73,4 +75,7 @@ unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = []
+allow-git = [
+    "https://github.com/tempoxyz/tempo",
+    "https://github.com/paradigmxyz/reth",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -16,10 +16,8 @@ ignore = [
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
 wildcards = "deny"
-# Allow wildcard for git deps (no version field in Cargo.toml)
-allow-wildcard-paths = [
-    "https://github.com/tempoxyz/tempo",
-]
+# Allow wildcard versions for path/git dependencies in private crates
+allow-wildcard-paths = true
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = "1.5"
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
-alloy = { version = "1.8", features = ["provider-http"] }
+alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = "1.5"
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.8", features = ["provider-http"] }
+alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = "1.5"
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.8", features = ["provider-http", "sol-types", "contract"] }
+alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
 tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = "1.5"
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/client.rs"
 
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
-alloy = { version = "1.8", features = ["provider-http"] }
+alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.5"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -30,6 +30,8 @@
 
 pub mod tx_builder;
 
+use std::num::NonZeroU64;
+
 use alloy::primitives::{Address, TxKind, U256};
 use tempo_primitives::transaction::{Call, SignedKeyAuthorization};
 
@@ -323,7 +325,7 @@ impl TempoCharge {
             .with_fee_token(fee_token)
             .with_nonce_key(nonce_key);
 
-            if let Some(vb) = valid_before.and_then(std::num::NonZeroU64::new) {
+            if let Some(vb) = valid_before.and_then(NonZeroU64::new) {
                 req = req.with_valid_before(vb);
             }
 

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -299,7 +299,7 @@ impl TempoCharge {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            Some(now + FEE_PAYER_VALID_BEFORE_SECS)
+            Some(now.saturating_add(FEE_PAYER_VALID_BEFORE_SECS))
         });
 
         let gas_limit = if let Some(gas) = options.gas_limit {
@@ -323,7 +323,7 @@ impl TempoCharge {
             .with_fee_token(fee_token)
             .with_nonce_key(nonce_key);
 
-            if let Some(vb) = valid_before {
+            if let Some(vb) = valid_before.and_then(std::num::NonZeroU64::new) {
                 req = req.with_valid_before(vb);
             }
 

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -67,7 +67,7 @@ pub fn build_tempo_tx(options: TempoTxOptions) -> TempoTransaction {
         } else {
             None
         },
-        valid_before: options.valid_before,
+        valid_before: options.valid_before.and_then(std::num::NonZeroU64::new),
         valid_after: None,
         tempo_authorization_list: vec![],
     }
@@ -300,7 +300,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: Some(9999999999),
+            expiry: std::num::NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -3,6 +3,8 @@
 //! Provides [`build_tempo_tx`] and [`build_charge_credential`] for constructing
 //! Tempo transactions and wrapping them in [`PaymentCredential`]s.
 
+use std::num::NonZeroU64;
+
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
 use tempo_alloy::rpc::TempoTransactionRequest;
@@ -67,7 +69,7 @@ pub fn build_tempo_tx(options: TempoTxOptions) -> TempoTransaction {
         } else {
             None
         },
-        valid_before: options.valid_before.and_then(std::num::NonZeroU64::new),
+        valid_before: options.valid_before.and_then(NonZeroU64::new),
         valid_after: None,
         tempo_authorization_list: vec![],
     }
@@ -300,7 +302,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: std::num::NonZeroU64::new(9999999999),
+            expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -93,6 +93,8 @@ pub fn local_key_spending_limit(auth: &SignedKeyAuthorization, token: Address) -
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use super::*;
     use alloy::signers::{local::PrivateKeySigner, SignerSync};
     use tempo_primitives::transaction::{
@@ -113,7 +115,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: std::num::NonZeroU64::new(9999999999),
+            expiry: NonZeroU64::new(9999999999),
             limits,
             allowed_calls: None,
         };

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -113,7 +113,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: Some(9999999999),
+            expiry: std::num::NonZeroU64::new(9999999999),
             limits,
             allowed_calls: None,
         };

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -235,6 +235,8 @@ pub async fn sign_and_encode_fee_payer_envelope_async(
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use super::*;
     use alloy::primitives::{Bytes, TxKind, U256};
     use alloy::signers::local::PrivateKeySigner;
@@ -324,7 +326,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: std::num::NonZeroU64::new(9999999999),
+            expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };
@@ -368,7 +370,7 @@ mod tests {
         let mut tx = test_tx();
         tx.fee_token = None;
         tx.nonce_key = alloy::primitives::U256::MAX;
-        tx.valid_before = std::num::NonZeroU64::new(9999999999);
+        tx.valid_before = NonZeroU64::new(9999999999);
         tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
             alloy::primitives::U256::ZERO,
             alloy::primitives::U256::ZERO,
@@ -399,7 +401,7 @@ mod tests {
         let mut tx = test_tx();
         tx.fee_token = None;
         tx.nonce_key = alloy::primitives::U256::MAX;
-        tx.valid_before = std::num::NonZeroU64::new(9999999999);
+        tx.valid_before = NonZeroU64::new(9999999999);
         tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
             alloy::primitives::U256::ZERO,
             alloy::primitives::U256::ZERO,
@@ -576,7 +578,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: std::num::NonZeroU64::new(9999999999),
+            expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -324,7 +324,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: Some(9999999999),
+            expiry: std::num::NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };
@@ -368,7 +368,7 @@ mod tests {
         let mut tx = test_tx();
         tx.fee_token = None;
         tx.nonce_key = alloy::primitives::U256::MAX;
-        tx.valid_before = Some(9999999999);
+        tx.valid_before = std::num::NonZeroU64::new(9999999999);
         tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
             alloy::primitives::U256::ZERO,
             alloy::primitives::U256::ZERO,
@@ -399,7 +399,7 @@ mod tests {
         let mut tx = test_tx();
         tx.fee_token = None;
         tx.nonce_key = alloy::primitives::U256::MAX;
-        tx.valid_before = Some(9999999999);
+        tx.valid_before = std::num::NonZeroU64::new(9999999999);
         tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
             alloy::primitives::U256::ZERO,
             alloy::primitives::U256::ZERO,
@@ -576,7 +576,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: Some(9999999999),
+            expiry: std::num::NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
         };

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -74,8 +74,8 @@ impl FeePayerEnvelope78 {
             access_list: tx.access_list,
             nonce_key: tx.nonce_key,
             nonce: tx.nonce,
-            valid_before: tx.valid_before,
-            valid_after: tx.valid_after,
+            valid_before: tx.valid_before.map(|v| v.get()),
+            valid_after: tx.valid_after.map(|v| v.get()),
             fee_token: tx.fee_token,
             sender,
             tempo_authorization_list: tx.tempo_authorization_list,
@@ -133,8 +133,8 @@ impl FeePayerEnvelope78 {
                 U256::ZERO,
                 false,
             )),
-            valid_before: self.valid_before,
-            valid_after: self.valid_after,
+            valid_before: self.valid_before.and_then(std::num::NonZeroU64::new),
+            valid_after: self.valid_after.and_then(std::num::NonZeroU64::new),
             key_authorization: self.key_authorization.clone(),
             tempo_authorization_list: self.tempo_authorization_list.clone(),
         };
@@ -336,7 +336,7 @@ mod tests {
                 U256::ZERO,
                 false,
             )),
-            valid_before: Some(9999999999),
+            valid_before: std::num::NonZeroU64::new(9999999999),
             valid_after: None,
             tempo_authorization_list: vec![],
         }
@@ -355,7 +355,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: Some(9999999999),
+            expiry: std::num::NonZeroU64::new(9999999999),
             limits: Some(vec![TokenLimit {
                 token: Address::repeat_byte(0x33),
                 limit: U256::from(1_000_000u64),
@@ -411,7 +411,7 @@ mod tests {
     fn roundtrip_with_valid_before_and_after() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = Some(1000);
+        tx.valid_after = std::num::NonZeroU64::new(1000);
 
         let env = sign_envelope(tx, &signer);
         assert!(env.valid_before.is_some());
@@ -434,7 +434,7 @@ mod tests {
     fn roundtrip_all_optionals_set() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = Some(500);
+        tx.valid_after = std::num::NonZeroU64::new(500);
         tx.fee_token = Some(Address::repeat_byte(0x55));
 
         let env = sign_envelope(tx, &signer);
@@ -459,7 +459,7 @@ mod tests {
     fn roundtrip_with_key_authorization_and_all_optionals() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = Some(42);
+        tx.valid_after = std::num::NonZeroU64::new(42);
         tx.fee_token = Some(Address::repeat_byte(0x66));
         tx.key_authorization = Some(make_signed_key_auth(&signer));
 

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -15,6 +15,8 @@
 //! The `0x78` envelope exists in mpp-rs because it embeds the fee-payer flow
 //! inline in the MPP credential exchange rather than using a separate RPC hop.
 
+use std::num::NonZeroU64;
+
 use alloy::eips::eip2930::AccessList;
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::rlp::{Buf, BufMut, Decodable, Encodable, Error as RlpError, Header, EMPTY_STRING_CODE};
@@ -133,8 +135,8 @@ impl FeePayerEnvelope78 {
                 U256::ZERO,
                 false,
             )),
-            valid_before: self.valid_before.and_then(std::num::NonZeroU64::new),
-            valid_after: self.valid_after.and_then(std::num::NonZeroU64::new),
+            valid_before: self.valid_before.and_then(NonZeroU64::new),
+            valid_after: self.valid_after.and_then(NonZeroU64::new),
             key_authorization: self.key_authorization.clone(),
             tempo_authorization_list: self.tempo_authorization_list.clone(),
         };
@@ -336,7 +338,7 @@ mod tests {
                 U256::ZERO,
                 false,
             )),
-            valid_before: std::num::NonZeroU64::new(9999999999),
+            valid_before: NonZeroU64::new(9999999999),
             valid_after: None,
             tempo_authorization_list: vec![],
         }
@@ -355,7 +357,7 @@ mod tests {
             chain_id: 42431,
             key_type: SignatureType::Secp256k1,
             key_id: signer.address(),
-            expiry: std::num::NonZeroU64::new(9999999999),
+            expiry: NonZeroU64::new(9999999999),
             limits: Some(vec![TokenLimit {
                 token: Address::repeat_byte(0x33),
                 limit: U256::from(1_000_000u64),
@@ -411,7 +413,7 @@ mod tests {
     fn roundtrip_with_valid_before_and_after() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = std::num::NonZeroU64::new(1000);
+        tx.valid_after = NonZeroU64::new(1000);
 
         let env = sign_envelope(tx, &signer);
         assert!(env.valid_before.is_some());
@@ -434,7 +436,7 @@ mod tests {
     fn roundtrip_all_optionals_set() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = std::num::NonZeroU64::new(500);
+        tx.valid_after = NonZeroU64::new(500);
         tx.fee_token = Some(Address::repeat_byte(0x55));
 
         let env = sign_envelope(tx, &signer);
@@ -459,7 +461,7 @@ mod tests {
     fn roundtrip_with_key_authorization_and_all_optionals() {
         let signer = test_signer();
         let mut tx = base_fee_payer_tx();
-        tx.valid_after = std::num::NonZeroU64::new(42);
+        tx.valid_after = NonZeroU64::new(42);
         tx.fee_token = Some(Address::repeat_byte(0x66));
         tx.key_authorization = Some(make_signed_key_auth(&signer));
 

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1128,6 +1128,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use alloy::primitives::hex;
 
     use super::{super::MODERATO_CHAIN_ID, *};
@@ -1336,7 +1338,7 @@ mod tests {
                 U256::ZERO,
                 false,
             )),
-            valid_before: std::num::NonZeroU64::new(now + valid_before_secs_from_now),
+            valid_before: NonZeroU64::new(now + valid_before_secs_from_now),
             valid_after: None,
             calls: vec![tempo_primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x20)),
@@ -2036,7 +2038,7 @@ mod tests {
             - 10;
 
         let mut tx = make_fee_payer_tx(60);
-        tx.valid_before = std::num::NonZeroU64::new(past);
+        tx.valid_before = NonZeroU64::new(past);
 
         let encoded = sign_and_encode_0x78(tx, &client_signer);
 

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -915,7 +915,7 @@ where
                     .duration_since(std::time::UNIX_EPOCH)
                     .map_err(|e| VerificationError::new(format!("System clock error: {e}")))?
                     .as_secs();
-                if vb <= now {
+                if vb.get() <= now {
                     return Err(VerificationError::new(format!(
                         "Fee payer envelope expired: valid_before ({vb}) is not in the future (now={now})"
                     )));
@@ -1336,7 +1336,7 @@ mod tests {
                 U256::ZERO,
                 false,
             )),
-            valid_before: Some(now + valid_before_secs_from_now),
+            valid_before: std::num::NonZeroU64::new(now + valid_before_secs_from_now),
             valid_after: None,
             calls: vec![tempo_primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x20)),
@@ -2036,7 +2036,7 @@ mod tests {
             - 10;
 
         let mut tx = make_fee_payer_tx(60);
-        tx.valid_before = Some(past);
+        tx.valid_before = std::num::NonZeroU64::new(past);
 
         let encoded = sign_and_encode_0x78(tx, &client_signer);
 

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -13,6 +13,7 @@
 
 #![cfg(feature = "integration")]
 
+use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use alloy::eips::Encodable2718;
@@ -1226,7 +1227,7 @@ async fn test_fee_payer_wrong_recipient_rejected() {
             U256::ZERO,
             false,
         )),
-        valid_before: Some(now + 25),
+        valid_before: NonZeroU64::new(now + 25),
         valid_after: None,
         calls: vec![Call {
             to: TxKind::Call(currency),


### PR DESCRIPTION
Bumps alloy from 1.8 to 2.0 and fixes all breaking changes.

## Changes
- Root `Cargo.toml`: alloy 1.8 → 2.0, tempo-alloy/tempo-primitives switched to git deps (crates.io 1.5.1 pins alloy 1.x sub-crates)
- Examples: alloy 2.0, tempo-alloy git deps
- Adapt to tempo-primitives API: `valid_before`, `valid_after`, `KeyAuthorization.expiry` → `Option<NonZeroU64>`
- Fix `vb <= now` comparison for NonZero type

## Testing
`cargo check` and `cargo clippy` pass clean. 783/785 tests pass — the 2 failures (`test_mpp_create`, `test_charge_dollar_amount`) are pre-existing hostname-detection issues on CI runners, not related to this PR.

Co-Authored-By: zerosnacks <95942363+zerosnacks@users.noreply.github.com>

Prompted by: zerosnacks