### PR TITLE
feat(client): add AcceptPaymentPolicy

### DIFF
--- a/src/client/accept_payment_policy.rs
+++ b/src/client/accept_payment_policy.rs
@@ -1,0 +1,163 @@
+//! Gates `Accept-Payment` header injection on outgoing requests.
+//!
+//! Without a gate, a global payment middleware advertises supported
+//! payment methods on every cross-origin request, which can break CORS
+//! preflight and leak wallet capabilities.
+//!
+//! Defaults to [`AcceptPaymentPolicy::Always`] for backwards compatibility.
+
+use reqwest::Url;
+
+/// Policy controlling when the `Accept-Payment` header is injected.
+#[derive(Clone, Debug, Default)]
+pub enum AcceptPaymentPolicy {
+    /// Always inject (default).
+    #[default]
+    Always,
+    /// Inject only when the request URL origin matches `same_origin`
+    /// (`scheme://host[:port]`).
+    SameOrigin { same_origin: String },
+    /// Never inject.
+    Never,
+    /// Inject only when the request URL matches one of the patterns.
+    /// Supports exact origins (`https://app.example.com`) and `*.example.com` wildcards.
+    Origins(Vec<String>),
+}
+
+impl AcceptPaymentPolicy {
+    /// Returns `true` if header injection is permitted for `url`.
+    pub fn allows(&self, url: &Url) -> bool {
+        match self {
+            Self::Always => true,
+            Self::Never => false,
+            Self::SameOrigin { same_origin } => match Url::parse(same_origin) {
+                Ok(parsed) => url.origin() == parsed.origin(),
+                Err(_) => false,
+            },
+            Self::Origins(patterns) => patterns.iter().any(|p| matches_origin(url, p)),
+        }
+    }
+}
+
+/// Match `url` against a pattern.
+///
+/// - `*.example.com` (bare hostname, no scheme) → wildcard subdomain match;
+///   also matches the bare domain.
+/// - `scheme://host[:port]` → exact `Url::origin()` equality.
+///
+/// Anything else (host-only without scheme, scheme-prefixed wildcards) is rejected.
+fn matches_origin(url: &Url, pattern: &str) -> bool {
+    if let Some(suffix_no_dot) = pattern.strip_prefix("*.") {
+        let url_host = match url.host_str() {
+            Some(h) => h.to_ascii_lowercase(),
+            None => return false,
+        };
+        let suffix = suffix_no_dot.to_ascii_lowercase();
+        return url_host == suffix || url_host.ends_with(&format!(".{suffix}"));
+    }
+
+    match Url::parse(pattern) {
+        Ok(pattern_url) => url.origin() == pattern_url.origin(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn url(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[test]
+    fn always_allows_any_url() {
+        let p = AcceptPaymentPolicy::Always;
+        assert!(p.allows(&url("https://example.com/api")));
+        assert!(p.allows(&url("http://localhost:8080/")));
+        assert!(p.allows(&url("https://cross-origin.example.com/")));
+    }
+
+    #[test]
+    fn never_blocks_any_url() {
+        let p = AcceptPaymentPolicy::Never;
+        assert!(!p.allows(&url("https://example.com/api")));
+        assert!(!p.allows(&url("http://localhost:8080/")));
+    }
+
+    #[test]
+    fn default_is_always() {
+        let p = AcceptPaymentPolicy::default();
+        assert!(p.allows(&url("https://example.com/")));
+    }
+
+    #[test]
+    fn same_origin_matches_exact_origin() {
+        let p = AcceptPaymentPolicy::SameOrigin {
+            same_origin: "https://app.example.com".to_string(),
+        };
+        assert!(p.allows(&url("https://app.example.com/api")));
+        assert!(p.allows(&url("https://app.example.com/")));
+        assert!(!p.allows(&url("https://other.example.com/api")));
+        assert!(!p.allows(&url("http://app.example.com/api"))); // different scheme
+    }
+
+    #[test]
+    fn same_origin_respects_port() {
+        let p = AcceptPaymentPolicy::SameOrigin {
+            same_origin: "http://localhost:3000".to_string(),
+        };
+        assert!(p.allows(&url("http://localhost:3000/api")));
+        assert!(!p.allows(&url("http://localhost:3001/api")));
+        assert!(!p.allows(&url("http://localhost/api")));
+    }
+
+    #[test]
+    fn origins_exact_match() {
+        let p = AcceptPaymentPolicy::Origins(vec!["https://app.example.com".to_string()]);
+        assert!(p.allows(&url("https://app.example.com/api")));
+        assert!(!p.allows(&url("https://other.com/api")));
+    }
+
+    #[test]
+    fn origins_wildcard_subdomain() {
+        let p = AcceptPaymentPolicy::Origins(vec!["*.example.com".to_string()]);
+        assert!(p.allows(&url("https://api.example.com/")));
+        assert!(p.allows(&url("https://x.y.example.com/")));
+        assert!(p.allows(&url("https://example.com/"))); // bare domain matches
+        assert!(!p.allows(&url("https://example.org/")));
+        assert!(!p.allows(&url("https://maliciousexample.com/"))); // suffix-attack guard
+    }
+
+    #[test]
+    fn origins_rejects_host_only_pattern() {
+        // Patterns without a scheme are rejected (must be wildcard or full origin).
+        let p = AcceptPaymentPolicy::Origins(vec!["api.example.com".to_string()]);
+        assert!(!p.allows(&url("https://api.example.com/")));
+    }
+
+    #[test]
+    fn origins_multiple_patterns() {
+        let p = AcceptPaymentPolicy::Origins(vec![
+            "https://app.example.com".to_string(),
+            "*.trusted.io".to_string(),
+        ]);
+        assert!(p.allows(&url("https://app.example.com/")));
+        assert!(p.allows(&url("https://api.trusted.io/")));
+        assert!(p.allows(&url("https://deep.x.trusted.io/")));
+        assert!(!p.allows(&url("https://untrusted.com/")));
+    }
+
+    #[test]
+    fn origins_wildcard_case_insensitive() {
+        let p = AcceptPaymentPolicy::Origins(vec!["*.Example.COM".to_string()]);
+        assert!(p.allows(&url("https://API.example.com/")));
+    }
+
+    #[test]
+    fn exact_origin_normalizes_default_port() {
+        // WHATWG URL.origin omits default ports (443 for https).
+        let p = AcceptPaymentPolicy::Origins(vec!["https://example.com:443".to_string()]);
+        assert!(p.allows(&url("https://example.com/")));
+    }
+}

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -5,6 +5,7 @@
 use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{RequestBuilder, Response, StatusCode};
 
+use super::accept_payment_policy::AcceptPaymentPolicy;
 use super::error::HttpError;
 use super::provider::PaymentProvider;
 use crate::protocol::core::accept_payment::{self, ACCEPT_PAYMENT_HEADER};
@@ -31,42 +32,64 @@ use crate::protocol::core::{
 ///     .send_with_payment(&provider)
 ///     .await?;
 /// ```
-pub trait PaymentExt {
+pub trait PaymentExt: Sized {
     /// Send the request, automatically handling 402 Payment Required responses.
     ///
-    /// If the initial request returns 402:
-    /// 1. Parse the challenge from the `WWW-Authenticate` header
-    /// 2. Call `provider.pay()` to execute the payment
-    /// 3. Retry the request with the credential in the `Authorization` header
-    ///
-    /// # Errors
-    ///
-    /// Returns `HttpError` if:
-    /// - The request cannot be cloned (required for retry)
-    /// - The 402 response is missing the `WWW-Authenticate` header
-    /// - The challenge cannot be parsed
-    /// - The payment fails
-    /// - The retry request fails
+    /// Equivalent to [`send_with_payment_policy`](Self::send_with_payment_policy)
+    /// with [`AcceptPaymentPolicy::Always`].
     fn send_with_payment<P: PaymentProvider>(
         self,
         provider: &P,
+    ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send {
+        self.send_with_payment_policy(provider, &AcceptPaymentPolicy::Always)
+    }
+
+    /// Like [`send_with_payment`](Self::send_with_payment) but only injects
+    /// `Accept-Payment` when `policy` permits the request URL. The 402-retry
+    /// path is unaffected.
+    fn send_with_payment_policy<P: PaymentProvider>(
+        self,
+        provider: &P,
+        policy: &AcceptPaymentPolicy,
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 }
 
 impl PaymentExt for RequestBuilder {
-    async fn send_with_payment<P: PaymentProvider>(
+    async fn send_with_payment_policy<P: PaymentProvider>(
         self,
         provider: &P,
+        policy: &AcceptPaymentPolicy,
     ) -> Result<Response, HttpError> {
         let retry_builder = self.try_clone().ok_or(HttpError::CloneFailed)?;
 
-        // Inject Accept-Payment header from provider's supported methods
-        let accept_header = provider.accept_payment_header();
-        let this = if let Some(ref header) = accept_header {
-            self.header(ACCEPT_PAYMENT_HEADER, header)
+        // Peek the built request to inspect caller-set headers and URL
+        // before injecting our own.
+        let peek = retry_builder.try_clone().and_then(|b| b.build().ok());
+        let url = peek.as_ref().map(|r| r.url().clone());
+        let caller_accept = peek.as_ref().and_then(|r| {
+            r.headers()
+                .get(ACCEPT_PAYMENT_HEADER)
+                .and_then(|v| v.to_str().ok())
+                .map(String::from)
+        });
+        let provider_accept = provider.accept_payment_header();
+
+        // Inject only if the caller didn't set their own header AND the
+        // policy permits it. Caller-set headers are never overwritten.
+        let inject = caller_accept.is_none() && url.as_ref().is_some_and(|u| policy.allows(u));
+
+        let this = if inject {
+            if let Some(ref header) = provider_accept {
+                self.header(ACCEPT_PAYMENT_HEADER, header)
+            } else {
+                self
+            }
         } else {
             self
         };
+
+        // Caller's header (if any) wins for retry-time ranking.
+        let ranking_accept = caller_accept.or(provider_accept);
 
         let resp = this.send().await?;
 
@@ -90,11 +113,10 @@ impl PaymentExt for RequestBuilder {
             .filter_map(|r| r.ok())
             .collect();
 
-        // Use Accept-Payment ranking when preferences are available,
-        // otherwise fall back to first supported challenge.
-        let challenge = if let Some(ref header) = accept_header {
+        // Rank challenges by the caller's preferences (if set) or the
+        // provider's. Falls back to first-supported on parse failure.
+        let challenge = if let Some(ref header) = ranking_accept {
             if let Ok(prefs) = accept_payment::parse(header) {
-                // Filter to supported, then rank by preference
                 let supported: Vec<_> = challenges
                     .iter()
                     .filter(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
@@ -600,6 +622,150 @@ mod tests {
                 .unwrap_err();
 
             assert!(matches!(err, HttpError::NoSupportedChallenge(_)));
+        }
+
+        /// Provider that exposes a known Accept-Payment header value so the
+        /// test can observe whether it was injected.
+        #[derive(Clone)]
+        struct AdvertisingProvider;
+
+        impl super::PaymentProvider for AdvertisingProvider {
+            fn supports(&self, _method: &str, _intent: &str) -> bool {
+                true
+            }
+            async fn pay(
+                &self,
+                _challenge: &PaymentChallenge,
+            ) -> Result<PaymentCredential, MppError> {
+                unimplemented!("not used in policy test")
+            }
+            fn accept_payment_header(&self) -> Option<String> {
+                Some("tempo/charge".to_string())
+            }
+        }
+
+        async fn spawn_header_capture() -> (String, Arc<std::sync::Mutex<Option<String>>>) {
+            let captured: Arc<std::sync::Mutex<Option<String>>> = Arc::new(Default::default());
+            let captured_clone = captured.clone();
+            let app = Router::new().route(
+                "/probe",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let captured = captured_clone.clone();
+                    async move {
+                        let v = req
+                            .headers()
+                            .get("accept-payment")
+                            .and_then(|h| h.to_str().ok())
+                            .map(|s| s.to_string());
+                        *captured.lock().unwrap() = v;
+                        AxumStatusCode::OK
+                    }
+                }),
+            );
+            let url = spawn_server(app).await;
+            (url, captured)
+        }
+
+        #[tokio::test]
+        async fn test_send_with_payment_default_injects() {
+            let (base_url, captured) = spawn_header_capture().await;
+            reqwest::Client::new()
+                .get(format!("{}/probe", base_url))
+                .send_with_payment(&AdvertisingProvider)
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), Some("tempo/charge"));
+        }
+
+        #[tokio::test]
+        async fn test_send_with_payment_policy_never_blocks() {
+            let (base_url, captured) = spawn_header_capture().await;
+            reqwest::Client::new()
+                .get(format!("{}/probe", base_url))
+                .send_with_payment_policy(&AdvertisingProvider, &AcceptPaymentPolicy::Never)
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), None);
+        }
+
+        #[tokio::test]
+        async fn test_caller_header_not_overwritten() {
+            // Caller sets Accept-Payment: stripe/charge → must not be replaced.
+            let (base_url, captured) = spawn_header_capture().await;
+            reqwest::Client::new()
+                .get(format!("{}/probe", base_url))
+                .header("Accept-Payment", "stripe/charge")
+                .send_with_payment(&AdvertisingProvider)
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), Some("stripe/charge"));
+        }
+
+        #[tokio::test]
+        async fn test_caller_header_drives_ranking() {
+            // Server offers tempo/charge AND stripe/charge.
+            // Provider supports both. Caller header prefers stripe;
+            // retry must select the stripe challenge.
+            let tempo_header = challenge_header("t1", "tempo", "charge");
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+            let combined = format!("{}, {}", tempo_header, stripe_header);
+
+            let picked: Arc<std::sync::Mutex<Option<String>>> = Arc::new(Default::default());
+            let picked_clone = picked.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let combined = combined.clone();
+                    let picked = picked_clone.clone();
+                    async move {
+                        if let Some(auth) = req.headers().get("authorization") {
+                            let v = auth.to_str().unwrap_or("").to_string();
+                            // Capture which challenge id was used (s1 vs t1).
+                            *picked.lock().unwrap() = Some(v);
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, combined)],
+                                "pay",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge"), ("stripe", "charge")]);
+            reqwest::Client::new()
+                .get(format!("{}/paid", base_url))
+                .header("Accept-Payment", "stripe/charge, tempo/charge;q=0.1")
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+            let used = picked.lock().unwrap().clone().unwrap_or_default();
+            let cred = crate::protocol::core::parse_authorization(&used).unwrap();
+            assert_eq!(
+                cred.challenge.id, "s1",
+                "expected stripe challenge (id s1) to be picked, got id: {}",
+                cred.challenge.id
+            );
+        }
+
+        #[tokio::test]
+        async fn test_send_with_payment_policy_same_origin_mismatch() {
+            let (base_url, captured) = spawn_header_capture().await;
+            reqwest::Client::new()
+                .get(format!("{}/probe", base_url))
+                .send_with_payment_policy(
+                    &AdvertisingProvider,
+                    &AcceptPaymentPolicy::SameOrigin {
+                        same_origin: "https://app.example.com".to_string(),
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), None);
         }
     }
 }

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -8,6 +8,7 @@ use reqwest::header::WWW_AUTHENTICATE;
 use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next};
 
+use crate::client::accept_payment_policy::AcceptPaymentPolicy;
 use crate::client::provider::PaymentProvider;
 use crate::protocol::core::accept_payment::{self, ACCEPT_PAYMENT_HEADER};
 use crate::protocol::core::{
@@ -38,12 +39,24 @@ use crate::protocol::core::{
 /// ```
 pub struct PaymentMiddleware<P> {
     provider: P,
+    accept_payment_policy: AcceptPaymentPolicy,
 }
 
 impl<P> PaymentMiddleware<P> {
-    /// Create a new payment middleware with the given provider.
+    /// Create middleware with the given provider. Defaults to
+    /// [`AcceptPaymentPolicy::Always`].
     pub fn new(provider: P) -> Self {
-        Self { provider }
+        Self {
+            provider,
+            accept_payment_policy: AcceptPaymentPolicy::default(),
+        }
+    }
+
+    /// Restrict where the `Accept-Payment` header is sent. The 402-retry
+    /// path is unaffected.
+    pub fn with_accept_payment_policy(mut self, policy: AcceptPaymentPolicy) -> Self {
+        self.accept_payment_policy = policy;
+        self
     }
 }
 
@@ -58,13 +71,27 @@ where
         extensions: &mut http_types::Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<Response> {
-        // Inject Accept-Payment header if the provider advertises methods
-        let accept_header = self.provider.accept_payment_header();
-        if let Some(ref header) = accept_header {
-            if let Ok(val) = header.parse() {
-                req.headers_mut().insert(ACCEPT_PAYMENT_HEADER, val);
+        // Snapshot any caller-set Accept-Payment header before injection.
+        let caller_accept = req
+            .headers()
+            .get(ACCEPT_PAYMENT_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let provider_accept = self.provider.accept_payment_header();
+
+        // Inject only if the caller didn't set their own header AND the
+        // policy permits it. Caller-set headers are never overwritten
+        if caller_accept.is_none() && self.accept_payment_policy.allows(req.url()) {
+            if let Some(ref header) = provider_accept {
+                if let Ok(val) = header.parse() {
+                    req.headers_mut().insert(ACCEPT_PAYMENT_HEADER, val);
+                }
             }
         }
+
+        // The caller's header (if any) wins for retry-time challenge ranking;
+        // otherwise fall back to the provider's preferences.
+        let ranking_accept = caller_accept.or(provider_accept);
 
         let retry_req = req.try_clone();
         let resp = next.clone().run(req, extensions).await?;
@@ -95,8 +122,9 @@ where
             .filter_map(|r| r.ok())
             .collect();
 
-        // Use Accept-Payment ranking when preferences are available
-        let challenge = if let Some(ref header) = accept_header {
+        // Rank challenges by the caller's preferences (if set) or the
+        // provider's.
+        let challenge = if let Some(ref header) = ranking_accept {
             if let Ok(prefs) = accept_payment::parse(header) {
                 let supported: Vec<_> = challenges
                     .iter()
@@ -341,6 +369,162 @@ mod tests {
                 "expected WWW-Authenticate error, got: {}",
                 err
             );
+        }
+
+        /// Advertises a known header value so tests can observe injection.
+        #[derive(Clone)]
+        struct AdvertisingProvider;
+
+        impl PaymentProvider for AdvertisingProvider {
+            fn supports(&self, _method: &str, _intent: &str) -> bool {
+                true
+            }
+
+            async fn pay(
+                &self,
+                _challenge: &PaymentChallenge,
+            ) -> Result<PaymentCredential, MppError> {
+                unimplemented!("not used in policy tests")
+            }
+
+            fn accept_payment_header(&self) -> Option<String> {
+                Some("tempo/charge".to_string())
+            }
+        }
+
+        async fn spawn_header_capture() -> (String, Arc<std::sync::Mutex<Option<String>>>) {
+            let captured: Arc<std::sync::Mutex<Option<String>>> = Arc::new(Default::default());
+            let captured_clone = captured.clone();
+            let app = Router::new().route(
+                "/probe",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let captured = captured_clone.clone();
+                    async move {
+                        let v = req
+                            .headers()
+                            .get("accept-payment")
+                            .and_then(|h| h.to_str().ok())
+                            .map(|s| s.to_string());
+                        *captured.lock().unwrap() = v;
+                        AxumStatusCode::OK
+                    }
+                }),
+            );
+            let url = spawn_server(app).await;
+            (url, captured)
+        }
+
+        #[tokio::test]
+        async fn test_policy_default_always_injects_header() {
+            let (base_url, captured) = spawn_header_capture().await;
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(AdvertisingProvider))
+                .build();
+            client
+                .get(format!("{}/probe", base_url))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), Some("tempo/charge"));
+        }
+
+        #[tokio::test]
+        async fn test_policy_never_suppresses_header() {
+            let (base_url, captured) = spawn_header_capture().await;
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(
+                    PaymentMiddleware::new(AdvertisingProvider)
+                        .with_accept_payment_policy(AcceptPaymentPolicy::Never),
+                )
+                .build();
+            client
+                .get(format!("{}/probe", base_url))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), None);
+        }
+
+        #[tokio::test]
+        async fn test_policy_same_origin_blocks_cross_origin() {
+            let (base_url, captured) = spawn_header_capture().await;
+            // same_origin set to a different origin → header must not be sent.
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(
+                    PaymentMiddleware::new(AdvertisingProvider).with_accept_payment_policy(
+                        AcceptPaymentPolicy::SameOrigin {
+                            same_origin: "https://app.example.com".to_string(),
+                        },
+                    ),
+                )
+                .build();
+            client
+                .get(format!("{}/probe", base_url))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), None);
+        }
+
+        #[tokio::test]
+        async fn test_caller_header_not_overwritten() {
+            // Caller sets Accept-Payment: stripe/charge → middleware must
+            // NOT replace it with the provider's tempo/charge value.
+            let (base_url, captured) = spawn_header_capture().await;
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(AdvertisingProvider))
+                .build();
+            client
+                .get(format!("{}/probe", base_url))
+                .header("Accept-Payment", "stripe/charge")
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(captured.lock().unwrap().as_deref(), Some("stripe/charge"));
+        }
+
+        #[tokio::test]
+        async fn test_policy_does_not_disable_402_retry() {
+            // A blocked outbound header must not stop the 402-retry path.
+            let (_, www_auth) = test_challenge();
+            let counter = Arc::new(AtomicU32::new(0));
+            let counter_clone = counter.clone();
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let www_auth = www_auth.clone();
+                    let counter = counter_clone.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth)],
+                                "pay",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(
+                    PaymentMiddleware::new(provider.clone())
+                        .with_accept_payment_policy(AcceptPaymentPolicy::Never),
+                )
+                .build();
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(counter.load(Ordering::SeqCst), 2);
         }
 
         #[tokio::test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,6 +17,8 @@
 //! let resp = client.get(url).send_with_payment(&provider).await?;
 //! ```
 
+#[cfg(feature = "client")]
+mod accept_payment_policy;
 mod error;
 mod provider;
 pub mod transport;
@@ -35,6 +37,9 @@ mod middleware;
 
 pub use error::HttpError;
 pub use provider::{MultiProvider, PaymentProvider};
+
+#[cfg(feature = "client")]
+pub use accept_payment_policy::AcceptPaymentPolicy;
 
 #[cfg(feature = "client")]
 pub use fetch::PaymentExt as Fetch;


### PR DESCRIPTION
Adds `AcceptPaymentPolicy` (Always / SameOrigin / Never / Origins) to gate when the Accept-Payment header is sent on outgoing requests.

Available on:
- `PaymentMiddleware::with_accept_payment_policy(policy)`
- `PaymentExt::send_with_payment_policy(provider, policy)`

Also: caller-set Accept-Payment headers are now preserved (previously overwritten) and drive challenge ranking on 402 retry.

Defaults to Always for backwards compatibility.