### PR TITLE
fix: validate broadcast transaction memos

### DIFF
--- a/.changelog/charge-broadcast-memo-binding.md
+++ b/.changelog/charge-broadcast-memo-binding.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Validated challenge-bound memos for server-broadcast Tempo charge transactions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Pin pnpm for Tempo Lints
+        run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
         uses: tempoxyz/lints@03cac25d02c1aaa0c6ca87860183879069abb921 # main
         with:

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 22
 
       - name: Install mppx CLI
-        run: npm i -g mppx@0.2.2
+        run: npm i -g mppx@0.6.20
 
       - name: Start Tempo node
         run: docker compose up -d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Patch Changes
 
-- Validated challenge-bound memos for server-broadcast Tempo charge transactions. (by @BrendanRyan, [#249](https://github.com/tempoxyz/mpp-rs/pull/249))
-
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Patch Changes
 
+- Validated challenge-bound memos for server-broadcast Tempo charge transactions. (by @BrendanRyan, [#249](https://github.com/tempoxyz/mpp-rs/pull/249))
+
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -833,6 +833,8 @@ where
         signed_tx: &str,
         charge: &ChargeRequest,
         expected_chain_id: u64,
+        challenge_id: &str,
+        realm: &str,
     ) -> Result<B256, VerificationError> {
         let tx_bytes = signed_tx
             .parse::<Bytes>()
@@ -906,7 +908,10 @@ where
         }
 
         // Verify the receipt contains the expected TIP-20 transfer(s)
-        self.verify_tip20_transfers(&receipt, currency, &expected)?;
+        let matched_logs = self.verify_tip20_transfers(&receipt, currency, &expected)?;
+        if charge.memo().is_none() {
+            assert_challenge_bound_memo(&matched_logs, challenge_id, realm)?;
+        }
 
         // Record the on-chain tx hash for hash-based replay protection
         if let Some(store) = &self.store {
@@ -1243,6 +1248,8 @@ where
                         charge_payload.signed_tx().unwrap(),
                         &request,
                         expected_chain_id,
+                        &credential.challenge.id,
+                        &credential.challenge.realm,
                     )
                     .await?;
                 Ok(Receipt::success(METHOD_NAME, format!("{:#x}", tx_hash)))


### PR DESCRIPTION
## Summary

Server-broadcast Tempo charge transactions could be accepted without validating the challenge-bound memo.