### PR TITLE
feat: port fee payer policy overrides from mppx#342

### DIFF
--- a/.changelog/add-policy-override.md
+++ b/.changelog/add-policy-override.md
@@ -2,4 +2,4 @@
 mpp: minor
 ---
 
-Added `FeePayerPolicyOverride` so servers can tune the fee-sponsor gas ceiling per call via `ChargeMethod::with_fee_payer_policy_override()`.
+Added `FeePayerPolicyOverride` so servers can tune fee-sponsor transaction limits per call via `ChargeMethod::with_fee_payer_policy_override()`. The override supports five fields: `max_gas` (gas-limit ceiling), `max_fee_per_gas` (EIP-1559 fee-per-gas ceiling), `max_priority_fee_per_gas` (priority-fee ceiling), `max_total_fee` (gas × fee ceiling), and `max_validity_window_seconds` (how far ahead `valid_before` may be set). All fields are optional and fall back to safe global defaults.

--- a/.changelog/add-policy-override.md
+++ b/.changelog/add-policy-override.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added `FeePayerPolicyOverride` so servers can tune the fee-sponsor gas ceiling per call via `ChargeMethod::with_fee_payer_policy_override()`.

--- a/.changelog/add-policy-override.md
+++ b/.changelog/add-policy-override.md
@@ -2,4 +2,4 @@
 mpp: minor
 ---
 
-Added `FeePayerPolicyOverride` so servers can tune fee-sponsor transaction limits per call via `ChargeMethod::with_fee_payer_policy_override()`. The override supports five fields: `max_gas` (gas-limit ceiling), `max_fee_per_gas` (EIP-1559 fee-per-gas ceiling), `max_priority_fee_per_gas` (priority-fee ceiling), `max_total_fee` (gas × fee ceiling), and `max_validity_window_seconds` (how far ahead `valid_before` may be set). All fields are optional and fall back to safe global defaults.
+Added `ChargeMethod::with_fee_payer_policy_override()` for per-server tuning of the fee-sponsor policy (`max_gas`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `max_total_fee`, `max_validity_window_seconds`), with per-chain defaults matching mppx#342.

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -48,7 +48,7 @@ const MAX_FEE_PAYER_GAS_LIMIT: u64 = 2_000_000;
 const MAX_FEE_PER_GAS_DEFAULT: u128 = 100_000_000_000;
 const MAX_PRIORITY_FEE_PER_GAS_DEFAULT: u128 = 10_000_000_000;
 const MAX_VALIDITY_WINDOW_SECS_DEFAULT: u64 = 15 * 60;
-const MAX_TOTAL_FEE_DEFAULT: u128 = 50_000_000_000_000_000; // 0.05 ETH — lower than max_gas * max_fee_per_gas
+const MAX_TOTAL_FEE_DEFAULT: u128 = 50_000_000_000_000_000; // lower than max_gas * max_fee_per_gas
 
 /// TIP-20 Transfer event topic: keccak256("Transfer(address,address,uint256)")
 /// TIP-20 is Tempo's token standard (compatible with ERC-20 Transfer events).

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -448,6 +448,36 @@ pub struct ChargeMethod<P> {
     fee_payer_signer: Option<Arc<alloy::signers::local::PrivateKeySigner>>,
     store: Option<Arc<dyn Store>>,
     cached_chain_id: Arc<OnceCell<u64>>,
+    fee_payer_policy_override: Option<FeePayerPolicyOverride>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FeePayerPolicy {
+    pub max_gas: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FeePayerPolicyOverride {
+    pub max_gas: Option<u64>,
+}
+
+impl Default for FeePayerPolicy {
+    fn default() -> FeePayerPolicy {
+        FeePayerPolicy {
+            max_gas: MAX_FEE_PAYER_GAS_LIMIT,
+        }
+    }
+}
+
+impl FeePayerPolicy {
+    /// Merge overrides onto the per-chain default.
+    pub fn resolve(_chain_id: u64, overrides: Option<&FeePayerPolicyOverride>) -> Self {
+        let base = Self::default();
+        let Some(o) = overrides else { return base };
+        Self {
+            max_gas: o.max_gas.unwrap_or(base.max_gas),
+        }
+    }
 }
 
 impl<P> ChargeMethod<P>
@@ -464,7 +494,14 @@ where
             fee_payer_signer: None,
             store: None,
             cached_chain_id: Arc::new(OnceCell::new()),
+            fee_payer_policy_override: None,
         }
+    }
+
+    // Configure fee payer
+    pub fn with_fee_payer_policy_override(mut self, overrides: FeePayerPolicyOverride) -> Self {
+        self.fee_payer_policy_override = Some(overrides);
+        self
     }
 
     /// Configure a store for transaction hash deduplication.
