### PR TITLE
fix: reject replayed session vouchers

### DIFF
--- a/.changelog/session-replay-delta.md
+++ b/.changelog/session-replay-delta.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Rejected replayed Tempo session vouchers that do not increase the accepted cumulative amount.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Pin pnpm for Tempo Lints
+        run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
         uses: tempoxyz/lints@03cac25d02c1aaa0c6ca87860183879069abb921 # main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Patch Changes
 
-- Rejected replayed Tempo session vouchers that do not increase the accepted cumulative amount. (by @BrendanRyan, [#247](https://github.com/tempoxyz/mpp-rs/pull/247))
-
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Patch Changes
 
+- Rejected replayed Tempo session vouchers that do not increase the accepted cumulative amount. (by @BrendanRyan, [#247](https://github.com/tempoxyz/mpp-rs/pull/247))
+
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -1033,10 +1033,9 @@ where
             ));
         }
 
-        // If voucher is not higher than what we already have, accept idempotently
-        // but still verify the signature to prevent channel hijacking via stale
-        // vouchers with forged signatures. Skip ecrecover only for exact replays
-        // of the already-verified highest voucher.
+        // If voucher is not higher than what we already have, verify the
+        // signature and reject it as a replay. A successful voucher must add new
+        // funds for the current metered request.
         if cumulative_amount <= channel.highest_voucher_amount {
             let sig_bytes = Self::parse_signature(signature_str)?;
             let is_exact_replay =
@@ -1063,7 +1062,9 @@ where
                     ));
                 }
             }
-            return Ok(Receipt::success(METHOD_NAME, &channel.channel_id));
+            return Err(VerificationError::delta_too_small(
+                "voucher does not add new funds",
+            ));
         }
 
         let delta = cumulative_amount - channel.highest_voucher_amount;
@@ -1842,7 +1843,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_exact_replay_of_highest_voucher_allowed() {
+    async fn test_exact_replay_of_highest_voucher_rejected() {
         use crate::protocol::methods::tempo::voucher::sign_voucher;
         use alloy::signers::local::PrivateKeySigner;
 
@@ -1868,7 +1869,7 @@ mod tests {
 
         let method = test_session_method(store);
 
-        // Exact replay: same amount AND same signature — should be accepted (idempotent)
+        // Exact replay: same amount and same signature does not add new funds.
         let result = method
             .verify_and_accept_voucher(
                 &channel_id_hex,
@@ -1885,7 +1886,8 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_ok());
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, Some(ErrorCode::DeltaTooSmall));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Rejected replayed Tempo session vouchers that do not increase the accepted cumulative amount.