### PR TITLE
chore: expose `new_with_config` constructor

### DIFF
--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -129,15 +129,9 @@ where
             chain_id: None,
         }
     }
-}
 
-impl<M> Mpp<M, ()>
-where
-    M: ChargeMethod,
-{
-    /// Create a payment handler with bound currency/recipient for testing.
-    #[cfg(test)]
-    pub(crate) fn new_with_config(
+    /// Create a new payment handler with pre-configured currency and recipient (advanced API).
+    pub fn new_with_config(
         method: M,
         realm: impl Into<String>,
         secret_key: impl Into<String>,


### PR DESCRIPTION
Make `Mpp::new_with_config` public. Previously gated behind `#[cfg(test)]`, which caused false unused code warnings