@@ -625,10 +662,13 @@ where
             )));
         }
 
-        if require_exact_calls && tx.gas_limit > MAX_FEE_PAYER_GAS_LIMIT {
+        let policy =
+            FeePayerPolicy::resolve(expected_chain_id, self.fee_payer_policy_override.as_ref());
+
+        if require_exact_calls && tx.gas_limit > policy.max_gas {
             return Err(VerificationError::new(format!(
                 "Fee-sponsored transaction gas limit {} exceeds maximum {}",
-                tx.gas_limit, MAX_FEE_PAYER_GAS_LIMIT
+                tx.gas_limit, policy.max_gas
             )));
         }
 
@@ -983,6 +1023,7 @@ where
         let fee_payer_signer = self.fee_payer_signer.clone();
         let store = self.store.clone();
         let cached_chain_id = Arc::clone(&self.cached_chain_id);
+        let fee_payer_policy_override = self.fee_payer_policy_override.clone();
 
         async move {
             let this = ChargeMethod {
@@ -990,6 +1031,7 @@ where
                 fee_payer_signer,
                 store,
                 cached_chain_id,
+                fee_payer_policy_override,
             };
 
             if credential.challenge.method.as_str() != METHOD_NAME {
@@ -1939,20 +1981,66 @@ mod tests {
             memo: None,
         }];
 
-        let tx_bytes = encode_signed_tx(
-            vec![tempo_primitives::transaction::Call {
-                to: TxKind::Call(currency),
-                value: U256::ZERO,
-                input: make_transfer_input(recipient, U256::from(100u64)),
-            }],
-            MAX_FEE_PAYER_GAS_LIMIT + 1,
-        );
+        let calls = vec![tempo_primitives::transaction::Call {
+            to: TxKind::Call(currency),
+            value: U256::ZERO,
+            input: make_transfer_input(recipient, U256::from(100u64)),
+        }];
+
+        let tx_bytes = encode_signed_tx(calls.clone(), MAX_FEE_PAYER_GAS_LIMIT + 1);
 
         let error = method
             .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true)
             .unwrap_err();
 
         assert!(error.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn test_policy_override_adjusts_fee_payer_gas_limit() {
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider);
+
+        let currency = Address::repeat_byte(0x20);
+        let recipient = Address::repeat_byte(0x33);
+        let expected = vec![Transfer {
+            amount: U256::from(100u64),
+            recipient,
+            memo: None,
+        }];
+
+        let calls = vec![tempo_primitives::transaction::Call {
+            to: TxKind::Call(currency),
+            value: U256::ZERO,
+            input: make_transfer_input(recipient, U256::from(100u64)),
+        }];
+
+        // with custom gas limit lower than default
+        let max_gas = 500_000;
+        let tx_bytes = encode_signed_tx(calls.clone(), max_gas + 1);
+        let overrides = FeePayerPolicyOverride {
+            max_gas: Some(max_gas),
+        };
+        let method = method.with_fee_payer_policy_override(overrides);
+        let error = method
+            .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true)
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains(&format!("exceeds maximum {}", max_gas)));
+
+        // Override raises ceiling; tx between default (1M) and override (2M) should now pass.
+        let tx_bytes = encode_signed_tx(calls, 1_500_000);
+        let overrides = FeePayerPolicyOverride {
+            max_gas: Some(2_000_000),
+        };
+        let result = method
+            .with_fee_payer_policy_override(overrides)
+            .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true);
+        assert!(result.is_ok());
     }
 
     /// cosign_fee_payer_transaction rejects txs with wrong nonce_key.

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -45,6 +45,9 @@ use super::transfers::{get_request_transfers, Transfer};
 use super::{proof, TempoChargeExt, CHAIN_ID, INTENT_CHARGE, METHOD_NAME};
 
 const MAX_FEE_PAYER_GAS_LIMIT: u64 = 1_000_000;
+const MAX_FEE_PER_GAS_DEFAULT: u128 = 10_000_000_000; // 10 gwei
+const MAX_PRIORITY_FEE_PER_GAS_DEFAULT: u128 = 1_000_000_000; // 1 gwei
+const MAX_VALIDITY_WINDOW_SECS_DEFAULT: u64 = 300; // 5 minutes
 
 /// TIP-20 Transfer event topic: keccak256("Transfer(address,address,uint256)")
 /// TIP-20 is Tempo's token standard (compatible with ERC-20 Transfer events).
