### PR TITLE
fix: prevent caching of 402 challenges

### DIFF
--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -116,6 +116,8 @@ impl IntoResponse for PaymentRequired {
                     header::CONTENT_TYPE,
                     HeaderValue::from_static("application/json"),
                 );
+                resp.headers_mut()
+                    .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
                 resp
             }
             Err(e) => (
@@ -504,6 +506,10 @@ mod tests {
         let resp = PaymentRequired(test_challenge()).into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
     }
 
     #[test]

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -190,6 +190,8 @@ where
                         HeaderValue::from_str(&challenge)
                             .unwrap_or_else(|_| HeaderValue::from_static("Payment")),
                     );
+                    resp.headers_mut()
+                        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
                     return Ok(resp);
                 }
             };
@@ -433,6 +435,10 @@ mod tests {
         let resp = svc.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
     }
 
     /// Test: valid auth → 200 with receipt.


### PR DESCRIPTION
Add `Cache-Control: no-store` to 402 responses. Prevents CDNs/proxies from caching time-bound HMAC challenges and serving stale ones to clients.