### PR TITLE
feat: add to_header/from_header for SessionReceipt

### DIFF
--- a/src/protocol/methods/tempo/session_receipt.rs
+++ b/src/protocol/methods/tempo/session_receipt.rs
@@ -2,6 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::error::{MppError, Result};
+use crate::protocol::core::types::{base64url_decode, base64url_encode};
 use crate::protocol::core::{MethodName, Receipt, ReceiptStatus};
 
 /// Session receipt for Tempo session/pay-as-you-go payments.
@@ -94,6 +96,25 @@ impl SessionReceipt {
             units: None,
             tx_hash: None,
         }
+    }
+
+    /// Serialize to a `Payment-Receipt` header value (base64url-encoded JSON).
+    pub fn to_header(&self) -> Result<String> {
+        let json = serde_json::to_string(self).map_err(|e| {
+            MppError::invalid_challenge_reason(format!(
+                "Failed to serialize session receipt: {}",
+                e
+            ))
+        })?;
+        Ok(base64url_encode(json.as_bytes()))
+    }
+
+    /// Parse from a `Payment-Receipt` header value (base64url-encoded JSON).
+    pub fn from_header(header: &str) -> Result<Self> {
+        let decoded = base64url_decode(header.trim())?;
+        serde_json::from_slice(&decoded).map_err(|e| {
+            MppError::invalid_challenge_reason(format!("Invalid session receipt JSON: {}", e))
+        })
     }
 
     /// Convert to a base [`Receipt`] for protocol-level compatibility.
@@ -215,5 +236,44 @@ mod tests {
         assert_eq!(base.method.as_str(), "tempo");
         assert_eq!(base.timestamp, "2026-01-01T00:00:00Z");
         assert_eq!(base.reference, "0xabc");
+    }
+
+    #[test]
+    fn test_header_roundtrip_and_malformed() {
+        // With optional fields set.
+        let mut receipt =
+            SessionReceipt::new("2026-01-01T00:00:00Z", "ch-99", "0xdef", "8000", "3000");
+        receipt.units = Some(42);
+        receipt.tx_hash = Some("0xaaa".to_string());
+
+        // Round-trip: all fields including optionals survive encode/decode.
+        let header = receipt.to_header().unwrap();
+        let parsed = SessionReceipt::from_header(&header).unwrap();
+        assert_eq!(parsed.channel_id, "0xdef");
+        assert_eq!(parsed.challenge_id, "ch-99");
+        assert_eq!(parsed.accepted_cumulative, "8000");
+        assert_eq!(parsed.spent, "3000");
+        assert_eq!(parsed.units, Some(42));
+        assert_eq!(parsed.tx_hash.as_deref(), Some("0xaaa"));
+        assert_eq!(parsed.reference, "0xdef");
+
+        // camelCase keys survive (verify raw JSON contains them).
+        let decoded = base64url_decode(header.trim()).unwrap();
+        let raw = String::from_utf8(decoded).unwrap();
+        assert!(raw.contains("\"channelId\""));
+        assert!(raw.contains("\"acceptedCumulative\""));
+        assert!(raw.contains("\"txHash\""));
+
+        // Without optional fields: they are absent from the wire.
+        let minimal = SessionReceipt::new("2026-01-01T00:00:00Z", "ch-1", "0x1", "100", "50");
+        let h2 = minimal.to_header().unwrap();
+        let d2 = String::from_utf8(base64url_decode(h2.trim()).unwrap()).unwrap();
+        assert!(!d2.contains("\"units\""));
+        assert!(!d2.contains("\"txHash\""));
+        assert!(SessionReceipt::from_header(&h2).is_ok());
+
+        // Malformed input: not valid base64url, and valid base64 but bad JSON.
+        assert!(SessionReceipt::from_header("!!!").is_err());
+        assert!(SessionReceipt::from_header(&base64url_encode(b"{}")).is_err());
     }
 }


### PR DESCRIPTION
Adds base64url JSON serialization for `SessionReceipt`, preserving all session-specific fields across the `Payment-Receipt` header wire format.