@@ -454,28 +457,49 @@ pub struct ChargeMethod<P> {
 #[derive(Debug, Clone)]
 pub struct FeePayerPolicy {
     pub max_gas: u64,
+    pub max_fee_per_gas: u128,
+    pub max_priority_fee_per_gas: u128,
+    pub max_total_fee: u128,
+    pub max_validity_window_seconds: u64,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FeePayerPolicyOverride {
     pub max_gas: Option<u64>,
+    pub max_fee_per_gas: Option<u128>,
+    pub max_priority_fee_per_gas: Option<u128>,
+    pub max_total_fee: Option<u128>,
+    pub max_validity_window_seconds: Option<u64>,
 }
 
 impl Default for FeePayerPolicy {
     fn default() -> FeePayerPolicy {
         FeePayerPolicy {
             max_gas: MAX_FEE_PAYER_GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS_DEFAULT,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS_DEFAULT,
+            max_total_fee: MAX_FEE_PAYER_GAS_LIMIT as u128 * MAX_FEE_PER_GAS_DEFAULT,
+            max_validity_window_seconds: MAX_VALIDITY_WINDOW_SECS_DEFAULT,
         }
     }
 }
 
 impl FeePayerPolicy {
     /// Merge overrides onto the per-chain default.
-    pub fn resolve(_chain_id: u64, overrides: Option<&FeePayerPolicyOverride>) -> Self {
+    pub fn resolve(chain_id: u64, overrides: Option<&FeePayerPolicyOverride>) -> Self {
+        let _ = chain_id; // reserved for per-chain defaults
         let base = Self::default();
         let Some(o) = overrides else { return base };
         Self {
             max_gas: o.max_gas.unwrap_or(base.max_gas),
+            max_fee_per_gas: o.max_fee_per_gas.unwrap_or(base.max_fee_per_gas),
+            max_priority_fee_per_gas: o
+                .max_priority_fee_per_gas
+                .unwrap_or(base.max_priority_fee_per_gas),
+            max_total_fee: o.max_total_fee.unwrap_or(base.max_total_fee),
+            max_validity_window_seconds: o
+                .max_validity_window_seconds
+                .unwrap_or(base.max_validity_window_seconds),
         }
     }
 }
@@ -944,23 +968,57 @@ where
             ));
         }
 
-        match tx.valid_before {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| VerificationError::new(format!("System clock error: {e}")))?
+            .as_secs();
+
+        let valid_before = match tx.valid_before {
             None => {
                 return Err(VerificationError::new(
                     "Fee payer envelope must include valid_before",
                 ));
             }
             Some(vb) => {
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .map_err(|e| VerificationError::new(format!("System clock error: {e}")))?
-                    .as_secs();
                 if vb.get() <= now {
                     return Err(VerificationError::new(format!(
                         "Fee payer envelope expired: valid_before ({vb}) is not in the future (now={now})"
                     )));
                 }
+                vb.get()
             }
+        };
+
+        let policy = FeePayerPolicy::resolve(tx.chain_id, self.fee_payer_policy_override.as_ref());
+
+        if tx.max_fee_per_gas > policy.max_fee_per_gas {
+            return Err(VerificationError::new(format!(
+                "max_fee_per_gas {} exceeds policy maximum {}",
+                tx.max_fee_per_gas, policy.max_fee_per_gas
+            )));
+        }
+
+        if tx.max_priority_fee_per_gas > policy.max_priority_fee_per_gas {
+            return Err(VerificationError::new(format!(
+                "max_priority_fee_per_gas {} exceeds policy maximum {}",
+                tx.max_priority_fee_per_gas, policy.max_priority_fee_per_gas
+            )));
+        }
+
+        let total_fee = (tx.gas_limit as u128).saturating_mul(tx.max_fee_per_gas);
+        if total_fee > policy.max_total_fee {
+            return Err(VerificationError::new(format!(
+                "Total fee {} (gas_limit * max_fee_per_gas) exceeds policy maximum {}",
+                total_fee, policy.max_total_fee
+            )));
+        }
+
+        if valid_before.saturating_sub(now) > policy.max_validity_window_seconds {
+            return Err(VerificationError::new(format!(
+                "valid_before window {}s exceeds policy maximum {}s",
+                valid_before.saturating_sub(now),
+                policy.max_validity_window_seconds
+            )));
         }
 
         // Rebuild the transaction with fee_token set and real fee_payer_signature
