### PR TITLE
chore(deps): switch tempo-alloy/tempo-primitives from git to crates.io 1.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.0", features = ["full"], optional = true }
 
-# Tempo dependencies (optional, git until tempo-alloy/tempo-primitives publish alloy 2.0 compat)
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", optional = true }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae", default-features = false, features = ["std", "serde"], optional = true }
+# Tempo dependencies (optional)
+tempo-alloy = { version = "1.6.0", optional = true }
+tempo-primitives = { version = "1.6.0", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -15,11 +15,7 @@ ignore = [
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`
-# Temporarily set to warn while tempo-alloy/tempo-primitives use git deps
-# (git deps are wildcards by nature, revert to deny once crates.io versions are published)
-wildcards = "warn"
-# Allow wildcard versions for path/git dependencies in private crates
-allow-wildcard-paths = true
+wildcards = "deny"
 highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = []
@@ -75,7 +71,4 @@ unknown-registry = "deny"
 # Lint level for what to happen when a crate from a git repository that is not
 # in the allow list is encountered
 unknown-git = "deny"
-allow-git = [
-    "https://github.com/tempoxyz/tempo",
-    "https://github.com/paradigmxyz/reth",
-]
+allow-git = []

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e00f196ebb53812f4e5dca6e47a972d01c24f5ae" }
+tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
### Changes
- `tempo-alloy`: git rev → `1.6.0` (root + 4 examples)
- `tempo-primitives`: git rev → `1.6.0` (root)
- `deny.toml`: revert temporary workarounds (wildcards back to `deny`, remove git allowlist)
