### PR TITLE
ci: run Tempo integration tests against live devnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,56 @@ jobs:
       - name: Check examples
         run: cargo check --workspace --exclude mpp
 
+  integration:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      TEMPO_TAG: latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || '' }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo update -p native-tls
+
+      - name: Resolve Tempo image digest
+        id: tempo-digest
+        run: |
+          digest=$(docker buildx imagetools inspect ghcr.io/tempoxyz/tempo:${TEMPO_TAG} --raw | sha256sum | cut -d' ' -f1)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Tempo Docker image
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        id: docker-cache
+        with:
+          path: /tmp/tempo-image.tar
+          key: tempo-image-${{ steps.tempo-digest.outputs.digest }}
+
+      - name: Load cached Tempo image
+        if: steps.docker-cache.outputs.cache-hit == 'true'
+        run: docker load -i /tmp/tempo-image.tar
+
+      - name: Pull and cache Tempo image
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull ghcr.io/tempoxyz/tempo:${TEMPO_TAG}
+          docker save ghcr.io/tempoxyz/tempo:${TEMPO_TAG} -o /tmp/tempo-image.tar
+
+      - name: Start Tempo devnet
+        run: docker compose up -d --wait
+
+      - name: Run integration tests
+        run: cargo test --features integration --test integration_charge -- --nocapture
+
+      - name: Stop Tempo devnet
+        if: always()
+        run: docker compose down
+
   deny:
     uses: tempoxyz/ci/.github/workflows/deny.yml@main
     permissions:
@@ -81,7 +131,7 @@ jobs:
   ci-gate:
     name: CI Gate
     if: always()