@@ -2022,6 +2080,7 @@ mod tests {
         let tx_bytes = encode_signed_tx(calls.clone(), max_gas + 1);
         let overrides = FeePayerPolicyOverride {
             max_gas: Some(max_gas),
+            ..Default::default()
         };
         let method = method.with_fee_payer_policy_override(overrides);
         let error = method
@@ -2036,6 +2095,7 @@ mod tests {
         let tx_bytes = encode_signed_tx(calls, 1_500_000);
         let overrides = FeePayerPolicyOverride {
             max_gas: Some(2_000_000),
+            ..Default::default()
         };
         let result = method
             .with_fee_payer_policy_override(overrides)
@@ -2377,5 +2437,171 @@ mod tests {
             Some(&42431),
             "original value should be retained"
         );
+    }
+
+    fn make_cosign_method(
+        fee_payer_policy_override: Option<FeePayerPolicyOverride>,
+    ) -> (
+        ChargeMethod<
+            impl alloy::providers::Provider<TempoNetwork> + Clone + Send + Sync + 'static,
+        >,
+        alloy::signers::local::PrivateKeySigner,
+        Address,
+    ) {
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let mut method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer.clone());
+        if let Some(overrides) = fee_payer_policy_override {
+            method = method.with_fee_payer_policy_override(overrides);
+        }
+        (method, fee_payer_signer, fee_token)
+    }
+
+    /// cosign_fee_payer_transaction rejects tx with max_fee_per_gas above policy.
+    #[test]
+    fn test_cosign_rejects_excessive_max_fee_per_gas() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        let overrides = FeePayerPolicyOverride {
+            max_fee_per_gas: Some(500_000_000), // 0.5 gwei ceiling
+            ..Default::default()
+        };
+        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.max_fee_per_gas = 600_000_000; // above 0.5 gwei ceiling
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("should reject excessive max_fee_per_gas");
+        assert!(
+            err.to_string().contains("max_fee_per_gas"),
+            "got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects tx with max_priority_fee_per_gas above policy.
+    #[test]
+    fn test_cosign_rejects_excessive_max_priority_fee_per_gas() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        let overrides = FeePayerPolicyOverride {
+            max_priority_fee_per_gas: Some(100_000_000), // 0.1 gwei ceiling
+            ..Default::default()
+        };
+        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.max_priority_fee_per_gas = 200_000_000; // above 0.1 gwei ceiling
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("should reject excessive max_priority_fee_per_gas");
+        assert!(
+            err.to_string().contains("max_priority_fee_per_gas"),
+            "got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects tx whose total fee exceeds the policy cap.
+    #[test]
+    fn test_cosign_rejects_excessive_total_fee() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        // Set a 0.5 gwei max_fee_per_gas ceiling and default gas limit of 1M →
+        // total_fee ceiling = 500_000_000_000_000.  Build a tx that hits exactly
+        // the total_fee limit by using a large gas_limit.
+        let overrides = FeePayerPolicyOverride {
+            max_total_fee: Some(500_000_000_000_000), // ceiling
+            ..Default::default()
+        };
+        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+
+        let mut tx = make_fee_payer_tx(60);
+        // gas_limit=1_000_000, max_fee_per_gas=1_000_000_000 →
+        // total = 1_000_000_000_000_000 > 500_000_000_000_000 ceiling
+        tx.gas_limit = 1_000_000;
+        tx.max_fee_per_gas = 1_000_000_000;
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("should reject excessive total fee");
+        assert!(
+            err.to_string().contains("Total fee"),
+            "got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects tx with valid_before window beyond policy max.
+    #[test]
+    fn test_cosign_rejects_excessive_validity_window() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        let overrides = FeePayerPolicyOverride {
+            max_validity_window_seconds: Some(30), // 30-second ceiling
+            ..Default::default()
+        };
+        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+
+        // valid_before = now + 120s → window of 120s > 30s ceiling
+        let tx = make_fee_payer_tx(120);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("should reject excessive validity window");
+        assert!(
+            err.to_string().contains("valid_before window"),
+            "got: {err}"
+        );
+    }
+
+    /// All five policy override fields are respected when set together.
+    #[test]
+    fn test_policy_override_all_fields_applied() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        // Generous overrides — tx should pass all checks.
+        let overrides = FeePayerPolicyOverride {
+            max_gas: Some(2_000_000),
+            max_fee_per_gas: Some(20_000_000_000),
+            max_priority_fee_per_gas: Some(2_000_000_000),
+            max_total_fee: Some(40_000_000_000_000_000),
+            max_validity_window_seconds: Some(600),
+        };
+        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.gas_limit = 1_500_000; // within 2M override
+        tx.max_fee_per_gas = 15_000_000_000; // within 20 gwei override
+        tx.max_priority_fee_per_gas = 1_500_000_000; // within 2 gwei override
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect("cosign should succeed when all fields within override limits");
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -39,15 +39,16 @@ use crate::protocol::core::{PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
 use crate::protocol::traits::{ChargeMethod as ChargeMethodTrait, VerificationError};
 use crate::store::Store;
-use crate::tempo::attribution;
+use crate::tempo::{attribution, MODERATO_CHAIN_ID};
 
 use super::transfers::{get_request_transfers, Transfer};
 use super::{proof, TempoChargeExt, CHAIN_ID, INTENT_CHARGE, METHOD_NAME};
 
-const MAX_FEE_PAYER_GAS_LIMIT: u64 = 1_000_000;
-const MAX_FEE_PER_GAS_DEFAULT: u128 = 10_000_000_000; // 10 gwei
-const MAX_PRIORITY_FEE_PER_GAS_DEFAULT: u128 = 1_000_000_000; // 1 gwei
-const MAX_VALIDITY_WINDOW_SECS_DEFAULT: u64 = 300; // 5 minutes
+const MAX_FEE_PAYER_GAS_LIMIT: u64 = 2_000_000;
+const MAX_FEE_PER_GAS_DEFAULT: u128 = 100_000_000_000;
+const MAX_PRIORITY_FEE_PER_GAS_DEFAULT: u128 = 10_000_000_000;
+const MAX_VALIDITY_WINDOW_SECS_DEFAULT: u64 = 15 * 60;
+const MAX_TOTAL_FEE_DEFAULT: u128 = 50_000_000_000_000_000; // 0.05 ETH — lower than max_gas * max_fee_per_gas
 
 /// TIP-20 Transfer event topic: keccak256("Transfer(address,address,uint256)")
 /// TIP-20 is Tempo's token standard (compatible with ERC-20 Transfer events).
@@ -478,7 +479,7 @@ impl Default for FeePayerPolicy {
             max_gas: MAX_FEE_PAYER_GAS_LIMIT,
             max_fee_per_gas: MAX_FEE_PER_GAS_DEFAULT,
             max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS_DEFAULT,
-            max_total_fee: MAX_FEE_PAYER_GAS_LIMIT as u128 * MAX_FEE_PER_GAS_DEFAULT,
+            max_total_fee: MAX_TOTAL_FEE_DEFAULT,
             max_validity_window_seconds: MAX_VALIDITY_WINDOW_SECS_DEFAULT,
         }
     }
@@ -487,8 +488,7 @@ impl Default for FeePayerPolicy {
 impl FeePayerPolicy {
     /// Merge overrides onto the per-chain default.
     pub fn resolve(chain_id: u64, overrides: Option<&FeePayerPolicyOverride>) -> Self {
-        let _ = chain_id; // reserved for per-chain defaults
-        let base = Self::default();
+        let base = Self::get_by_chain_id(chain_id);
         let Some(o) = overrides else { return base };
         Self {
             max_gas: o.max_gas.unwrap_or(base.max_gas),
@@ -500,6 +500,17 @@ impl FeePayerPolicy {
             max_validity_window_seconds: o
                 .max_validity_window_seconds
                 .unwrap_or(base.max_validity_window_seconds),
+        }
+    }
+
+    fn get_by_chain_id(chain_id: u64) -> Self {
+        match chain_id {
+            // Moderato regularly needs a higher priority fee than mainnet.
+            MODERATO_CHAIN_ID => Self {
+                max_priority_fee_per_gas: 50_000_000_000,
+                ..Self::default()
+            },
+            _ => Self::default(),
         }
     }
 }
@@ -522,7 +533,11 @@ where
         }
     }
 
-    // Configure fee payer
+    /// Override the fee-sponsor policy applied to fee-payer envelopes.
+    ///
+    /// Each unset field falls back to the per-chain default. Use to raise or
+    /// lower `max_gas`, `max_fee_per_gas`, `max_priority_fee_per_gas`,
+    /// `max_total_fee`, or `max_validity_window_seconds` per server.
     pub fn with_fee_payer_policy_override(mut self, overrides: FeePayerPolicyOverride) -> Self {
         self.fee_payer_policy_override = Some(overrides);
         self
@@ -998,18 +1013,28 @@ where
             )));
         }
 
