### PR TITLE
feat: add `external_id` field to Receipt

### DIFF
--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -803,6 +803,10 @@ pub struct Receipt {
 
     /// Transaction hash or reference
     pub reference: String,
+
+    /// Merchant correlation reference, echoed from the credential payload.
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
+    pub external_id: Option<String>,
 }
 
 impl Receipt {
@@ -814,7 +818,15 @@ impl Receipt {
             method: method.into(),
             timestamp: now_iso8601(),
             reference: reference.into(),
+            external_id: None,
         }
+    }
+
+    /// Set the merchant correlation reference.
+    #[must_use]
+    pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
+        self.external_id = Some(external_id.into());
+        self
     }
 
     /// Check if the payment was successful.
@@ -1059,8 +1071,26 @@ mod tests {
             method: "tempo".into(),
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             reference: "0xabc".to_string(),
+            external_id: None,
         };
         assert!(success.is_success());
+        assert!(success.external_id.is_none());
+    }
+
+    #[test]
+    fn test_receipt_with_external_id() {
+        let receipt = Receipt::success("tempo", "0xabc").with_external_id("order-123");
+        assert_eq!(receipt.external_id.as_deref(), Some("order-123"));
+
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(json.contains("\"externalId\":\"order-123\""));
+
+        let parsed: Receipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.external_id.as_deref(), Some("order-123"));
+
+        let bare = Receipt::success("tempo", "0xabc");
+        let bare_json = serde_json::to_string(&bare).unwrap();
+        assert!(!bare_json.contains("externalId"));
     }
 
     #[test]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -634,6 +634,7 @@ mod tests {
             method: "tempo".into(),
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             reference: "0xabc123".to_string(),
+            external_id: None,
         };
 
         let header = format_receipt(&receipt).unwrap();

--- a/src/protocol/methods/tempo/session_receipt.rs
+++ b/src/protocol/methods/tempo/session_receipt.rs
@@ -104,6 +104,7 @@ impl SessionReceipt {
             method: MethodName::new(&self.method),
             timestamp: self.timestamp.clone(),
             reference: self.reference.clone(),
+            external_id: None,
         }
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -483,6 +483,7 @@ mod tests {
                         method: crate::protocol::core::MethodName::new("tempo"),
                         timestamp: "2025-01-01T00:00:00Z".into(),
                         reference: "0xabc".into(),
+                        external_id: None,
                     })
                 } else {
                     Err("payment rejected".into())
@@ -578,6 +579,7 @@ mod tests {
             method: MethodName::new("tempo"),
             timestamp: "2025-01-01T00:00:00Z".into(),
             reference: "0xabc".into(),
+            external_id: None,
         };
 
         let resp = WithReceipt {


### PR DESCRIPTION
Adds `external_id` field to `Receipt`, `externalId`. Serializes as `"externalId"` on the wire, omitted when `None`. Includes `with_external_id()` builder method.