### PR TITLE
chore: switch to crates.io OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -20,10 +21,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
       - name: Changelogs
         uses: tempoxyz/changelogs@54f693643e1bd8469293bdfcbfb647bceb559490 # master
         with:
           conventional-commit: true
-          crate-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          crate-token: ${{ steps.auth.outputs.token }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
 
       - name: Changelogs


### PR DESCRIPTION
Replace `CARGO_REGISTRY_TOKEN` secret with OIDC trusted publishing via `rust-lang/crates-io-auth-action`. Short-lived tokens are exchanged per workflow run — no long-lived secret needed.

### Before merging

- Configure trusted publishing on crates.io: `mpp` crate → Settings → Trusted Publishing (owner: `tempoxyz`, repo: `mpp-rs`, workflow: `release.yml`)
- After verified, delete the `CARGO_REGISTRY_TOKEN` repo secret