-        if tx.max_priority_fee_per_gas > policy.max_priority_fee_per_gas {
-            return Err(VerificationError::new(format!(
-                "max_priority_fee_per_gas {} exceeds policy maximum {}",
-                tx.max_priority_fee_per_gas, policy.max_priority_fee_per_gas
-            )));
-        }
-
         let total_fee = (tx.gas_limit as u128).saturating_mul(tx.max_fee_per_gas);
         if total_fee > policy.max_total_fee {
             return Err(VerificationError::new(format!(
                 "Total fee {} (gas_limit * max_fee_per_gas) exceeds policy maximum {}",
                 total_fee, policy.max_total_fee
+            )));
+        }
+
+        // Priority fee above the per-gas ceiling is a client bug — EIP-1559 would
+        // silently clip it to `max_fee_per_gas - base_fee`, so reject early for a
+        // clearer error.
+        if tx.max_priority_fee_per_gas > tx.max_fee_per_gas {
+            return Err(VerificationError::new(format!(
+                "max_priority_fee_per_gas {} exceeds max_fee_per_gas {}",
+                tx.max_priority_fee_per_gas, tx.max_fee_per_gas
+            )));
+        }
+
+        if tx.max_priority_fee_per_gas > policy.max_priority_fee_per_gas {
+            return Err(VerificationError::new(format!(
+                "max_priority_fee_per_gas {} exceeds policy maximum {}",
+                tx.max_priority_fee_per_gas, policy.max_priority_fee_per_gas
             )));
         }
 
