### PR TITLE
feat: add `alloy-transport-mpp` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["web-programming", "authentication", "cryptography"]
 [workspace]
 members = [
   ".",
+  "crates/alloy-transport-mpp",
   "examples/axum-extractor",
   "examples/basic",
   "examples/session/multi-fetch",

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+name = "alloy-transport-mpp"
+description = "Machine Payments Protocol (MPP) transport layer over WebSocket for alloy"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.91"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/tempoxyz/mpp-rs"
+repository = "https://github.com/tempoxyz/mpp-rs"
+keywords = ["alloy", "mpp", "payments", "websocket", "ethereum"]
+categories = ["web-programming", "authentication", "cryptography"]
+readme = "README.md"
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = [
+    "-Zunstable-options",
+    "--generate-link-to-definition",
+    "--show-type-layout",
+]
+
+[dependencies]
+alloy-json-rpc = { version = "2.0", default-features = false }
+alloy-pubsub = { version = "2.0", default-features = false }
+alloy-transport = { version = "2.0", default-features = false }
+alloy-transport-ws = { version = "2.0", default-features = false }
+
+mpp = { path = "../..", default-features = false, features = ["ws"] }
+
+futures = "0.3"
+serde_json = "1"
+tracing = "0.1"
+url = "2"
+
+# non-WASM only
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+http = "1"
+tokio = { version = "1", features = ["sync", "rt", "time", "macros"] }
+# Pinned to match the version used by alloy-transport-ws 2.0.x.
+tokio-tungstenite = "0.28"
+rustls = { version = "0.23", default-features = false, optional = true }
+
+[dev-dependencies]
+futures = "0.3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
+# Pinned to match the version used by alloy-transport-ws 2.0.x so the
+# WebSocketConfig types align between the integration tests and the crate.
+tokio-tungstenite = "0.28"
+
+[features]
+default = ["aws-lc-rs"]
+aws-lc-rs = ["alloy-transport-ws/aws-lc-rs", "dep:rustls", "rustls?/aws-lc-rs"]
+ring = ["alloy-transport-ws/ring", "dep:rustls", "rustls?/ring"]
+native-tls = ["alloy-transport-ws/native-tls"]
+rustls-tls = ["alloy-transport-ws/rustls-tls"]

--- a/crates/alloy-transport-mpp/README.md
+++ b/crates/alloy-transport-mpp/README.md
@@ -1,0 +1,20 @@
+# alloy-transport-mpp
+
+[Machine Payments Protocol (MPP)](https://github.com/tempoxyz/mpp-rs)
+WebSocket transport for [alloy](https://github.com/alloy-rs/alloy).
+
+This crate adds an opt-in WebSocket transport that speaks the MPP wire
+protocol while remaining a drop-in `PubSubConnect` implementation for the
+rest of alloy. JSON-RPC frames are wrapped in MPP `message` envelopes;
+payment `challenge`, `needVoucher`, `receipt` and `error` frames are
+handled internally via a user-supplied
+[`PaymentProvider`](https://docs.rs/mpp/latest/mpp/client/trait.PaymentProvider.html)
+(and an optional `VoucherProvider` for streaming/session intents).
+
+```rust,ignore
+use alloy_provider::ProviderBuilder;
+use alloy_transport_mpp::MppWsConnect;
+
+let connect = MppWsConnect::new("wss://paid.example/rpc", my_provider);
+let provider = ProviderBuilder::new().connect_pubsub(connect).await?;
+```

--- a/crates/alloy-transport-mpp/src/lib.rs
+++ b/crates/alloy-transport-mpp/src/lib.rs
@@ -1,0 +1,21 @@
+#![doc = include_str!("../README.md")]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+#[macro_use]
+extern crate tracing;
+
+#[cfg(not(target_family = "wasm"))]
+mod ws;
+#[cfg(not(target_family = "wasm"))]
+pub use ws::{MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider, VoucherRequest};
+
+// Re-exports for ergonomics.
+#[cfg(not(target_family = "wasm"))]
+pub use mpp::{
+    client::{
+        ws::{WsClientMessage, WsServerMessage},
+        PaymentProvider,
+    },
+    PaymentChallenge, PaymentCredential, Receipt,
+};

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -14,6 +14,8 @@ use alloy_transport::{
 use alloy_transport_ws::WebSocketConfig;
 use futures::{SinkExt, StreamExt};
 use http::{header::AUTHORIZATION, HeaderValue, Request as HttpRequest};
+#[cfg(test)]
+use mpp::PaymentPayload;
 use mpp::{
     client::{
         ws::{WsClientMessage, WsServerMessage},
@@ -21,11 +23,14 @@ use mpp::{
     },
     format_authorization, MppError, PaymentChallenge, PaymentCredential, Receipt,
 };
-use serde_json::value::RawValue;
+use serde_json::{
+    from_str as json_from_str, from_value as json_from_value, value::RawValue, Value,
+};
 use std::{
     collections::VecDeque,
     fmt,
-    future::Future,
+    future::{ready, Future},
+    io::Error as IoError,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -34,6 +39,7 @@ use std::{
 };
 use tokio::{
     net::TcpStream,
+    pin, select, spawn,
     sync::{
         broadcast::{self, Receiver as BroadcastReceiver},
         watch::{self, Receiver as WatchReceiver},
@@ -42,6 +48,7 @@ use tokio::{
     time::{sleep, Instant},
 };
 use tokio_tungstenite::{
+    connect_async_with_config,
     tungstenite::{self, client::IntoClientRequest, Message},
     MaybeTlsStream, WebSocketStream,
 };
@@ -353,7 +360,7 @@ where
             .clone()
             .into_client_request()
             .map_err(TransportErrorKind::custom)?;
-        let (socket, _) = tokio_tungstenite::connect_async_with_config(request, self.config, false)
+        let (socket, _) = connect_async_with_config(request, self.config, false)
             .await
             .map_err(TransportErrorKind::custom)?;
 
@@ -400,12 +407,12 @@ async fn run_translator<P, V>(
     // so application traffic never races the initial challenge.
     let mut handshake_complete = false;
     let keepalive = sleep(keepalive_interval);
-    tokio::pin!(keepalive);
+    pin!(keepalive);
 
     // Bounds time spent waiting for a challenge or a pay()/next_voucher()
     // task to complete.
     let handshake_deadline = sleep(handshake_timeout);
-    tokio::pin!(handshake_deadline);
+    pin!(handshake_deadline);
 
     // Off-loop tasks: spawning `pay`/`next_voucher` keeps the keepalive arm
     // responsive while signing/broadcasting takes place.
@@ -421,13 +428,13 @@ async fn run_translator<P, V>(
         let frontend_open = handshake_complete && !payment_in_flight;
         let can_flush = frontend_open && !pending_outbound.is_empty();
 
-        tokio::select! {
+        select! {
             biased;
 
             // 1. Flush one buffered RPC when handshake is done and no
             //    credential exchange is in flight. The ready future keeps
             //    other arms reachable between sends.
-            _ = std::future::ready(()), if can_flush => {
+            _ = ready(()), if can_flush => {
                 let rpc = pending_outbound.pop_front().expect("guarded by can_flush");
                 keepalive.as_mut().reset(Instant::now() + keepalive_interval);
                 if let Err(err) = send_jsonrpc(&mut socket, rpc).await {
@@ -614,9 +621,9 @@ async fn poll_join<T>(pending: &mut Option<JoinHandle<T>>) -> Result<T, JoinErro
 
 async fn send_jsonrpc(socket: &mut WsStream, rpc: Box<RawValue>) -> Result<(), tungstenite::Error> {
     // Parse the JSON-RPC envelope so it serializes back as a structured object
-    // (matching mpp-rs's `WsClientMessage::Data { data: serde_json::Value }`).
-    let data: serde_json::Value = serde_json::from_str(rpc.get())
-        .map_err(|e| tungstenite::Error::Io(std::io::Error::other(e)))?;
+    // (matching mpp-rs's `WsClientMessage::Data { data: Value }`).
+    let data: Value =
+        json_from_str(rpc.get()).map_err(|e| tungstenite::Error::Io(IoError::other(e)))?;
     let frame = WsClientMessage::Data { data };
     socket.send(Message::Text(frame.to_text().into())).await
 }
@@ -700,7 +707,7 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
     pending_pay: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
     pending_voucher: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
 ) -> Result<(), TerminationReason> {
-    let server_msg: WsServerMessage = match serde_json::from_str(text) {
+    let server_msg: WsServerMessage = match json_from_str(text) {
         Ok(m) => m,
         Err(err) => {
             error!(%err, %text, "failed to deserialize MPP frame");
@@ -725,7 +732,7 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
             if let Some(err) = error {
                 warn!(%err, "MPP challenge carried error message");
             }
-            let parsed: PaymentChallenge = match serde_json::from_value(challenge) {
+            let parsed: PaymentChallenge = match json_from_value(challenge) {
                 Ok(c) => c,
                 Err(err) => {
                     error!(%err, "failed to deserialize PaymentChallenge");
@@ -751,12 +758,12 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
             // Spawn `pay()` so the main loop stays responsive (keepalive,
             // socket reads) while the provider signs/broadcasts.
             let provider = payment_provider.clone();
-            *pending_pay = Some(tokio::spawn(async move { provider.pay(&parsed).await }));
+            *pending_pay = Some(spawn(async move { provider.pay(&parsed).await }));
             Ok(())
         }
         WsServerMessage::Data { data } => {
             // mpp-rs encodes the inner payload as a JSON-encoded string.
-            let item: PubSubItem = match serde_json::from_str(&data) {
+            let item: PubSubItem = match json_from_str(&data) {
                 Ok(i) => i,
                 Err(err) => {
                     error!(%err, %data, "failed to deserialize JSON-RPC payload from MPP data frame");
@@ -796,13 +803,11 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
             let _ = events_tx.send(MppEvent::NeedVoucher(req.clone()));
 
             let provider = voucher_provider.clone();
-            *pending_voucher = Some(tokio::spawn(
-                async move { provider.next_voucher(&req).await },
-            ));
+            *pending_voucher = Some(spawn(async move { provider.next_voucher(&req).await }));
             Ok(())
         }
         WsServerMessage::Receipt { receipt } => {
-            let parsed: Receipt = match serde_json::from_value(receipt) {
+            let parsed: Receipt = match json_from_value(receipt) {
                 Ok(r) => r,
                 Err(err) => {
                     error!(%err, "failed to deserialize Receipt");
@@ -840,7 +845,6 @@ fn install_default_crypto_provider() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mpp::PaymentPayload;
 
     #[derive(Clone)]
     struct DummyProvider;

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -1,0 +1,1000 @@
+//! MPP WebSocket transport for alloy.
+//!
+//! Wraps every outgoing JSON-RPC frame in an MPP `message` envelope and
+//! intercepts inbound `challenge`, `needVoucher`, `receipt`, and `error`
+//! frames to drive a user-supplied [`PaymentProvider`] (and optional
+//! [`VoucherProvider`] for streaming sessions).
+
+use alloy_json_rpc::PubSubItem;
+use alloy_pubsub::{ConnectionHandle, ConnectionInterface, PubSubConnect};
+use alloy_transport::{
+    utils::{guess_local_url, Spawnable},
+    Authorization, TransportErrorKind, TransportResult,
+};
+use alloy_transport_ws::WebSocketConfig;
+use futures::{SinkExt, StreamExt};
+use http::{header::AUTHORIZATION, HeaderValue, Request as HttpRequest};
+use mpp::{
+    client::{
+        ws::{WsClientMessage, WsServerMessage},
+        PaymentProvider,
+    },
+    format_authorization, MppError, PaymentChallenge, PaymentCredential, Receipt,
+};
+use serde_json::value::RawValue;
+use std::{
+    collections::VecDeque,
+    fmt,
+    future::Future,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{
+    net::TcpStream,
+    sync::{
+        broadcast::{self, Receiver as BroadcastReceiver},
+        watch::{self, Receiver as WatchReceiver},
+    },
+    task::{JoinError, JoinHandle},
+    time::{sleep, Instant},
+};
+use tokio_tungstenite::{
+    tungstenite::{self, client::IntoClientRequest, Message},
+    MaybeTlsStream, WebSocketStream,
+};
+use url::Url;
+
+type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const DEFAULT_KEEPALIVE_SECS: u64 = 10;
+const DEFAULT_HANDSHAKE_TIMEOUT_SECS: u64 = 30;
+const DEFAULT_EVENTS_CAPACITY: usize = 64;
+
+/// Server-issued request for a fresh session voucher.
+///
+/// Emitted as part of an MPP `needVoucher` frame when a streaming session's
+/// channel balance has been exhausted and the server is asking the client
+/// for a new signed cumulative voucher.
+#[derive(Clone, Debug)]
+pub struct VoucherRequest {
+    /// Channel ID (`"0x…"`).
+    pub channel_id: String,
+    /// Cumulative amount the server needs the next voucher to cover.
+    pub required_cumulative: String,
+    /// Cumulative amount the server has already accepted vouchers for.
+    pub accepted_cumulative: String,
+    /// Total channel deposit on-chain.
+    pub deposit: String,
+}
+
+/// Optional companion to [`PaymentProvider`] for streaming/session intents.
+///
+/// When the server emits a `needVoucher` frame, the translator calls
+/// [`VoucherProvider::next_voucher`] to obtain the next signed voucher.
+/// The default [`NoVoucher`] implementation rejects all voucher requests,
+/// which is the right behavior for charge-only flows.
+pub trait VoucherProvider: Clone + Send + Sync + 'static {
+    /// Produce a fresh voucher credential for the given session request.
+    fn next_voucher(
+        &self,
+        request: &VoucherRequest,
+    ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
+}
+
+/// Default no-op [`VoucherProvider`].
+///
+/// Returns an error for every voucher request. Use this when your
+/// `PaymentProvider` only handles one-shot `charge` intents.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoVoucher;
+
+impl VoucherProvider for NoVoucher {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request(
+            "voucher provider not configured; configure MppWsConnect::with_voucher_provider",
+        ))
+    }
+}
+
+/// Significant MPP events observed by the translator.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum MppEvent {
+    /// A challenge was received from the server.
+    Challenge(PaymentChallenge),
+    /// A credential was successfully sent in response to a challenge.
+    CredentialSent,
+    /// A `needVoucher` frame was received.
+    NeedVoucher(VoucherRequest),
+    /// A voucher credential was sent.
+    VoucherSent,
+    /// A receipt was received.
+    Receipt(Receipt),
+    /// The server emitted an error frame.
+    Error(String),
+}
+
+/// Side channel for observing MPP-specific events on a connection.
+///
+/// Obtain one with [`MppWsConnect::mpp_handle`] **before** calling
+/// `connect_pubsub`/`connect_client`. Receivers are persistent across
+/// reconnects — the senders live on `MppWsConnect` itself, and every
+/// successive translator task publishes into the same channels.
+#[derive(Debug)]
+pub struct MppHandle {
+    /// The most recently observed receipt (`None` until the first one).
+    pub receipt: WatchReceiver<Option<Receipt>>,
+    /// Stream of MPP events; lossy under backpressure (uses
+    /// [`tokio::sync::broadcast`]).
+    pub events: BroadcastReceiver<MppEvent>,
+}
+
+/// Reason a translator session ended; controls whether the pubsub layer
+/// reconnects.
+#[derive(Clone, Copy, Debug)]
+enum TerminationReason {
+    /// Socket-level failure. Reconnect using the configured retry policy.
+    Transient,
+    /// Deterministic MPP failure (provider error, server `error` frame,
+    /// malformed/unexpected frame). Do not reconnect.
+    Fatal,
+}
+
+/// Connection details for an MPP-over-WebSocket transport.
+///
+/// `MppWsConnect` is a drop-in [`PubSubConnect`] that speaks the
+/// [MPP WS wire protocol](https://github.com/tempoxyz/mpp-rs). Outbound
+/// JSON-RPC frames are wrapped as `{"type":"message","data":<payload>}`;
+/// server-issued `challenge` / `needVoucher` frames are settled by the
+/// supplied [`PaymentProvider`] / [`VoucherProvider`].
+///
+/// On reconnect, [`PaymentProvider::pay`] is called again with the server's
+/// new challenge — providers should handle repeated calls cheaply.
+///
+/// Only socket-level failures are retried; deterministic MPP failures are
+/// terminal and short-circuit further reconnect attempts.
+#[derive(Clone)]
+pub struct MppWsConnect<P, V = NoVoucher> {
+    url: String,
+    auth: Option<Authorization>,
+    config: Option<WebSocketConfig>,
+    max_retries: u32,
+    retry_interval: Duration,
+    keepalive_interval: Duration,
+    handshake_timeout: Duration,
+    payment_provider: P,
+    voucher_provider: V,
+    receipt_tx: watch::Sender<Option<Receipt>>,
+    events_tx: broadcast::Sender<MppEvent>,
+    /// Latched on fatal MPP failure; short-circuits future `connect()` calls.
+    fatal: Arc<AtomicBool>,
+}
+
+// Manual Debug impl: redact secrets in `url` and `auth`; omit providers
+// and internal channels.
+impl<P, V> fmt::Debug for MppWsConnect<P, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MppWsConnect")
+            .field("url", &redact_url_userinfo(&self.url))
+            .field("auth", &self.auth.as_ref().map(|_| "<redacted>"))
+            .field("max_retries", &self.max_retries)
+            .field("retry_interval", &self.retry_interval)
+            .field("keepalive_interval", &self.keepalive_interval)
+            .field("handshake_timeout", &self.handshake_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Strip `user:pass@` from a URL string for safe logging.
+fn redact_url_userinfo(raw: &str) -> String {
+    match Url::parse(raw) {
+        Ok(mut u) if !u.username().is_empty() || u.password().is_some() => {
+            let _ = u.set_username("");
+            let _ = u.set_password(None);
+            u.to_string()
+        }
+        Ok(_) => raw.to_string(),
+        Err(_) => "<unparsable>".to_string(),
+    }
+}
+
+impl<P> MppWsConnect<P, NoVoucher> {
+    /// Create a new MPP WebSocket connector.
+    ///
+    /// If the URL contains userinfo (`wss://user:pass@host`), it is extracted
+    /// as a basic `Authorization` header for the WS handshake.
+    pub fn new<S: Into<String>>(url: S, payment_provider: P) -> Self {
+        let url = url.into();
+        let auth = Url::parse(&url)
+            .ok()
+            .and_then(|parsed| Authorization::extract_from_url(&parsed));
+        let (receipt_tx, _) = watch::channel(None);
+        let (events_tx, _) = broadcast::channel(DEFAULT_EVENTS_CAPACITY);
+        Self {
+            url,
+            auth,
+            config: None,
+            max_retries: 10,
+            retry_interval: Duration::from_secs(3),
+            keepalive_interval: Duration::from_secs(DEFAULT_KEEPALIVE_SECS),
+            handshake_timeout: Duration::from_secs(DEFAULT_HANDSHAKE_TIMEOUT_SECS),
+            payment_provider,
+            voucher_provider: NoVoucher,
+            receipt_tx,
+            events_tx,
+            fatal: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl<P, V> MppWsConnect<P, V> {
+    /// Sets the authorization header for the underlying WS handshake.
+    pub fn with_auth(mut self, auth: Authorization) -> Self {
+        self.auth = Some(auth);
+        self
+    }
+
+    /// Sets the websocket config.
+    pub const fn with_config(mut self, config: WebSocketConfig) -> Self {
+        self.config = Some(config);
+        self
+    }
+
+    /// Sets the max number of reconnect retries.
+    pub const fn with_max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    /// Sets the base reconnect retry interval.
+    pub const fn with_retry_interval(mut self, retry_interval: Duration) -> Self {
+        self.retry_interval = retry_interval;
+        self
+    }
+
+    /// Sets the keepalive ping interval.
+    pub const fn with_keepalive_interval(mut self, keepalive_interval: Duration) -> Self {
+        self.keepalive_interval = keepalive_interval;
+        self
+    }
+
+    /// Sets the per-phase handshake timeout.
+    ///
+    /// Bounds the time spent waiting for the server's `challenge` /
+    /// `needVoucher` and for the local `pay()` / `next_voucher()` to complete.
+    /// On expiry the connection is closed with a fatal error and not
+    /// reconnected.
+    pub const fn with_handshake_timeout(mut self, handshake_timeout: Duration) -> Self {
+        self.handshake_timeout = handshake_timeout;
+        self
+    }
+
+    /// Plug in a [`VoucherProvider`] for streaming/session intents.
+    pub fn with_voucher_provider<V2: VoucherProvider>(
+        self,
+        voucher_provider: V2,
+    ) -> MppWsConnect<P, V2> {
+        MppWsConnect {
+            url: self.url,
+            auth: self.auth,
+            config: self.config,
+            max_retries: self.max_retries,
+            retry_interval: self.retry_interval,
+            keepalive_interval: self.keepalive_interval,
+            handshake_timeout: self.handshake_timeout,
+            payment_provider: self.payment_provider,
+            voucher_provider,
+            receipt_tx: self.receipt_tx,
+            events_tx: self.events_tx,
+            fatal: self.fatal,
+        }
+    }
+
+    /// Get a side-channel handle to observe receipts and MPP events.
+    ///
+    /// Call this **before** handing the connector to a `ProviderBuilder`
+    /// or `ClientBuilder`. The receivers stay valid across reconnects.
+    pub fn mpp_handle(&self) -> MppHandle {
+        MppHandle {
+            receipt: self.receipt_tx.subscribe(),
+            events: self.events_tx.subscribe(),
+        }
+    }
+
+    /// Get the URL of the connection.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+impl<P: Clone, V: Clone> IntoClientRequest for MppWsConnect<P, V> {
+    fn into_client_request(self) -> tungstenite::Result<tungstenite::handshake::client::Request> {
+        let mut request: HttpRequest<()> = self.url.into_client_request()?;
+        if let Some(auth) = self.auth {
+            let mut auth_value = HeaderValue::from_str(&auth.to_string())?;
+            auth_value.set_sensitive(true);
+            request.headers_mut().insert(AUTHORIZATION, auth_value);
+        }
+        request.into_client_request()
+    }
+}
+
+impl<P, V> PubSubConnect for MppWsConnect<P, V>
+where
+    P: PaymentProvider + 'static,
+    V: VoucherProvider,
+{
+    fn is_local(&self) -> bool {
+        guess_local_url(&self.url)
+    }
+
+    async fn connect(&self) -> TransportResult<ConnectionHandle> {
+        // Refuse to reconnect after a fatal MPP failure.
+        if self.fatal.load(Ordering::Acquire) {
+            // NOTE: ideally this would be a non-retryable transport error so the
+            // pubsub service short-circuits the reconnect loop. The published
+            // `alloy-transport` (<= 2.0.4) does not yet expose a non-retryable
+            // helper, so we surface a custom error and rely on the latched
+            // `fatal` flag — every retry will hit this branch and return
+            // immediately, so the loop only burns a few wakeups before the
+            // service exhausts its `max_retries` budget.
+            return Err(TransportErrorKind::custom_str(
+                "MPP connection terminated by a fatal error; not reconnecting",
+            ));
+        }
+
+        #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+        install_default_crypto_provider();
+
+        let request = self
+            .clone()
+            .into_client_request()
+            .map_err(TransportErrorKind::custom)?;
+        let (socket, _) = tokio_tungstenite::connect_async_with_config(request, self.config, false)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+
+        let (handle, interface) = ConnectionHandle::new();
+
+        run_translator(
+            socket,
+            interface,
+            self.payment_provider.clone(),
+            self.voucher_provider.clone(),
+            self.keepalive_interval,
+            self.handshake_timeout,
+            self.receipt_tx.clone(),
+            self.events_tx.clone(),
+            self.fatal.clone(),
+        )
+        .spawn_task();
+
+        Ok(handle
+            .with_max_retries(self.max_retries)
+            .with_retry_interval(self.retry_interval))
+    }
+}
+
+/// Bridge between alloy's JSON-RPC channels and MPP frames.
+#[allow(clippy::too_many_arguments)]
+async fn run_translator<P, V>(
+    mut socket: WsStream,
+    mut interface: ConnectionInterface,
+    payment_provider: P,
+    voucher_provider: V,
+    keepalive_interval: Duration,
+    handshake_timeout: Duration,
+    receipt_tx: watch::Sender<Option<Receipt>>,
+    events_tx: broadcast::Sender<MppEvent>,
+    fatal: Arc<AtomicBool>,
+) where
+    P: PaymentProvider + 'static,
+    V: VoucherProvider,
+{
+    let mut termination: Option<TerminationReason> = None;
+    let mut expecting_pong = false;
+    // `false` until the first credential has been sent; gates outbound JSON-RPC
+    // so application traffic never races the initial challenge.
+    let mut handshake_complete = false;
+    let keepalive = sleep(keepalive_interval);
+    tokio::pin!(keepalive);
+
+    // Bounds time spent waiting for a challenge or a pay()/next_voucher()
+    // task to complete.
+    let handshake_deadline = sleep(handshake_timeout);
+    tokio::pin!(handshake_deadline);
+
+    // Off-loop tasks: spawning `pay`/`next_voucher` keeps the keepalive arm
+    // responsive while signing/broadcasting takes place.
+    let mut pending_pay: Option<JoinHandle<Result<PaymentCredential, MppError>>> = None;
+    let mut pending_voucher: Option<JoinHandle<Result<PaymentCredential, MppError>>> = None;
+    // Outbound RPCs queued while not safe to send (handshake/payment).
+    // Polling `recv_from_frontend` unconditionally lets shutdown be observed
+    // mid-payment.
+    let mut pending_outbound: VecDeque<Box<RawValue>> = VecDeque::new();
+
+    loop {
+        let payment_in_flight = pending_pay.is_some() || pending_voucher.is_some();
+        let frontend_open = handshake_complete && !payment_in_flight;
+        let can_flush = frontend_open && !pending_outbound.is_empty();
+
+        tokio::select! {
+            biased;
+
+            // 1. Flush one buffered RPC when handshake is done and no
+            //    credential exchange is in flight. The ready future keeps
+            //    other arms reachable between sends.
+            _ = std::future::ready(()), if can_flush => {
+                let rpc = pending_outbound.pop_front().expect("guarded by can_flush");
+                keepalive.as_mut().reset(Instant::now() + keepalive_interval);
+                if let Err(err) = send_jsonrpc(&mut socket, rpc).await {
+                    error!(%err, "WS connection error");
+                    termination = Some(TerminationReason::Transient);
+                    break;
+                }
+            }
+
+            // 2. Inbound RPC from frontend → buffer. Always polled so a
+            //    `None` (shutdown / handle dropped) is seen promptly.
+            inst = interface.recv_from_frontend() => {
+                match inst {
+                    Some(rpc) => pending_outbound.push_back(rpc),
+                    None => break,
+                }
+            }
+
+            // 3. Pay task completion.
+            res = poll_join(&mut pending_pay), if pending_pay.is_some() => {
+                pending_pay = None;
+                match res {
+                    Ok(Ok(cred)) => {
+                        if let Err(reason) = send_credential(&mut socket, &cred, &events_tx, false).await {
+                            termination = Some(reason);
+                            break;
+                        }
+                        handshake_complete = true;
+                    }
+                    Ok(Err(err)) => {
+                        error!(?err, "MPP payment provider failed");
+                        let _ = events_tx.send(MppEvent::Error(format!(
+                            "{err}; not reconnecting"
+                        )));
+                        termination = Some(TerminationReason::Fatal);
+                        break;
+                    }
+                    Err(join_err) => {
+                        error!(%join_err, "MPP payment task panicked");
+                        let _ = events_tx.send(MppEvent::Error(format!(
+                            "payment task panicked: {join_err}; not reconnecting"
+                        )));
+                        termination = Some(TerminationReason::Fatal);
+                        break;
+                    }
+                }
+            }
+
+            // 4. Voucher task completion.
+            res = poll_join(&mut pending_voucher), if pending_voucher.is_some() => {
+                pending_voucher = None;
+                match res {
+                    Ok(Ok(cred)) => {
+                        if let Err(reason) = send_credential(&mut socket, &cred, &events_tx, true).await {
+                            termination = Some(reason);
+                            break;
+                        }
+                        handshake_complete = true;
+                    }
+                    Ok(Err(err)) => {
+                        error!(?err, "MPP voucher provider failed");
+                        let _ = events_tx.send(MppEvent::Error(format!(
+                            "{err}; not reconnecting"
+                        )));
+                        termination = Some(TerminationReason::Fatal);
+                        break;
+                    }
+                    Err(join_err) => {
+                        error!(%join_err, "MPP voucher task panicked");
+                        let _ = events_tx.send(MppEvent::Error(format!(
+                            "voucher task panicked: {join_err}; not reconnecting"
+                        )));
+                        termination = Some(TerminationReason::Fatal);
+                        break;
+                    }
+                }
+            }
+
+            // 5. Keepalive ping.
+            _ = &mut keepalive => {
+                if expecting_pong {
+                    error!("WS server missed a pong");
+                    termination = Some(TerminationReason::Transient);
+                    break;
+                }
+                keepalive.as_mut().reset(Instant::now() + keepalive_interval);
+                if let Err(err) = socket.send(Message::Ping(Default::default())).await {
+                    error!(%err, "WS connection error");
+                    termination = Some(TerminationReason::Transient);
+                    break;
+                }
+                expecting_pong = true;
+            }
+
+            // 6. Handshake / payment timeout. Only armed while not `frontend_open`.
+            _ = &mut handshake_deadline, if !frontend_open => {
+                error!("MPP handshake timed out");
+                let _ = events_tx.send(MppEvent::Error(
+                    "MPP handshake timed out; not reconnecting".to_string(),
+                ));
+                termination = Some(TerminationReason::Fatal);
+                break;
+            }
+
+            // 7. Inbound from socket → MPP frame.
+            resp = socket.next() => {
+                let pay_was_pending = pending_pay.is_some();
+                let voucher_was_pending = pending_voucher.is_some();
+                match resp {
+                    Some(Ok(item)) => {
+                        if item.is_pong() {
+                            expecting_pong = false;
+                        }
+                        match handle_message(
+                            item,
+                            &interface,
+                            &payment_provider,
+                            &voucher_provider,
+                            &receipt_tx,
+                            &events_tx,
+                            &mut pending_pay,
+                            &mut pending_voucher,
+                        ).await {
+                            Ok(()) => {
+                                // Reset the handshake deadline when a new
+                                // pay()/next_voucher() task is spawned.
+                                let entered_pay = !pay_was_pending && pending_pay.is_some();
+                                let entered_voucher =
+                                    !voucher_was_pending && pending_voucher.is_some();
+                                if entered_pay || entered_voucher {
+                                    handshake_deadline
+                                        .as_mut()
+                                        .reset(Instant::now() + handshake_timeout);
+                                }
+                            }
+                            Err(reason) => {
+                                termination = Some(reason);
+                                break;
+                            }
+                        }
+                    }
+                    Some(Err(err)) => {
+                        error!(%err, "WS connection error");
+                        termination = Some(TerminationReason::Transient);
+                        break;
+                    }
+                    None => {
+                        error!("WS server has gone away");
+                        termination = Some(TerminationReason::Transient);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Cancel any background tasks still running on shutdown.
+    if let Some(h) = pending_pay {
+        h.abort();
+    }
+    if let Some(h) = pending_voucher {
+        h.abort();
+    }
+
+    match termination {
+        Some(TerminationReason::Transient) => interface.close_with_error(),
+        Some(TerminationReason::Fatal) => {
+            // Latch so subsequent `connect()` calls short-circuit.
+            fatal.store(true, Ordering::Release);
+            interface.close_with_error();
+        }
+        None => {}
+    }
+}
+
+/// Wait on a possibly-`None` `JoinHandle`. Caller must guard with
+/// `pending.is_some()` in the surrounding `select!`.
+async fn poll_join<T>(pending: &mut Option<JoinHandle<T>>) -> Result<T, JoinError> {
+    pending
+        .as_mut()
+        .expect("guarded by select! `if` clause")
+        .await
+}
+
+async fn send_jsonrpc(socket: &mut WsStream, rpc: Box<RawValue>) -> Result<(), tungstenite::Error> {
+    // Parse the JSON-RPC envelope so it serializes back as a structured object
+    // (matching mpp-rs's `WsClientMessage::Data { data: serde_json::Value }`).
+    let data: serde_json::Value = serde_json::from_str(rpc.get())
+        .map_err(|e| tungstenite::Error::Io(std::io::Error::other(e)))?;
+    let frame = WsClientMessage::Data { data };
+    socket.send(Message::Text(frame.to_text().into())).await
+}
+
+async fn send_credential(
+    socket: &mut WsStream,
+    cred: &PaymentCredential,
+    events_tx: &broadcast::Sender<MppEvent>,
+    is_voucher: bool,
+) -> Result<(), TerminationReason> {
+    // Malformed credentials from the provider are deterministic; don't retry.
+    let auth = match format_authorization(cred) {
+        Ok(s) => s,
+        Err(err) => {
+            error!(?err, "failed to format MPP credential");
+            let _ = events_tx.send(MppEvent::Error(format!(
+                "failed to format MPP credential: {err}; not reconnecting"
+            )));
+            return Err(TerminationReason::Fatal);
+        }
+    };
+    // Socket errors are transient: a fresh socket yields a fresh challenge.
+    let frame = WsClientMessage::Credential { credential: auth };
+    if let Err(err) = socket.send(Message::Text(frame.to_text().into())).await {
+        error!(%err, "failed to send MPP credential");
+        return Err(TerminationReason::Transient);
+    }
+    let _ = events_tx.send(if is_voucher {
+        MppEvent::VoucherSent
+    } else {
+        MppEvent::CredentialSent
+    });
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_message<P: PaymentProvider + 'static, V: VoucherProvider>(
+    msg: Message,
+    interface: &ConnectionInterface,
+    payment_provider: &P,
+    voucher_provider: &V,
+    receipt_tx: &watch::Sender<Option<Receipt>>,
+    events_tx: &broadcast::Sender<MppEvent>,
+    pending_pay: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+    pending_voucher: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+) -> Result<(), TerminationReason> {
+    match msg {
+        Message::Text(text) => {
+            handle_text(
+                &text,
+                interface,
+                payment_provider,
+                voucher_provider,
+                receipt_tx,
+                events_tx,
+                pending_pay,
+                pending_voucher,
+            )
+            .await
+        }
+        Message::Close(frame) => {
+            error!(?frame, "Received WS close frame");
+            Err(TerminationReason::Transient)
+        }
+        Message::Binary(_) => {
+            error!("Received binary WS frame; expected text");
+            Err(TerminationReason::Fatal)
+        }
+        Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => Ok(()),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
+    text: &str,
+    interface: &ConnectionInterface,
+    payment_provider: &P,
+    voucher_provider: &V,
+    receipt_tx: &watch::Sender<Option<Receipt>>,
+    events_tx: &broadcast::Sender<MppEvent>,
+    pending_pay: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+    pending_voucher: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+) -> Result<(), TerminationReason> {
+    let server_msg: WsServerMessage = match serde_json::from_str(text) {
+        Ok(m) => m,
+        Err(err) => {
+            error!(%err, %text, "failed to deserialize MPP frame");
+            let _ = events_tx.send(MppEvent::Error(format!(
+                "malformed MPP frame: {err}; not reconnecting"
+            )));
+            return Err(TerminationReason::Fatal);
+        }
+    };
+
+    match server_msg {
+        WsServerMessage::Challenge { challenge, error } => {
+            if pending_pay.is_some() {
+                error!("server issued a second challenge while a payment was in flight; closing");
+                let _ = events_tx.send(MppEvent::Error(
+                    "server issued a second challenge while a payment was in flight; not \
+                     reconnecting"
+                        .to_string(),
+                ));
+                return Err(TerminationReason::Fatal);
+            }
+            if let Some(err) = error {
+                warn!(%err, "MPP challenge carried error message");
+            }
+            let parsed: PaymentChallenge = match serde_json::from_value(challenge) {
+                Ok(c) => c,
+                Err(err) => {
+                    error!(%err, "failed to deserialize PaymentChallenge");
+                    let _ = events_tx.send(MppEvent::Error(format!(
+                        "malformed PaymentChallenge: {err}; not reconnecting"
+                    )));
+                    return Err(TerminationReason::Fatal);
+                }
+            };
+            debug!(method = %parsed.method, intent = %parsed.intent, "MPP challenge received");
+            let _ = events_tx.send(MppEvent::Challenge(parsed.clone()));
+
+            // Skip `pay()` if the provider doesn't support (method, intent).
+            if !payment_provider.supports(parsed.method.as_str(), parsed.intent.as_str()) {
+                error!(method = %parsed.method, intent = %parsed.intent, "unsupported MPP challenge");
+                let _ = events_tx.send(MppEvent::Error(format!(
+                    "PaymentProvider does not support method={}, intent={}; not reconnecting",
+                    parsed.method, parsed.intent,
+                )));
+                return Err(TerminationReason::Fatal);
+            }
+
+            // Spawn `pay()` so the main loop stays responsive (keepalive,
+            // socket reads) while the provider signs/broadcasts.
+            let provider = payment_provider.clone();
+            *pending_pay = Some(tokio::spawn(async move { provider.pay(&parsed).await }));
+            Ok(())
+        }
+        WsServerMessage::Data { data } => {
+            // mpp-rs encodes the inner payload as a JSON-encoded string.
+            let item: PubSubItem = match serde_json::from_str(&data) {
+                Ok(i) => i,
+                Err(err) => {
+                    error!(%err, %data, "failed to deserialize JSON-RPC payload from MPP data frame");
+                    let _ = events_tx.send(MppEvent::Error(format!(
+                        "malformed MPP Data payload: {err}; not reconnecting"
+                    )));
+                    return Err(TerminationReason::Fatal);
+                }
+            };
+            interface.send_to_frontend(item).map_err(|err| {
+                error!(item=?err.0, "failed to forward to frontend");
+                TerminationReason::Fatal
+            })
+        }
+        WsServerMessage::NeedVoucher {
+            channel_id,
+            required_cumulative,
+            accepted_cumulative,
+            deposit,
+        } => {
+            if pending_voucher.is_some() {
+                error!("server issued a second NeedVoucher while a voucher was in flight; closing");
+                let _ = events_tx.send(MppEvent::Error(
+                    "server issued a second NeedVoucher while a voucher was in flight; not \
+                     reconnecting"
+                        .to_string(),
+                ));
+                return Err(TerminationReason::Fatal);
+            }
+            let req = VoucherRequest {
+                channel_id,
+                required_cumulative,
+                accepted_cumulative,
+                deposit,
+            };
+            debug!(?req, "MPP needVoucher received");
+            let _ = events_tx.send(MppEvent::NeedVoucher(req.clone()));
+
+            let provider = voucher_provider.clone();
+            *pending_voucher = Some(tokio::spawn(
+                async move { provider.next_voucher(&req).await },
+            ));
+            Ok(())
+        }
+        WsServerMessage::Receipt { receipt } => {
+            let parsed: Receipt = match serde_json::from_value(receipt) {
+                Ok(r) => r,
+                Err(err) => {
+                    error!(%err, "failed to deserialize Receipt");
+                    let _ = events_tx.send(MppEvent::Error(format!(
+                        "malformed Receipt: {err}; not reconnecting"
+                    )));
+                    return Err(TerminationReason::Fatal);
+                }
+            };
+            debug!(?parsed, "MPP receipt received");
+            let _ = receipt_tx.send(Some(parsed.clone()));
+            let _ = events_tx.send(MppEvent::Receipt(parsed));
+            Ok(())
+        }
+        WsServerMessage::Error { error } => {
+            error!(%error, "MPP error frame");
+            let _ = events_tx.send(MppEvent::Error(error));
+            Err(TerminationReason::Fatal)
+        }
+    }
+}
+
+#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+fn install_default_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return;
+    }
+    #[cfg(feature = "aws-lc-rs")]
+    let provider = rustls::crypto::aws_lc_rs::default_provider();
+    #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+    let provider = rustls::crypto::ring::default_provider();
+    let _ = rustls::crypto::CryptoProvider::install_default(provider);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpp::PaymentPayload;
+
+    #[derive(Clone)]
+    struct DummyProvider;
+    impl PaymentProvider for DummyProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            false
+        }
+        async fn pay(&self, ch: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            Ok(PaymentCredential::new(
+                ch.to_echo(),
+                PaymentPayload::hash("0x00"),
+            ))
+        }
+    }
+
+    #[test]
+    fn into_client_request_sets_auth_header() {
+        let connect = MppWsConnect::new("ws://example.com/rpc", DummyProvider)
+            .with_auth(Authorization::bearer("tok"));
+        let req = connect.into_client_request().unwrap();
+        let v = req.headers().get(AUTHORIZATION).unwrap();
+        assert_eq!(v.to_str().unwrap(), "Bearer tok");
+    }
+
+    #[test]
+    fn is_local_heuristic() {
+        assert!(MppWsConnect::new("ws://localhost:8545", DummyProvider).is_local());
+        assert!(MppWsConnect::new("ws://127.0.0.1:8545", DummyProvider).is_local());
+        assert!(!MppWsConnect::new("wss://eth.example/rpc", DummyProvider).is_local());
+    }
+
+    #[test]
+    fn mpp_handle_initial_state() {
+        let connect = MppWsConnect::new("ws://localhost", DummyProvider);
+        let handle = connect.mpp_handle();
+        assert!(handle.receipt.borrow().is_none());
+        // Multiple subscribers are independent.
+        let _other = connect.mpp_handle();
+    }
+
+    #[tokio::test]
+    async fn no_voucher_returns_error() {
+        let req = VoucherRequest {
+            channel_id: "0xabc".into(),
+            required_cumulative: "100".into(),
+            accepted_cumulative: "50".into(),
+            deposit: "200".into(),
+        };
+        assert!(NoVoucher.next_voucher(&req).await.is_err());
+    }
+
+    #[test]
+    fn with_voucher_provider_swaps_v_type() {
+        // Compile-time assertion that the type parameter changes as advertised.
+        #[derive(Clone)]
+        struct V;
+        impl VoucherProvider for V {
+            async fn next_voucher(
+                &self,
+                _: &VoucherRequest,
+            ) -> Result<PaymentCredential, MppError> {
+                Err(MppError::bad_request("never"))
+            }
+        }
+        let connect: MppWsConnect<DummyProvider, V> =
+            MppWsConnect::new("ws://localhost", DummyProvider).with_voucher_provider(V);
+        // The connector remains usable.
+        assert!(connect.is_local());
+    }
+
+    #[test]
+    fn new_extracts_basic_auth_from_url_userinfo() {
+        let connect = MppWsConnect::new("ws://alice:secret@example.com/rpc", DummyProvider);
+        let req = connect.into_client_request().unwrap();
+        let v = req.headers().get(AUTHORIZATION).expect("auth header set");
+        // The exact base64 of "alice:secret" is fixed.
+        assert_eq!(v.to_str().unwrap(), "Basic YWxpY2U6c2VjcmV0");
+    }
+
+    #[test]
+    fn new_without_userinfo_has_no_auth_header() {
+        let connect = MppWsConnect::new("ws://example.com/rpc", DummyProvider);
+        let req = connect.into_client_request().unwrap();
+        assert!(req.headers().get(AUTHORIZATION).is_none());
+    }
+
+    #[test]
+    fn with_auth_overrides_url_extracted_auth() {
+        // URL has userinfo, but explicit `with_auth` should win.
+        let connect = MppWsConnect::new("ws://alice:secret@example.com/rpc", DummyProvider)
+            .with_auth(Authorization::bearer("override"));
+        let req = connect.into_client_request().unwrap();
+        let v = req.headers().get(AUTHORIZATION).unwrap();
+        assert_eq!(v.to_str().unwrap(), "Bearer override");
+    }
+
+    #[test]
+    fn url_accessor_returns_configured_url() {
+        let connect = MppWsConnect::new("ws://example.com/rpc", DummyProvider);
+        assert_eq!(connect.url(), "ws://example.com/rpc");
+    }
+
+    #[test]
+    fn is_local_handles_more_url_shapes() {
+        // Path-only does not change the locality of the host.
+        assert!(MppWsConnect::new("ws://localhost/rpc", DummyProvider).is_local());
+        assert!(MppWsConnect::new("ws://127.0.0.1:8545/v1/ws", DummyProvider).is_local());
+        // Public hosts and TLS schemes are not local.
+        assert!(!MppWsConnect::new("ws://eth.example.com", DummyProvider).is_local());
+        assert!(!MppWsConnect::new("wss://eth.example.com:8545/rpc", DummyProvider).is_local());
+        // 0.0.0.0 is *not* treated as local by the upstream heuristic, despite
+        // being a bind-any address; pin this behavior to catch surprises.
+        assert!(!MppWsConnect::new("ws://0.0.0.0:8545", DummyProvider).is_local());
+    }
+
+    #[test]
+    fn mpp_handle_multiple_subscribers_are_independent() {
+        let connect = MppWsConnect::new("ws://localhost", DummyProvider);
+        let h1 = connect.mpp_handle();
+        let h2 = connect.mpp_handle();
+        // Both watchers see the initial empty state.
+        assert!(h1.receipt.borrow().is_none());
+        assert!(h2.receipt.borrow().is_none());
+        // Two independent receivers exist; sender count is 1 (the connector's tx).
+        assert_eq!(connect.events_tx.receiver_count(), 2);
+    }
+
+    #[test]
+    fn debug_redacts_url_userinfo_and_auth() {
+        let connect = MppWsConnect::new("wss://alice:supersecret@example.com/rpc", DummyProvider)
+            .with_auth(Authorization::bearer("token-xyz"));
+        let s = format!("{connect:?}");
+        assert!(!s.contains("supersecret"), "password leaked: {s}");
+        assert!(!s.contains("alice"), "username leaked: {s}");
+        assert!(!s.contains("token-xyz"), "bearer token leaked: {s}");
+        assert!(s.contains("<redacted>"), "auth not marked redacted: {s}");
+        assert!(s.contains("example.com"), "host should remain: {s}");
+    }
+
+    #[test]
+    fn builder_setters_apply() {
+        // Ensure the const builder methods chain cleanly. Field correctness
+        // is covered indirectly by the integration tests; here we just assert
+        // the type compiles and is usable across all setters.
+        let cfg = WebSocketConfig::default();
+        let connect = MppWsConnect::new("ws://localhost:8545", DummyProvider)
+            .with_config(cfg)
+            .with_max_retries(7)
+            .with_retry_interval(Duration::from_millis(250))
+            .with_keepalive_interval(Duration::from_millis(500))
+            .with_auth(Authorization::raw("custom-token"));
+        // Round-trips through IntoClientRequest with the explicit auth header.
+        let req = connect.into_client_request().unwrap();
+        let v = req.headers().get(AUTHORIZATION).unwrap();
+        assert_eq!(v.to_str().unwrap(), "custom-token");
+    }
+}

--- a/crates/alloy-transport-mpp/tests/ws_integration.rs
+++ b/crates/alloy-transport-mpp/tests/ws_integration.rs
@@ -12,19 +12,21 @@ use mpp::{
     client::PaymentProvider, protocol::core::Base64UrlJson, MppError, PaymentChallenge,
     PaymentCredential, PaymentPayload, Receipt,
 };
+use serde_json::{from_str as json_from_str, json, to_value as json_to_value, Value};
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::Notify,
+    spawn,
+    sync::{broadcast::Receiver as BroadcastReceiver, oneshot, Notify},
     time::{sleep, timeout},
 };
-use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
+use tokio_tungstenite::{accept_async, tungstenite::Message, WebSocketStream};
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -62,7 +64,7 @@ fn test_challenge() -> PaymentChallenge {
         "alloy-test",
         "tempo",
         "charge",
-        Base64UrlJson::from_value(&serde_json::json!({"amount":"1000","currency":"USD"})).unwrap(),
+        Base64UrlJson::from_value(&json!({"amount":"1000","currency":"USD"})).unwrap(),
     )
 }
 
@@ -74,37 +76,37 @@ where
 {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
-    tokio::spawn(async move {
+    spawn(async move {
         let (stream, _) = listener.accept().await.unwrap();
-        let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        let ws = accept_async(stream).await.unwrap();
         script(ws).await;
     });
     format!("ws://127.0.0.1:{port}")
 }
 
-async fn send_text(ws: &mut ServerStream, value: serde_json::Value) {
+async fn send_text(ws: &mut ServerStream, value: Value) {
     ws.send(Message::Text(value.to_string().into()))
         .await
         .unwrap();
 }
 
-async fn recv_value(ws: &mut ServerStream) -> serde_json::Value {
+async fn recv_value(ws: &mut ServerStream) -> Value {
     let msg = ws.next().await.unwrap().unwrap();
     let text = msg.into_text().unwrap();
-    serde_json::from_str(&text).unwrap()
+    json_from_str(&text).unwrap()
 }
 
-fn challenge_frame() -> serde_json::Value {
-    serde_json::json!({
+fn challenge_frame() -> Value {
+    json!({
         "type": "challenge",
-        "challenge": serde_json::to_value(test_challenge()).unwrap(),
+        "challenge": json_to_value(test_challenge()).unwrap(),
         "error": null,
     })
 }
 
-fn receipt_frame() -> serde_json::Value {
+fn receipt_frame() -> Value {
     let receipt = Receipt::success("tempo", "0xreference");
-    serde_json::json!({ "type": "receipt", "receipt": receipt })
+    json!({ "type": "receipt", "receipt": receipt })
 }
 
 #[tokio::test]
@@ -169,7 +171,7 @@ async fn json_rpc_round_trips_through_mpp_message_envelope() {
             let id = inner["id"].clone();
 
             // Echo back a wrapped JSON-RPC response.
-            let response = serde_json::json!({
+            let response = json!({
                 "jsonrpc": "2.0",
                 "id": id,
                 "result": "0x1234",
@@ -177,7 +179,7 @@ async fn json_rpc_round_trips_through_mpp_message_envelope() {
             // mpp-rs's WsServerMessage::Data has data: String (JSON-encoded).
             send_text(
                 &mut ws,
-                serde_json::json!({ "type": "message", "data": response.to_string() }),
+                json!({ "type": "message", "data": response.to_string() }),
             )
             .await;
             sleep(Duration::from_millis(100)).await;
@@ -205,7 +207,7 @@ async fn need_voucher_with_provider_emits_voucher_credential() {
             let _ = recv_value(&mut ws).await;
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "needVoucher",
                     "channelId": "0xchannel",
                     "requiredCumulative": "2000",
@@ -245,7 +247,7 @@ async fn need_voucher_without_provider_surfaces_error_event() {
             let _ = recv_value(&mut ws).await;
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "needVoucher",
                     "channelId": "0xchannel",
                     "requiredCumulative": "2000",
@@ -361,7 +363,7 @@ async fn duplicate_need_voucher_closes_connection() {
         }
     }
 
-    let voucher_frame = serde_json::json!({
+    let voucher_frame = json!({
         "type": "needVoucher",
         "channelId": "0xchannel",
         "requiredCumulative": "2000",
@@ -470,7 +472,7 @@ async fn voucher_provider_error_surfaces_event_and_closes() {
             let _ = recv_value(&mut ws).await;
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "needVoucher",
                     "channelId": "0xchannel",
                     "requiredCumulative": "2000",
@@ -514,14 +516,14 @@ async fn multiple_json_rpc_requests_round_trip_in_session() {
                 assert_eq!(outbound["type"], "message");
                 let inner = &outbound["data"];
                 let id = inner["id"].clone();
-                let response = serde_json::json!({
+                let response = json!({
                     "jsonrpc": "2.0",
                     "id": id,
                     "result": format!("0x{}", id),
                 });
                 send_text(
                     &mut ws,
-                    serde_json::json!({ "type": "message", "data": response.to_string() }),
+                    json!({ "type": "message", "data": response.to_string() }),
                 )
                 .await;
             }
@@ -566,14 +568,14 @@ async fn request_buffered_until_handshake_completes() {
             let second = recv_value(&mut ws).await;
             assert_eq!(second["type"], "message");
             let id = second["data"]["id"].clone();
-            let response = serde_json::json!({
+            let response = json!({
                 "jsonrpc": "2.0",
                 "id": id,
                 "result": "0xqueued",
             });
             send_text(
                 &mut ws,
-                serde_json::json!({ "type": "message", "data": response.to_string() }),
+                json!({ "type": "message", "data": response.to_string() }),
             )
             .await;
             sleep(Duration::from_millis(50)).await;
@@ -704,7 +706,7 @@ async fn malformed_challenge_closes_connection() {
         Box::pin(async move {
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "challenge",
                     "challenge": "not-an-object",
                     "error": null,
@@ -745,7 +747,7 @@ async fn malformed_data_payload_closes_connection() {
             let _ = recv_value(&mut ws).await;
             send_text(
                 &mut ws,
-                serde_json::json!({ "type": "message", "data": "not json at all" }),
+                json!({ "type": "message", "data": "not json at all" }),
             )
             .await;
             let _ = ws.next().await;
@@ -781,7 +783,7 @@ async fn multiple_receipts_update_watch_channel() {
             // Two distinct receipts back-to-back.
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "receipt",
                     "receipt": Receipt::success("tempo", "0xfirst"),
                 }),
@@ -789,7 +791,7 @@ async fn multiple_receipts_update_watch_channel() {
             .await;
             send_text(
                 &mut ws,
-                serde_json::json!({
+                json!({
                     "type": "receipt",
                     "receipt": Receipt::success("tempo", "0xsecond"),
                 }),
@@ -857,7 +859,7 @@ async fn multiple_event_subscribers_each_receive_handshake() {
     let mut h2 = connect.mpp_handle();
     let _conn = connect.connect().await.unwrap();
 
-    async fn drain_until_receipt(rx: &mut tokio::sync::broadcast::Receiver<MppEvent>) -> bool {
+    async fn drain_until_receipt(rx: &mut BroadcastReceiver<MppEvent>) -> bool {
         let mut saw_challenge = false;
         let mut saw_credential = false;
         let mut saw_receipt = false;
@@ -883,11 +885,7 @@ async fn multiple_event_subscribers_each_receive_handshake() {
 async fn server_error_frame_surfaces_event_and_closes() {
     let url = spawn_server(|mut ws| {
         Box::pin(async move {
-            send_text(
-                &mut ws,
-                serde_json::json!({ "type": "error", "error": "bad request" }),
-            )
-            .await;
+            send_text(&mut ws, json!({ "type": "error", "error": "bad request" })).await;
             sleep(Duration::from_millis(50)).await;
         })
     })
@@ -998,15 +996,15 @@ async fn fatal_provider_error_does_not_re_invoke_pay() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let accepts_srv = accepts.clone();
-    tokio::spawn(async move {
+    spawn(async move {
         loop {
             let (stream, _) = match listener.accept().await {
                 Ok(p) => p,
                 Err(_) => return,
             };
             accepts_srv.fetch_add(1, Ordering::SeqCst);
-            tokio::spawn(async move {
-                if let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await {
+            spawn(async move {
+                if let Ok(mut ws) = accept_async(stream).await {
                     send_text(&mut ws, challenge_frame()).await;
                     let _ = timeout(Duration::from_millis(200), ws.next()).await;
                 }
@@ -1056,7 +1054,7 @@ async fn shutdown_during_in_flight_payment_breaks_promptly() {
     }
 
     // Server signals once the client closes the WS.
-    let (client_gone_tx, client_gone_rx) = tokio::sync::oneshot::channel::<()>();
+    let (client_gone_tx, client_gone_rx) = oneshot::channel::<()>();
     let url = spawn_server(move |mut ws| {
         Box::pin(async move {
             send_text(&mut ws, challenge_frame()).await;
@@ -1083,7 +1081,7 @@ async fn shutdown_during_in_flight_payment_breaks_promptly() {
         .unwrap();
     assert!(matches!(ev, MppEvent::Challenge(_)));
 
-    let start = std::time::Instant::now();
+    let start = Instant::now();
     drop(conn);
 
     timeout(Duration::from_secs(2), client_gone_rx)

--- a/crates/alloy-transport-mpp/tests/ws_integration.rs
+++ b/crates/alloy-transport-mpp/tests/ws_integration.rs
@@ -1,0 +1,1101 @@
+//! Integration tests for `alloy_transport_mpp` against a tiny in-process MPP
+//! WebSocket server.
+//!
+//! Each test spawns a dedicated server on `127.0.0.1:0` that scripts a
+//! sequence of MPP frames and asserts the client's responses.
+
+use alloy_json_rpc::{Id, Request};
+use alloy_pubsub::PubSubConnect;
+use alloy_transport_mpp::{MppEvent, MppWsConnect, VoucherProvider, VoucherRequest};
+use futures::{future::BoxFuture, SinkExt, StreamExt};
+use mpp::{
+    client::PaymentProvider, protocol::core::Base64UrlJson, MppError, PaymentChallenge,
+    PaymentCredential, PaymentPayload, Receipt,
+};
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::Notify,
+    time::{sleep, timeout},
+};
+use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+struct StubProvider;
+
+impl PaymentProvider for StubProvider {
+    fn supports(&self, _: &str, _: &str) -> bool {
+        true
+    }
+    async fn pay(&self, ch: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            ch.to_echo(),
+            PaymentPayload::hash("0xdeadbeef"),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct StubVoucherProvider;
+
+impl VoucherProvider for StubVoucherProvider {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        let ch = test_challenge();
+        Ok(PaymentCredential::new(
+            ch.to_echo(),
+            PaymentPayload::hash("0xvoucher"),
+        ))
+    }
+}
+
+fn test_challenge() -> PaymentChallenge {
+    PaymentChallenge::new(
+        "test-id",
+        "alloy-test",
+        "tempo",
+        "charge",
+        Base64UrlJson::from_value(&serde_json::json!({"amount":"1000","currency":"USD"})).unwrap(),
+    )
+}
+
+type ServerStream = WebSocketStream<TcpStream>;
+
+async fn spawn_server<F>(script: F) -> String
+where
+    F: FnOnce(ServerStream) -> BoxFuture<'static, ()> + Send + 'static,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+        script(ws).await;
+    });
+    format!("ws://127.0.0.1:{port}")
+}
+
+async fn send_text(ws: &mut ServerStream, value: serde_json::Value) {
+    ws.send(Message::Text(value.to_string().into()))
+        .await
+        .unwrap();
+}
+
+async fn recv_value(ws: &mut ServerStream) -> serde_json::Value {
+    let msg = ws.next().await.unwrap().unwrap();
+    let text = msg.into_text().unwrap();
+    serde_json::from_str(&text).unwrap()
+}
+
+fn challenge_frame() -> serde_json::Value {
+    serde_json::json!({
+        "type": "challenge",
+        "challenge": serde_json::to_value(test_challenge()).unwrap(),
+        "error": null,
+    })
+}
+
+fn receipt_frame() -> serde_json::Value {
+    let receipt = Receipt::success("tempo", "0xreference");
+    serde_json::json!({ "type": "receipt", "receipt": receipt })
+}
+
+#[tokio::test]
+async fn handshake_emits_challenge_credential_and_receipt_events() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let cred = recv_value(&mut ws).await;
+            assert_eq!(cred["type"], "credential");
+            assert!(cred["credential"].as_str().unwrap().starts_with("Payment "));
+            send_text(&mut ws, receipt_frame()).await;
+            // Hold the connection open briefly so the client can observe.
+            sleep(Duration::from_millis(100)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    // Receipt watch updates.
+    timeout(TIMEOUT, handle.receipt.changed())
+        .await
+        .unwrap()
+        .unwrap();
+    let r = handle.receipt.borrow().clone().expect("receipt set");
+    assert_eq!(r.reference, "0xreference");
+    assert_eq!(r.method.as_str(), "tempo");
+
+    // Events stream sees the full handshake in order.
+    let e1 = timeout(TIMEOUT, handle.events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(e1, MppEvent::Challenge(_)));
+    let e2 = timeout(TIMEOUT, handle.events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(e2, MppEvent::CredentialSent));
+    let e3 = timeout(TIMEOUT, handle.events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(e3, MppEvent::Receipt(_)));
+}
+
+#[tokio::test]
+async fn json_rpc_round_trips_through_mpp_message_envelope() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Handshake.
+            send_text(&mut ws, challenge_frame()).await;
+            let _cred = recv_value(&mut ws).await;
+
+            // Receive the wrapped JSON-RPC request.
+            let outbound = recv_value(&mut ws).await;
+            assert_eq!(outbound["type"], "message");
+            let inner = &outbound["data"];
+            assert_eq!(inner["method"], "eth_blockNumber");
+            let id = inner["id"].clone();
+
+            // Echo back a wrapped JSON-RPC response.
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": "0x1234",
+            });
+            // mpp-rs's WsServerMessage::Data has data: String (JSON-encoded).
+            send_text(
+                &mut ws,
+                serde_json::json!({ "type": "message", "data": response.to_string() }),
+            )
+            .await;
+            sleep(Duration::from_millis(100)).await;
+        })
+    })
+    .await;
+
+    let frontend = MppWsConnect::new(url, StubProvider)
+        .into_service()
+        .await
+        .unwrap();
+    let req = Request::new("eth_blockNumber", Id::Number(1), ())
+        .serialize()
+        .unwrap();
+    let resp = timeout(TIMEOUT, frontend.send(req)).await.unwrap().unwrap();
+    let payload = resp.payload.as_success().unwrap();
+    assert_eq!(payload.get(), "\"0x1234\"");
+}
+
+#[tokio::test]
+async fn need_voucher_with_provider_emits_voucher_credential() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "needVoucher",
+                    "channelId": "0xchannel",
+                    "requiredCumulative": "2000",
+                    "acceptedCumulative": "1000",
+                    "deposit": "5000",
+                }),
+            )
+            .await;
+            // Expect a second credential frame in response.
+            let cred = recv_value(&mut ws).await;
+            assert_eq!(cred["type"], "credential");
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider).with_voucher_provider(StubVoucherProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    // Drain events until we see VoucherSent.
+    let mut saw_voucher = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::VoucherSent = ev {
+            saw_voucher = true;
+            break;
+        }
+    }
+    assert!(saw_voucher, "expected VoucherSent event");
+}
+
+#[tokio::test]
+async fn need_voucher_without_provider_surfaces_error_event() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "needVoucher",
+                    "channelId": "0xchannel",
+                    "requiredCumulative": "2000",
+                    "acceptedCumulative": "1000",
+                    "deposit": "5000",
+                }),
+            )
+            .await;
+            // Translator should error and close; absorb the close.
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    // Default voucher provider = NoVoucher.
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut saw_error = false;
+    let mut saw_need_voucher = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        match ev {
+            MppEvent::NeedVoucher(_) => saw_need_voucher = true,
+            MppEvent::Error(_) => {
+                saw_error = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(saw_need_voucher, "expected NeedVoucher event");
+    assert!(
+        saw_error,
+        "expected Error event when NoVoucher provider rejects"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_challenge_or_voucher_closes_connection() {
+    // Test (a): two Challenge frames back-to-back before the first pay completes.
+    // The provider blocks until released so the second Challenge arrives while
+    // the first JoinHandle is still pending.
+    #[derive(Clone)]
+    struct BlockingProvider(Arc<Notify>);
+    impl PaymentProvider for BlockingProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            true
+        }
+        async fn pay(&self, ch: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.0.notified().await;
+            Ok(PaymentCredential::new(
+                ch.to_echo(),
+                PaymentPayload::hash("0xfeedface"),
+            ))
+        }
+    }
+
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            send_text(&mut ws, challenge_frame()).await;
+            // Drain whatever the client sends until the socket dies.
+            while let Some(msg) = ws.next().await {
+                if msg.is_err() {
+                    break;
+                }
+            }
+        })
+    })
+    .await;
+
+    let release = Arc::new(Notify::new());
+    let connect = MppWsConnect::new(url, BlockingProvider(release.clone()));
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    // Drop the connector so its `events_tx` sender clone goes away — the
+    // broadcast channel only closes once *all* senders are gone.
+    drop(connect);
+
+    // The translator should close because the second Challenge is duplicate.
+    // The pending pay task is aborted on shutdown — release the latch so it
+    // doesn't hold the test open if abort racy.
+    release.notify_waiters();
+
+    // Receiver should eventually close (RecvError::Closed) once the translator exits.
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(closed, "translator should close after duplicate Challenge");
+}
+
+#[tokio::test]
+async fn duplicate_need_voucher_closes_connection() {
+    #[derive(Clone)]
+    struct BlockingVoucher(Arc<Notify>);
+    impl VoucherProvider for BlockingVoucher {
+        async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+            self.0.notified().await;
+            let ch = test_challenge();
+            Ok(PaymentCredential::new(
+                ch.to_echo(),
+                PaymentPayload::hash("0xvoucher"),
+            ))
+        }
+    }
+
+    let voucher_frame = serde_json::json!({
+        "type": "needVoucher",
+        "channelId": "0xchannel",
+        "requiredCumulative": "2000",
+        "acceptedCumulative": "1000",
+        "deposit": "5000",
+    });
+
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Complete the initial challenge handshake.
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            // Two needVoucher frames back-to-back.
+            send_text(&mut ws, voucher_frame.clone()).await;
+            send_text(&mut ws, voucher_frame).await;
+            while let Some(msg) = ws.next().await {
+                if msg.is_err() {
+                    break;
+                }
+            }
+        })
+    })
+    .await;
+
+    let release = Arc::new(Notify::new());
+    let connect = MppWsConnect::new(url, StubProvider)
+        .with_voucher_provider(BlockingVoucher(release.clone()));
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    drop(connect);
+
+    release.notify_waiters();
+
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(
+        closed,
+        "translator should close after duplicate NeedVoucher"
+    );
+}
+
+#[tokio::test]
+async fn payment_provider_error_surfaces_event_and_closes() {
+    // The provider rejects the challenge with an error; the translator must
+    // surface it as MppEvent::Error and close.
+    #[derive(Clone)]
+    struct FailingProvider;
+    impl PaymentProvider for FailingProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            true
+        }
+        async fn pay(&self, _: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            Err(MppError::bad_request("nope"))
+        }
+    }
+
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            // Client should NOT send a credential; just absorb whatever ends the conn.
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, FailingProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut saw_error = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::Error(s) = ev {
+            assert!(s.contains("nope") || !s.is_empty());
+            saw_error = true;
+            break;
+        }
+    }
+    assert!(
+        saw_error,
+        "expected Error event when payment provider returns Err"
+    );
+}
+
+#[tokio::test]
+async fn voucher_provider_error_surfaces_event_and_closes() {
+    #[derive(Clone)]
+    struct FailingVoucher;
+    impl VoucherProvider for FailingVoucher {
+        async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+            Err(MppError::bad_request("voucher unavailable"))
+        }
+    }
+
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "needVoucher",
+                    "channelId": "0xchannel",
+                    "requiredCumulative": "2000",
+                    "acceptedCumulative": "1000",
+                    "deposit": "5000",
+                }),
+            )
+            .await;
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider).with_voucher_provider(FailingVoucher);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut saw_error = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::Error(_) = ev {
+            saw_error = true;
+            break;
+        }
+    }
+    assert!(
+        saw_error,
+        "expected Error event when voucher provider returns Err"
+    );
+}
+
+#[tokio::test]
+async fn multiple_json_rpc_requests_round_trip_in_session() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Handshake.
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            // Echo back a fixed result for each incoming request.
+            for _ in 0..3 {
+                let outbound = recv_value(&mut ws).await;
+                assert_eq!(outbound["type"], "message");
+                let inner = &outbound["data"];
+                let id = inner["id"].clone();
+                let response = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": format!("0x{}", id),
+                });
+                send_text(
+                    &mut ws,
+                    serde_json::json!({ "type": "message", "data": response.to_string() }),
+                )
+                .await;
+            }
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let frontend = MppWsConnect::new(url, StubProvider)
+        .into_service()
+        .await
+        .unwrap();
+    for i in 1..=3u64 {
+        let req = Request::new("eth_blockNumber", Id::Number(i), ())
+            .serialize()
+            .unwrap();
+        let resp = timeout(TIMEOUT, frontend.send(req)).await.unwrap().unwrap();
+        let payload = resp.payload.as_success().unwrap();
+        assert_eq!(payload.get(), &format!("\"0x{i}\""));
+    }
+}
+
+#[tokio::test]
+async fn request_buffered_until_handshake_completes() {
+    // Verifies that an RPC issued before the challenge arrives is held in
+    // the frontend channel and only flushed once the credential is sent.
+    // Server-side ordering of reads guarantees the property: credential
+    // MUST come before the wrapped JSON-RPC `message`.
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Delay so the client has time to push the RPC into the channel
+            // before the challenge is even on the wire.
+            sleep(Duration::from_millis(150)).await;
+            send_text(&mut ws, challenge_frame()).await;
+
+            // The very first frame from the client must be the credential,
+            // not the queued JSON-RPC message.
+            let first = recv_value(&mut ws).await;
+            assert_eq!(first["type"], "credential");
+
+            // The next frame is the buffered JSON-RPC request.
+            let second = recv_value(&mut ws).await;
+            assert_eq!(second["type"], "message");
+            let id = second["data"]["id"].clone();
+            let response = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": "0xqueued",
+            });
+            send_text(
+                &mut ws,
+                serde_json::json!({ "type": "message", "data": response.to_string() }),
+            )
+            .await;
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let frontend = MppWsConnect::new(url, StubProvider)
+        .into_service()
+        .await
+        .unwrap();
+    let req = Request::new("eth_blockNumber", Id::Number(1), ())
+        .serialize()
+        .unwrap();
+    let resp = timeout(TIMEOUT, frontend.send(req)).await.unwrap().unwrap();
+    let payload = resp.payload.as_success().unwrap();
+    assert_eq!(payload.get(), "\"0xqueued\"");
+}
+
+#[tokio::test]
+async fn re_challenge_mid_session_pays_again() {
+    // Server sends two challenges (with a gap so the first pay completes
+    // before the second arrives) and expects two credentials.
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let first = recv_value(&mut ws).await;
+            assert_eq!(first["type"], "credential");
+            // Brief gap so `pending_pay` is None when the next challenge lands.
+            sleep(Duration::from_millis(50)).await;
+            send_text(&mut ws, challenge_frame()).await;
+            let second = recv_value(&mut ws).await;
+            assert_eq!(second["type"], "credential");
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut challenges = 0;
+    let mut credentials_sent = 0;
+    while let Ok(Ok(ev)) = timeout(Duration::from_millis(800), handle.events.recv()).await {
+        match ev {
+            MppEvent::Challenge(_) => challenges += 1,
+            MppEvent::CredentialSent => credentials_sent += 1,
+            _ => {}
+        }
+        if challenges == 2 && credentials_sent == 2 {
+            break;
+        }
+    }
+    assert_eq!(challenges, 2, "expected two challenges");
+    assert_eq!(credentials_sent, 2, "expected two credentials sent");
+}
+
+#[tokio::test]
+async fn server_close_frame_closes_connection() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Send a Close frame straight away.
+            ws.close(None).await.ok();
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    drop(connect);
+
+    // Translator should exit; eventually the events channel closes once the
+    // last sender (the translator's clone) is dropped.
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(closed, "translator should close after server Close frame");
+}
+
+#[tokio::test]
+async fn binary_frame_closes_connection() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Send an unsolicited binary frame; translator only handles text.
+            ws.send(Message::Binary(vec![0xde, 0xad, 0xbe, 0xef].into()))
+                .await
+                .unwrap();
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    drop(connect);
+
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(closed, "translator should close on binary frame");
+}
+
+#[tokio::test]
+async fn malformed_challenge_closes_connection() {
+    // The outer envelope is valid, but the inner `challenge` payload cannot
+    // be deserialized into a PaymentChallenge.
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "challenge",
+                    "challenge": "not-an-object",
+                    "error": null,
+                }),
+            )
+            .await;
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    drop(connect);
+
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(closed, "translator should close on malformed challenge");
+}
+
+#[tokio::test]
+async fn malformed_data_payload_closes_connection() {
+    // Handshake completes, then server sends a Data frame whose inner
+    // payload is not valid JSON-RPC. The translator must close.
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            send_text(
+                &mut ws,
+                serde_json::json!({ "type": "message", "data": "not json at all" }),
+            )
+            .await;
+            let _ = ws.next().await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+    drop(connect);
+
+    let mut closed = false;
+    for _ in 0..50 {
+        match timeout(Duration::from_millis(100), handle.events.recv()).await {
+            Ok(Err(_)) => {
+                closed = true;
+                break;
+            }
+            Ok(Ok(_)) => continue,
+            Err(_) => continue,
+        }
+    }
+    assert!(closed, "translator should close on malformed Data payload");
+}
+
+#[tokio::test]
+async fn multiple_receipts_update_watch_channel() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            // Two distinct receipts back-to-back.
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "receipt",
+                    "receipt": Receipt::success("tempo", "0xfirst"),
+                }),
+            )
+            .await;
+            send_text(
+                &mut ws,
+                serde_json::json!({
+                    "type": "receipt",
+                    "receipt": Receipt::success("tempo", "0xsecond"),
+                }),
+            )
+            .await;
+            sleep(Duration::from_millis(100)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    // The broadcast event channel sees one event per receipt — collect both.
+    let mut refs = Vec::new();
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::Receipt(r) = ev {
+            refs.push(r.reference);
+            if refs.len() == 2 {
+                break;
+            }
+        }
+    }
+    assert_eq!(refs, vec!["0xfirst".to_string(), "0xsecond".to_string()]);
+
+    // The watch channel collapses to the most recent value; assert it
+    // converges on the second receipt (may already be there).
+    if handle
+        .receipt
+        .borrow()
+        .as_ref()
+        .map(|r| r.reference.as_str())
+        != Some("0xsecond")
+    {
+        timeout(TIMEOUT, handle.receipt.changed())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+    let latest = handle
+        .receipt
+        .borrow()
+        .as_ref()
+        .expect("latest receipt")
+        .reference
+        .clone();
+    assert_eq!(latest, "0xsecond");
+}
+
+#[tokio::test]
+async fn multiple_event_subscribers_each_receive_handshake() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            let _ = recv_value(&mut ws).await;
+            send_text(&mut ws, receipt_frame()).await;
+            sleep(Duration::from_millis(100)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut h1 = connect.mpp_handle();
+    let mut h2 = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    async fn drain_until_receipt(rx: &mut tokio::sync::broadcast::Receiver<MppEvent>) -> bool {
+        let mut saw_challenge = false;
+        let mut saw_credential = false;
+        let mut saw_receipt = false;
+        while let Ok(Ok(ev)) = timeout(TIMEOUT, rx.recv()).await {
+            match ev {
+                MppEvent::Challenge(_) => saw_challenge = true,
+                MppEvent::CredentialSent => saw_credential = true,
+                MppEvent::Receipt(_) => {
+                    saw_receipt = true;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        saw_challenge && saw_credential && saw_receipt
+    }
+
+    assert!(drain_until_receipt(&mut h1.events).await);
+    assert!(drain_until_receipt(&mut h2.events).await);
+}
+
+#[tokio::test]
+async fn server_error_frame_surfaces_event_and_closes() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(
+                &mut ws,
+                serde_json::json!({ "type": "error", "error": "bad request" }),
+            )
+            .await;
+            sleep(Duration::from_millis(50)).await;
+        })
+    })
+    .await;
+
+    let connect = MppWsConnect::new(url, StubProvider);
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let ev = timeout(TIMEOUT, handle.events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    match ev {
+        MppEvent::Error(s) => assert_eq!(s, "bad request"),
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unsupported_challenge_skips_pay_and_closes_fatal() {
+    #[derive(Clone, Default)]
+    struct UnsupportedProvider(Arc<AtomicUsize>);
+    impl PaymentProvider for UnsupportedProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            false
+        }
+        async fn pay(&self, _: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Err(MppError::bad_request("should not be called"))
+        }
+    }
+
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            // Server must not receive a credential frame.
+            let next = timeout(Duration::from_millis(200), ws.next()).await;
+            assert!(next.is_err() || matches!(next, Ok(None) | Ok(Some(Err(_)))));
+        })
+    })
+    .await;
+
+    let pay_calls = Arc::new(AtomicUsize::new(0));
+    let connect = MppWsConnect::new(url, UnsupportedProvider(pay_calls.clone()));
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut saw_unsupported = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::Error(s) = ev {
+            assert!(s.contains("does not support"), "unexpected error: {s}");
+            saw_unsupported = true;
+            break;
+        }
+    }
+    assert!(saw_unsupported, "expected unsupported-method error event");
+    assert_eq!(
+        pay_calls.load(Ordering::SeqCst),
+        0,
+        "pay() must not be invoked"
+    );
+}
+
+#[tokio::test]
+async fn handshake_timeout_surfaces_error_when_server_silent() {
+    let url = spawn_server(|mut ws| {
+        Box::pin(async move {
+            // Hold the connection open without sending any frame.
+            let _ = timeout(Duration::from_secs(2), ws.next()).await;
+        })
+    })
+    .await;
+
+    let connect =
+        MppWsConnect::new(url, StubProvider).with_handshake_timeout(Duration::from_millis(200));
+    let mut handle = connect.mpp_handle();
+    let _conn = connect.connect().await.unwrap();
+
+    let mut saw_timeout = false;
+    while let Ok(Ok(ev)) = timeout(TIMEOUT, handle.events.recv()).await {
+        if let MppEvent::Error(s) = ev {
+            assert!(s.contains("timed out"), "unexpected error message: {s}");
+            saw_timeout = true;
+            break;
+        }
+    }
+    assert!(saw_timeout, "expected handshake timeout error event");
+}
+
+#[tokio::test]
+async fn fatal_provider_error_does_not_re_invoke_pay() {
+    // The server issues a challenge on every accept; any reconnect would
+    // surface as another accept and another `pay()` call.
+    #[derive(Clone, Default)]
+    struct CountingFailingProvider(Arc<AtomicUsize>);
+    impl PaymentProvider for CountingFailingProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            true
+        }
+        async fn pay(&self, _: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Err(MppError::bad_request("insufficient funds"))
+        }
+    }
+
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let accepts_srv = accepts.clone();
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            accepts_srv.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                if let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await {
+                    send_text(&mut ws, challenge_frame()).await;
+                    let _ = timeout(Duration::from_millis(200), ws.next()).await;
+                }
+            });
+        }
+    });
+    let url = format!("ws://127.0.0.1:{port}");
+
+    let pay_calls = Arc::new(AtomicUsize::new(0));
+    let connect = MppWsConnect::new(url, CountingFailingProvider(pay_calls.clone()))
+        .with_max_retries(5)
+        .with_retry_interval(Duration::from_millis(10));
+    let _frontend = connect.into_service().await.unwrap();
+
+    // Long enough that several reconnects would happen if classification were wrong.
+    sleep(Duration::from_millis(800)).await;
+
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "fatal error must not trigger reconnects"
+    );
+    assert_eq!(
+        pay_calls.load(Ordering::SeqCst),
+        1,
+        "pay() must not be re-invoked"
+    );
+}
+
+#[tokio::test]
+async fn shutdown_during_in_flight_payment_breaks_promptly() {
+    // Dropping the handle while pay() is parked must close the socket
+    // without waiting for the keepalive interval or handshake timeout.
+    #[derive(Clone)]
+    struct BlockingProvider(Arc<Notify>);
+    impl PaymentProvider for BlockingProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            true
+        }
+        async fn pay(&self, ch: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.0.notified().await;
+            Ok(PaymentCredential::new(
+                ch.to_echo(),
+                PaymentPayload::hash("0xnever"),
+            ))
+        }
+    }
+
+    // Server signals once the client closes the WS.
+    let (client_gone_tx, client_gone_rx) = tokio::sync::oneshot::channel::<()>();
+    let url = spawn_server(move |mut ws| {
+        Box::pin(async move {
+            send_text(&mut ws, challenge_frame()).await;
+            while let Some(msg) = ws.next().await {
+                match msg {
+                    Ok(Message::Close(_)) | Err(_) => break,
+                    _ => {}
+                }
+            }
+            let _ = client_gone_tx.send(());
+        })
+    })
+    .await;
+
+    let release = Arc::new(Notify::new());
+    let connect = MppWsConnect::new(url, BlockingProvider(release.clone()));
+    let mut handle = connect.mpp_handle();
+    let conn = connect.connect().await.unwrap();
+
+    // Wait until pay() has been spawned (and is now parked).
+    let ev = timeout(TIMEOUT, handle.events.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(ev, MppEvent::Challenge(_)));
+
+    let start = std::time::Instant::now();
+    drop(conn);
+
+    timeout(Duration::from_secs(2), client_gone_rx)
+        .await
+        .expect("translator should drop the WS stream promptly after handle is dropped")
+        .expect("server task should still be alive");
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "shutdown observed in {elapsed:?}; should be ≪ keepalive interval"
+    );
+
+    // Unpark pay() so the spawned task can finish on abort.
+    release.notify_waiters();
+}


### PR DESCRIPTION
Adds a new `alloy-transport-mpp` workspace member: an alloy WebSocket transport that speaks the MPP wire protocol.

Drop-in `PubSubConnect` implementation that wraps JSON-RPC frames in MPP `message` envelopes and handles the challenge / credential / receipt handshake (and optional voucher exchange for streaming sessions) via user-supplied `PaymentProvider` / `VoucherProvider` implementations.

```rust,ignore
use alloy_provider::ProviderBuilder;
use alloy_transport_mpp::MppWsConnect;

let connect = MppWsConnect::new("wss://paid.example/rpc", my_provider);
let provider = ProviderBuilder::new().connect_pubsub(connect).await?;
```