-    needs: [lint, test, deny]
+    needs: [lint, test, integration, deny]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tempo-primitives = { version = "1.6.0", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }
-reqwest-middleware = { version = "0.4", optional = true }
+reqwest-middleware = { version = "0.5", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
 http-types = { package = "http", version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ server = ["tokio", "futures-core", "async-stream", "http-types"]
 # Method implementations
 evm = ["alloy", "hex", "rand"]
 tempo = ["evm", "tempo-alloy", "tempo-primitives", "uuid"]
-stripe = ["dep:reqwest"]
+stripe = ["dep:reqwest", "reqwest?/form"]
 
 # Utilities
 utils = ["hex", "rand"]
@@ -54,7 +54,7 @@ ws = ["server", "client", "dep:tokio-tungstenite", "dep:futures-util"]
 
 reqwest-default-tls = ["reqwest?/default-tls"]
 reqwest-native-tls = ["reqwest?/native-tls"]
-reqwest-rustls-tls = ["reqwest?/rustls-tls"]
+reqwest-rustls-tls = ["reqwest?/rustls"]
 
 # Integration tests (requires a running Tempo localnet)
 integration = ["tempo", "server", "client", "axum"]
@@ -107,7 +107,7 @@ futures-util = { version = "0.3", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8", features = ["ws"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 hex = "0.4"
 tokio-tungstenite = "0.26"
 futures-util = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,13 +68,13 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_json_canonicalizer = "0.3"
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing"] }
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 
 # Optional dependencies
 hex = { version = "0.4", optional = true }
 base64 = "0.22"
-rand = { version = "0.9", optional = true }
+rand = { version = "0.10", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
@@ -86,7 +86,7 @@ tempo-alloy = { version = "1.6.0", optional = true }
 tempo-primitives = { version = "1.6.0", optional = true }
 
 # HTTP client dependencies (optional)
-reqwest = { version = "0.12", default-features = false, features = ["json"], optional = true }
+reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }
 reqwest-middleware = { version = "0.4", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
@@ -107,7 +107,7 @@ futures-util = { version = "0.3", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8", features = ["ws"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
 hex = "0.4"
 tokio-tungstenite = "0.26"
 futures-util = "0.3"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,11 @@ services:
     ports:
       - "8545:8545"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8545", "-X", "POST", "-H", "Content-Type: application/json", "-d", "{\"jsonrpc\":\"2.0\",\"method\":\"eth_chainId\",\"params\":[],\"id\":1}"]
+      test:
+        [
+          "CMD-SHELL",
+          "bash -lc 'body=\"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"method\\\":\\\"eth_chainId\\\",\\\"params\\\":[],\\\"id\\\":1}\"; exec 3<>/dev/tcp/127.0.0.1/8545; printf \"POST / HTTP/1.1\\r\\nHost: localhost\\r\\nContent-Type: application/json\\r\\nContent-Length: $${#body}\\r\\nConnection: close\\r\\n\\r\\n%s\" \"$$body\" >&3; timeout 2 grep -q \"result\" <&3'",
+        ]
       interval: 2s
       timeout: 5s
       retries: 15

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.10"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "2.0", features = ["provider-http"] }
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.10"

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -18,7 +18,7 @@ alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"]
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -18,8 +18,8 @@ alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"]
 tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -19,7 +19,7 @@ tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -19,11 +19,11 @@ tempo-alloy = "1.6.0"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"
 futures = "0.3"
 async-stream = "0.3"
 urlencoding = "2"

--- a/examples/stripe/Cargo.toml
+++ b/examples/stripe/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/client.rs"
 mpp = { path = "../..", features = ["server", "client", "stripe"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 rand = "0.10"

--- a/examples/stripe/Cargo.toml
+++ b/examples/stripe/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/client.rs"
 mpp = { path = "../..", features = ["server", "client", "stripe"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
-rand = "0.9"
+rand = "0.10"
 base64 = "0.22"

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -453,7 +453,7 @@ pub fn compute_challenge_id(
     digest: Option<&str>,
     opaque: Option<&str>,
 ) -> String {
-    use hmac::{Hmac, Mac};
+    use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     type HmacSha256 = Hmac<Sha256>;

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -903,7 +903,10 @@ mod tests {
     use crate::protocol::traits::ErrorCode;
     #[cfg(feature = "tempo")]
     use crate::server::{tempo, ChargeOptions, TempoConfig};
-    use std::future::Future;
+    use std::{
+        future::Future,
+        sync::{Arc, Mutex},
+    };
 
     #[derive(Clone)]
     struct MockMethod;
@@ -920,6 +923,31 @@ mod tests {
             _request: &ChargeRequest,
         ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
             async { Ok(Receipt::success("mock", "mock_ref")) }
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingMethod {
+        seen_request: Arc<Mutex<Option<ChargeRequest>>>,
+    }
+
+    #[allow(clippy::manual_async_fn)]
+    impl ChargeMethod for RecordingMethod {
+        fn method(&self) -> &str {
+            "mock"
+        }
+
+        fn verify(
+            &self,
+            _credential: &PaymentCredential,
+            request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
+            let seen_request = self.seen_request.clone();
+            let request = request.clone();
+            async move {
+                *seen_request.lock().unwrap() = Some(request);
+                Ok(Receipt::success("mock", "0xabc123"))
+            }
         }
     }
 
@@ -1038,6 +1066,73 @@ mod tests {
         let mpp_err: MppError = err.into();
         let problem = mpp_err.to_problem_details(None);
         assert_eq!(problem.status, 402);
+    }
+
+    #[tokio::test]
+    async fn test_verify_returns_receipt_for_success() {
+        let payment = Mpp::new(MockMethod, "api.example.com", "secret");
+        let credential = test_credential("secret");
+        let request = test_request();
+
+        let receipt = payment.verify(&credential, &request).await.unwrap();
+
+        assert!(receipt.is_success());
+        assert_eq!(receipt.reference, "mock_ref");
+    }
+
+    #[tokio::test]
+    async fn test_verify_credential_decodes_request() {
+        let request = ChargeRequest {
+            amount: "500000".into(),
+            currency: "0x20c0000000000000000000000000000000000000".into(),
+            recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
+            ..Default::default()
+        };
+        let encoded = crate::protocol::core::Base64UrlJson::from_typed(&request).unwrap();
+        let expires = (time::OffsetDateTime::now_utc() + time::Duration::minutes(5))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let secret = "test-secret";
+        let id = crate::protocol::core::compute_challenge_id(
+            secret,
+            "api.example.com",
+            "mock",
+            "charge",
+            encoded.raw(),
+            Some(&expires),
+            None,
+            None,
+        );
+        let credential = PaymentCredential::new(
+            ChallengeEcho {
+                id,
+                realm: "api.example.com".into(),
+                method: "mock".into(),
+                intent: "charge".into(),
+                request: encoded,
+                expires: Some(expires),
+                digest: None,
+                opaque: None,
+            },
+            PaymentPayload::hash("0x123"),
+        );
+        let seen_request = Arc::new(Mutex::new(None));
+        let payment = Mpp::new(
+            RecordingMethod {
+                seen_request: seen_request.clone(),
+            },
+            "api.example.com",
+            secret,
+        );
+
+        let receipt = payment.verify_credential(&credential).await.unwrap();
+
+        assert!(receipt.is_success());
+        assert_eq!(receipt.reference, "0xabc123");
+        let seen = seen_request.lock().unwrap().clone().unwrap();
+        assert_eq!(seen.amount, request.amount);
+        assert_eq!(seen.currency, request.currency);
+        assert_eq!(seen.recipient, request.recipient);
     }
 
     #[cfg(feature = "tempo")]

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -924,24 +924,6 @@ mod tests {
     }
 
     #[derive(Clone)]
-    struct SuccessReceiptMethod;
-
-    #[allow(clippy::manual_async_fn)]
-    impl ChargeMethod for SuccessReceiptMethod {
-        fn method(&self) -> &str {
-            "mock"
-        }
-
-        fn verify(
-            &self,
-            _credential: &PaymentCredential,
-            _request: &ChargeRequest,
-        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
-            async { Ok(Receipt::success("mock", "0xabc123")) }
-        }
-    }
-
-    #[derive(Clone)]
     struct FailedTransactionMethod;
 
     #[allow(clippy::manual_async_fn)]
@@ -1035,20 +1017,6 @@ mod tests {
         assert_eq!(challenge.method.as_str(), "tempo");
         assert_eq!(challenge.intent.as_str(), "charge");
         assert_eq!(challenge.id.len(), 43);
-    }
-
-    #[tokio::test]
-    async fn test_verify_returns_receipt_for_success() {
-        let payment = Mpp::new(SuccessReceiptMethod, "api.example.com", "secret");
-        let credential = test_credential("secret");
-        let request = test_request();
-
-        let result = payment.verify(&credential, &request).await;
-
-        assert!(result.is_ok());
-        let receipt = result.unwrap();
-        assert!(receipt.is_success());
-        assert_eq!(receipt.reference, "0xabc123");
     }
 
     #[tokio::test]
@@ -1191,59 +1159,6 @@ mod tests {
         let payment = Mpp::new(MockMethod, "api.example.com", "secret");
         let result = payment.charge("1.00");
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_verify_credential_decodes_request() {
-        let request = ChargeRequest {
-            amount: "500000".into(),
-            currency: "0x20c0000000000000000000000000000000000000".into(),
-            recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
-            ..Default::default()
-        };
-        let encoded = crate::protocol::core::Base64UrlJson::from_typed(&request).unwrap();
-        let raw = encoded.raw().to_string();
-
-        let secret = "test-secret";
-        let expires = (time::OffsetDateTime::now_utc() + time::Duration::minutes(5))
-            .format(&time::format_description::well_known::Rfc3339)
-            .unwrap();
-        let id = {
-            #[cfg(feature = "tempo")]
-            {
-                crate::protocol::methods::tempo::generate_challenge_id(
-                    secret,
-                    "api.example.com",
-                    "mock",
-                    "charge",
-                    &raw,
-                    Some(&expires),
-                    None,
-                    None,
-                )
-            }
-            #[cfg(not(feature = "tempo"))]
-            {
-                "test-id".to_string()
-            }
-        };
-
-        let echo = ChallengeEcho {
-            id,
-            realm: "api.example.com".into(),
-            method: "mock".into(),
-            intent: "charge".into(),
-            request: crate::protocol::core::Base64UrlJson::from_raw(raw),
-            expires: Some(expires),
-            digest: None,
-            opaque: None,
-        };
-        let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
-
-        let payment = Mpp::new(SuccessReceiptMethod, "api.example.com", secret);
-        let receipt = payment.verify_credential(&credential).await.unwrap();
-        assert!(receipt.is_success());
-        assert_eq!(receipt.reference, "0xabc123");
     }
 
     #[cfg(feature = "tempo")]

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1938,8 +1938,8 @@ async fn test_proof_credential_replay_rejected() {
         credential1.source.clone().unwrap_or_default(),
         credential1.payload.clone(),
     );
-    let replayed_auth =
-        mpp::format_authorization(&replayed_credential).expect("failed to format replayed credential");
+    let replayed_auth = mpp::format_authorization(&replayed_credential)
+        .expect("failed to format replayed credential");
 
     let resp3 = Client::new()
         .get(format!("{url}/identity"))

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1667,3 +1667,293 @@ async fn test_e2e_fee_payer_premium_charge() {
     handle.abort();
     let _ = handle.await;
 }
+
+// ==================== Replay protection tests ====================
+
+/// Transaction credential replay protection: the same tx hash used for a second
+/// challenge should be rejected because the memo is bound to the first challenge ID.
+#[tokio::test]
+async fn test_tx_hash_replay_rejected() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+    fund_account(&rpc, client_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(server_signer)
+        .secret_key("replay-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    // First payment — should succeed.
+    let resp1 = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("first payment failed");
+    assert_eq!(resp1.status(), 200);
+
+    let receipt_hdr = resp1
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    let tx_hash = &receipt.reference;
+
+    // Get a fresh challenge.
+    let resp2 = Client::new()
+        .get(format!("{url}/paid"))
+        .send()
+        .await
+        .expect("challenge request failed");
+    assert_eq!(resp2.status(), 402);
+
+    let www_auth = resp2
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let challenge = mpp::parse_www_authenticate(www_auth).expect("failed to parse challenge");
+
+    // Build a credential reusing the old tx hash with the new challenge.
+    let echo = challenge.to_echo();
+    let credential = mpp::PaymentCredential::new(echo, mpp::PaymentPayload::hash(tx_hash));
+    let auth_header =
+        mpp::format_authorization(&credential).expect("failed to format authorization");
+
+    // Submit — should be rejected (memo bound to old challenge, not this one).
+    let resp3 = Client::new()
+        .get(format!("{url}/paid"))
+        .header("authorization", &auth_header)
+        .send()
+        .await
+        .expect("replay request failed");
+
+    assert_eq!(
+        resp3.status(),
+        402,
+        "replayed tx hash with different challenge should be rejected"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Hash credential with extra transfer logs: a transaction that has additional
+/// transfers (plain transfer without challenge-bound memo) should be rejected.
+#[tokio::test]
+async fn test_hash_credential_with_extra_transfer_rejected() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let extra_recipient = PrivateKeySigner::random();
+
+    fund_account(&rpc, server_signer.address()).await;
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("extra-transfer-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    // Step 1: Get the 402 challenge.
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(resp.status(), 402);
+
+    let www_auth = resp
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let challenge = mpp::parse_www_authenticate(www_auth).expect("failed to parse challenge");
+
+    // Step 2: Send a transaction with TWO transfers in a single multicall:
+    // one to the correct recipient, one to an extra recipient.
+    let charge: mpp::ChargeRequest = challenge.request.decode().unwrap();
+    let amount: U256 = charge.amount.parse().unwrap();
+    let currency: Address = charge.currency.parse().unwrap();
+
+    let transfer_correct =
+        ITIP20::transferCall::new((server_signer.address(), amount)).abi_encode();
+    let transfer_extra =
+        ITIP20::transferCall::new((extra_recipient.address(), amount)).abi_encode();
+
+    let tx_hash = dev_send(
+        &rpc,
+        vec![
+            Call {
+                to: TxKind::Call(currency),
+                value: U256::ZERO,
+                input: Bytes::from(transfer_correct),
+            },
+            Call {
+                to: TxKind::Call(currency),
+                value: U256::ZERO,
+                input: Bytes::from(transfer_extra),
+            },
+        ],
+    )
+    .await;
+
+    // Step 3: Build a credential with the tx hash.
+    let echo = challenge.to_echo();
+    let credential =
+        mpp::PaymentCredential::new(echo, mpp::PaymentPayload::hash(format!("{tx_hash:#x}")));
+    let auth_header =
+        mpp::format_authorization(&credential).expect("failed to format authorization");
+
+    // Step 4: Submit — should be rejected because the memo in the correct
+    // transfer won't be challenge-bound (plain transfer, not transferWithMemo).
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .header("authorization", &auth_header)
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(
+        resp.status(),
+        402,
+        "transaction with extra transfers (and no challenge-bound memo) should be rejected"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+/// Proof credential replay protection: a $0 proof credential for one challenge
+/// cannot be replayed against a different challenge.
+#[tokio::test]
+async fn test_proof_credential_replay_rejected() {
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let server_signer = PrivateKeySigner::random();
+    let client_signer = PrivateKeySigner::random();
+
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", server_signer.address()),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .secret_key("proof-replay-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
+
+    // Step 1: Get a $0 challenge and create a proof credential.
+    let resp1 = Client::new()
+        .get(format!("{url}/identity"))
+        .send()
+        .await
+        .expect("identity request failed");
+    assert_eq!(resp1.status(), 402);
+
+    let www_auth1 = resp1
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let challenge1 = mpp::parse_www_authenticate(www_auth1).expect("failed to parse challenge");
+
+    let credential1 = provider
+        .pay(&challenge1)
+        .await
+        .expect("failed to create proof credential");
+
+    let auth_header1 =
+        mpp::format_authorization(&credential1).expect("failed to format credential");
+
+    // Verify the first proof works.
+    let resp_ok = Client::new()
+        .get(format!("{url}/identity"))
+        .header("authorization", &auth_header1)
+        .send()
+        .await
+        .expect("identity auth request failed");
+    assert_eq!(resp_ok.status(), 200);
+
+    // Step 2: Get a SECOND challenge (different challenge ID).
+    let resp2 = Client::new()
+        .get(format!("{url}/identity"))
+        .send()
+        .await
+        .expect("second identity request failed");
+    assert_eq!(resp2.status(), 402);
+
+    let www_auth2 = resp2
+        .headers()
+        .get("www-authenticate")
+        .expect("missing WWW-Authenticate")
+        .to_str()
+        .unwrap();
+    let challenge2 = mpp::parse_www_authenticate(www_auth2).expect("failed to parse challenge");
+
+    // Sanity: the two challenges have different IDs.
+    assert_ne!(
+        challenge1.id, challenge2.id,
+        "two challenges should have distinct IDs"
+    );
+
+    // Step 3: Try to use the FIRST proof credential against the SECOND challenge.
+    // Build a credential with the second challenge's echo but the first
+    // credential's payload (signature bound to challenge1.id).
+    let echo2 = challenge2.to_echo();
+    let replayed_credential = mpp::PaymentCredential::with_source(
+        echo2,
+        credential1.source.clone().unwrap_or_default(),
+        credential1.payload.clone(),
+    );
+    let replayed_auth =
+        mpp::format_authorization(&replayed_credential).expect("failed to format replayed credential");
+
+    let resp3 = Client::new()
+        .get(format!("{url}/identity"))
+        .header("authorization", &replayed_auth)
+        .send()
+        .await
+        .expect("replay request failed");
+
+    assert_eq!(
+        resp3.status(),
+        402,
+        "proof credential replayed against different challenge should be rejected"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary

Run charge integration tests against a real Tempo devnet container in CI. Add replay-focused live tests, keep fast charge verification unit coverage, and make the Docker healthcheck work with the Tempo image.