@@ -2057,11 +2082,6 @@ mod tests {
 
     #[test]
     fn test_policy_override_adjusts_fee_payer_gas_limit() {
-        let provider =
-            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
-                .connect_http("http://127.0.0.1:1".parse().unwrap());
-        let method = ChargeMethod::new(provider);
-
         let currency = Address::repeat_byte(0x20);
         let recipient = Address::repeat_byte(0x33);
         let expected = vec![Transfer {
@@ -2069,39 +2089,51 @@ mod tests {
             recipient,
             memo: None,
         }];
-
         let calls = vec![tempo_primitives::transaction::Call {
             to: TxKind::Call(currency),
             value: U256::ZERO,
             input: make_transfer_input(recipient, U256::from(100u64)),
         }];
 
-        // with custom gas limit lower than default
-        let max_gas = 500_000;
-        let tx_bytes = encode_signed_tx(calls.clone(), max_gas + 1);
-        let overrides = FeePayerPolicyOverride {
-            max_gas: Some(max_gas),
-            ..Default::default()
+        let build_method = || {
+            let provider =
+                alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                    .connect_http("http://127.0.0.1:1".parse().unwrap());
+            ChargeMethod::new(provider)
         };
-        let method = method.with_fee_payer_policy_override(overrides);
-        let error = method
-            .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true)
+
+        // Lower ceiling: default (2M) would accept 2.5M, override (500k) rejects.
+        let lowered = build_method().with_fee_payer_policy_override(FeePayerPolicyOverride {
+            max_gas: Some(500_000),
+            ..Default::default()
+        });
+        let tx_under_default_over_override = encode_signed_tx(calls.clone(), 500_001);
+        let error = lowered
+            .validate_transaction_transfers(
+                &tx_under_default_over_override,
+                currency,
+                &expected,
+                CHAIN_ID,
+                true,
+            )
             .unwrap_err();
+        assert!(error.to_string().contains("exceeds maximum 500000"));
 
-        assert!(error
-            .to_string()
-            .contains(&format!("exceeds maximum {}", max_gas)));
-
-        // Override raises ceiling; tx between default (1M) and override (2M) should now pass.
-        let tx_bytes = encode_signed_tx(calls, 1_500_000);
-        let overrides = FeePayerPolicyOverride {
-            max_gas: Some(2_000_000),
+        // Raise ceiling: default (2M) would reject 2.5M, override (3M) accepts.
+        let raised = build_method().with_fee_payer_policy_override(FeePayerPolicyOverride {
+            max_gas: Some(3_000_000),
             ..Default::default()
-        };
-        let result = method
-            .with_fee_payer_policy_override(overrides)
-            .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true);
-        assert!(result.is_ok());
+        });
+        let tx_over_default_under_override = encode_signed_tx(calls, 2_500_000);
+        raised
+            .validate_transaction_transfers(
+                &tx_over_default_under_override,
+                currency,
+                &expected,
+                CHAIN_ID,
+                true,
+            )
+            .expect("override should raise ceiling above default");
     }
 
     /// cosign_fee_payer_transaction rejects txs with wrong nonce_key.
@@ -2443,7 +2475,7 @@ mod tests {
     fn make_cosign_method(
         fee_payer_policy_override: Option<FeePayerPolicyOverride>,
     ) -> (
-        ChargeMethod<impl alloy::providers::Provider<TempoNetwork> + Clone + Send + Sync + 'static>,
+        ChargeMethod<impl alloy::providers::Provider<TempoNetwork> + Clone + 'static>,
         alloy::signers::local::PrivateKeySigner,
         Address,
     ) {
@@ -2539,6 +2571,27 @@ mod tests {
         assert!(err.to_string().contains("Total fee"), "got: {err}");
     }
 
+    #[test]
+    fn test_cosign_rejects_excessive_total_fee_under_gas_limit_and_fee_per_gas() {
+        let (method, client_signer, fee_token) = make_cosign_method(None);
+
+        let mut tx = make_fee_payer_tx(60);
+        // gas_limit=1_999_999, max_fee_per_gas=99_000_000_000 →
+        // total = 197_999_901_000_000_000 > 50_000_000_000_000_000 MAX_TOTAL_FEE_DEFAULT
+        tx.gas_limit = 1_999_999;
+        tx.max_fee_per_gas = 99_000_000_000;
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("should reject excessive total fee");
+        assert!(err.to_string().contains("Total fee"), "got: {err}");
+    }
+
     /// cosign_fee_payer_transaction rejects tx with valid_before window beyond policy max.
     #[test]
     fn test_cosign_rejects_excessive_validity_window() {
@@ -2591,5 +2644,48 @@ mod tests {
                 fee_token,
             )
             .expect("cosign should succeed when all fields within override limits");
+    }
+
+    /// EIP-1559 invariant: priority fee cannot exceed max fee per gas.
+    #[test]
+    fn test_cosign_rejects_priority_fee_above_max_fee() {
+        let (method, client_signer, fee_token) = make_cosign_method(None);
+
+        let mut tx = make_fee_payer_tx(60);
+        // Both within policy ceilings, but priority > max_fee violates EIP-1559.
+        tx.max_fee_per_gas = 1_000_000_000; // 1 gwei
+        tx.max_priority_fee_per_gas = 2_000_000_000; // 2 gwei > max_fee_per_gas
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect_err("priority fee above max fee must be rejected");
+        assert!(
+            err.to_string()
+                .contains("max_priority_fee_per_gas 2000000000 exceeds max_fee_per_gas"),
+            "got: {err}"
+        );
+    }
+
+    /// Moderato chain default raises `max_priority_fee_per_gas` to 50 gwei.
+    #[test]
+    fn test_policy_moderato_default_raises_priority_fee() {
+        let tempo_mainnet = FeePayerPolicy::resolve(CHAIN_ID, None);
+        let moderato = FeePayerPolicy::resolve(MODERATO_CHAIN_ID, None);
+
+        assert_eq!(tempo_mainnet.max_priority_fee_per_gas, 10_000_000_000);
+        assert_eq!(moderato.max_priority_fee_per_gas, 50_000_000_000);
+        // All other fields should equal the mainnet default.
+        assert_eq!(moderato.max_gas, tempo_mainnet.max_gas);
+        assert_eq!(moderato.max_fee_per_gas, tempo_mainnet.max_fee_per_gas);
+        assert_eq!(moderato.max_total_fee, tempo_mainnet.max_total_fee);
+        assert_eq!(
+            moderato.max_validity_window_seconds,
+            tempo_mainnet.max_validity_window_seconds
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -2039,13 +2039,14 @@ mod tests {
             memo: None,
         }];
 
-        let calls = vec![tempo_primitives::transaction::Call {
-            to: TxKind::Call(currency),
-            value: U256::ZERO,
-            input: make_transfer_input(recipient, U256::from(100u64)),
-        }];
-
-        let tx_bytes = encode_signed_tx(calls.clone(), MAX_FEE_PAYER_GAS_LIMIT + 1);
+        let tx_bytes = encode_signed_tx(
+            vec![tempo_primitives::transaction::Call {
+                to: TxKind::Call(currency),
+                value: U256::ZERO,
+                input: make_transfer_input(recipient, U256::from(100u64)),
+            }],
+            MAX_FEE_PAYER_GAS_LIMIT + 1,
+        );
 
         let error = method
             .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true)
@@ -2442,9 +2443,7 @@ mod tests {
     fn make_cosign_method(
         fee_payer_policy_override: Option<FeePayerPolicyOverride>,
     ) -> (
-        ChargeMethod<
-            impl alloy::providers::Provider<TempoNetwork> + Clone + Send + Sync + 'static,
-        >,
+        ChargeMethod<impl alloy::providers::Provider<TempoNetwork> + Clone + Send + Sync + 'static>,
         alloy::signers::local::PrivateKeySigner,
         Address,
     ) {
@@ -2465,12 +2464,11 @@ mod tests {
     /// cosign_fee_payer_transaction rejects tx with max_fee_per_gas above policy.
     #[test]
     fn test_cosign_rejects_excessive_max_fee_per_gas() {
-        let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let overrides = FeePayerPolicyOverride {
             max_fee_per_gas: Some(500_000_000), // 0.5 gwei ceiling
             ..Default::default()
         };
-        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+        let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
         let mut tx = make_fee_payer_tx(60);
         tx.max_fee_per_gas = 600_000_000; // above 0.5 gwei ceiling
@@ -2483,21 +2481,17 @@ mod tests {
                 fee_token,
             )
             .expect_err("should reject excessive max_fee_per_gas");
-        assert!(
-            err.to_string().contains("max_fee_per_gas"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("max_fee_per_gas"), "got: {err}");
     }
 
     /// cosign_fee_payer_transaction rejects tx with max_priority_fee_per_gas above policy.
     #[test]
     fn test_cosign_rejects_excessive_max_priority_fee_per_gas() {
-        let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let overrides = FeePayerPolicyOverride {
             max_priority_fee_per_gas: Some(100_000_000), // 0.1 gwei ceiling
             ..Default::default()
         };
-        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+        let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
         let mut tx = make_fee_payer_tx(60);
         tx.max_priority_fee_per_gas = 200_000_000; // above 0.1 gwei ceiling
@@ -2519,15 +2513,14 @@ mod tests {
     /// cosign_fee_payer_transaction rejects tx whose total fee exceeds the policy cap.
     #[test]
     fn test_cosign_rejects_excessive_total_fee() {
-        let client_signer = alloy::signers::local::PrivateKeySigner::random();
         // Set a 0.5 gwei max_fee_per_gas ceiling and default gas limit of 1M →
-        // total_fee ceiling = 500_000_000_000_000.  Build a tx that hits exactly
+        // total_fee ceiling = 500_000_000_000_000. Build a tx that hits exactly
         // the total_fee limit by using a large gas_limit.
         let overrides = FeePayerPolicyOverride {
             max_total_fee: Some(500_000_000_000_000), // ceiling
             ..Default::default()
         };
-        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+        let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
         let mut tx = make_fee_payer_tx(60);
         // gas_limit=1_000_000, max_fee_per_gas=1_000_000_000 →
@@ -2543,21 +2536,17 @@ mod tests {
                 fee_token,
             )
             .expect_err("should reject excessive total fee");
-        assert!(
-            err.to_string().contains("Total fee"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("Total fee"), "got: {err}");
     }
 
     /// cosign_fee_payer_transaction rejects tx with valid_before window beyond policy max.
     #[test]
     fn test_cosign_rejects_excessive_validity_window() {
-        let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let overrides = FeePayerPolicyOverride {
             max_validity_window_seconds: Some(30), // 30-second ceiling
             ..Default::default()
         };
-        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+        let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
         // valid_before = now + 120s → window of 120s > 30s ceiling
         let tx = make_fee_payer_tx(120);
@@ -2579,7 +2568,6 @@ mod tests {
     /// All five policy override fields are respected when set together.
     #[test]
     fn test_policy_override_all_fields_applied() {
-        let client_signer = alloy::signers::local::PrivateKeySigner::random();
         // Generous overrides — tx should pass all checks.
         let overrides = FeePayerPolicyOverride {
             max_gas: Some(2_000_000),
@@ -2588,7 +2576,7 @@ mod tests {
             max_total_fee: Some(40_000_000_000_000_000),
             max_validity_window_seconds: Some(600),
         };
-        let (method, _, fee_token) = make_cosign_method(Some(overrides));
+        let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
         let mut tx = make_fee_payer_tx(60);
         tx.gas_limit = 1_500_000; // within 2M override

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -135,7 +135,7 @@ pub use types::{Split, TempoMethodDetails};
 pub use voucher::{compute_channel_id, sign_voucher, DOMAIN_NAME, DOMAIN_VERSION};
 
 #[cfg(feature = "server")]
-pub use method::ChargeMethod;
+pub use method::{ChargeMethod, FeePayerPolicy, FeePayerPolicyOverride};
 #[cfg(feature = "server")]
 pub use session_method::{
     ChannelState, ChannelStore, InMemoryChannelStore, SessionMethod, SessionMethodConfig,


### PR DESCRIPTION
Ports [mppx#342](https://github.com/wevm/mppx/pull/342). Adds `FeePayerPolicy` and `FeePayerPolicyOverride` types plus `ChargeMethod::with_fee_payer_policy_override()` so servers can tune fee-sponsorship policy per call: `max_gas`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `max_total_fee`, `max_validity_window_seconds`.

Bundled into a single PR per request from @brendanjryan.