### PR TITLE
chore: group dependabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      rust-deps:
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -15,3 +18,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]


### PR DESCRIPTION
Group all cargo and github-actions dependabot updates into single weekly PRs instead of one PR per dependency.

Prompted by: brendan

Co-Authored-By: Brendan Ryan <1572504+brendanjryan@users.noreply.github.com>