### PR TITLE
ci: lint entire workspace in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - name: Run Tempo Lints
         uses: tempoxyz/lints@0dbe62767b6e15963a652f5476bc0b8ae111d6fc # main
         with:

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -29,7 +29,6 @@ use tempo_alloy::TempoNetwork;
 
 const RPC_URL: &str = "https://rpc.moderato.tempo.xyz";
 const CHAIN_ID: u64 = 42431;
-const CURRENCY: &str = "0x20c0000000000000000000000000000000000000";
 /// 0.01 pathUSD in base units (6 decimals).
 const AMOUNT_PER_REQUEST: &str = "10000";
 

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -987,7 +987,7 @@ mod tests {
     /// an RPC call we can't mock here), we test the validation predicate
     /// directly against `OnChainChannel` values — the same struct and field
     /// comparisons used in the real function.
-
+    ///
     /// Helper: evaluates the same predicate used by `try_recover_channel`.
     fn recovery_accepts(
         on_chain: &OnChainChannel,


### PR DESCRIPTION
Add `--workspace --all-targets` to the CI clippy command and remove unused `CURRENCY` constant it caught.