### PR TITLE
fix: bind proof signatures to wallet

### DIFF
--- a/.changelog/proof-wallet-binding.md
+++ b/.changelog/proof-wallet-binding.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Bound zero-amount Tempo proof signatures to the wallet being authenticated.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Pin pnpm for Tempo Lints
+        run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
         uses: tempoxyz/lints@03cac25d02c1aaa0c6ca87860183879069abb921 # main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Patch Changes
 
+- Bound zero-amount Tempo proof signatures to the wallet being authenticated. (by @BrendanRyan, [#253](https://github.com/tempoxyz/mpp-rs/pull/253))
+
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Patch Changes
 
-- Bound zero-amount Tempo proof signatures to the wallet being authenticated. (by @BrendanRyan, [#253](https://github.com/tempoxyz/mpp-rs/pull/253))
-
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -236,14 +236,13 @@ impl TempoCharge {
         options: SignOptions,
     ) -> Result<SignedTempoCharge, MppError> {
         if self.amount.is_zero() {
-            // Proof credentials are raw typed-data signatures, so they bind to
-            // the actual signing key rather than a keychain-wrapped wallet address.
-            let from = signer.address();
+            let signing_mode = options.signing_mode.unwrap_or_default();
+            let from = signing_mode.from_address(signer.address());
             let credential = PaymentCredential::with_source(
                 self.challenge.to_echo(),
                 proof::proof_source(from, self.chain_id),
                 PaymentPayload::proof(
-                    proof::sign_proof(signer, self.chain_id, &self.challenge.id).await?,
+                    proof::sign_proof(signer, self.chain_id, &self.challenge.id, from).await?,
                 ),
             );
 

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -129,8 +129,9 @@ impl PaymentProvider for TempoProvider {
         let mut charge = super::charge::TempoCharge::from_challenge(challenge)?;
 
         if charge.amount().is_zero() {
-            let signature = sign_proof(&self.signer, charge.chain_id(), &challenge.id).await?;
             let from = self.signing_mode.from_address(self.signer.address());
+            let signature =
+                sign_proof(&self.signer, charge.chain_id(), &challenge.id, from).await?;
             let source = PaymentCredential::evm_did(charge.chain_id(), &from.to_string());
 
             return Ok(PaymentCredential::with_source(

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1201,6 +1201,7 @@ where
                     &credential.challenge.id,
                     sig_hex,
                     parsed_source.address,
+                    parsed_source.address,
                 ) {
                     // Keychain fallback: signer may be an access key authorized
                     // for the source wallet. Recover the signer and check on-chain.
@@ -1208,6 +1209,7 @@ where
                         expected_chain_id,
                         &credential.challenge.id,
                         sig_hex,
+                        parsed_source.address,
                     )
                     .map_err(|_| {
                         VerificationError::new("Proof signature does not match source.")
@@ -1384,7 +1386,7 @@ mod tests {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&signer, 42431, &challenge.id)
+        let signature = proof::sign_proof(&signer, 42431, &challenge.id, signer.address())
             .await
             .unwrap();
         let credential = PaymentCredential::with_source(
@@ -1408,7 +1410,7 @@ mod tests {
         let other = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&other, 42431, &challenge.id)
+        let signature = proof::sign_proof(&other, 42431, &challenge.id, other.address())
             .await
             .unwrap();
         let payload = crate::protocol::core::PaymentPayload::proof(signature);
@@ -1424,6 +1426,7 @@ mod tests {
             42431,
             &credential.challenge.id,
             payload.proof_signature().unwrap(),
+            parsed.address,
             parsed.address,
         ));
     }

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -15,6 +15,7 @@ alloy::sol! {
     #[derive(Debug)]
     struct Proof {
         string challengeId;
+        address wallet;
     }
 }
 
@@ -64,7 +65,7 @@ pub fn parse_proof_source(source: &str) -> crate::error::Result<ProofSource> {
 }
 
 /// Compute the EIP-712 signing hash for a proof credential.
-pub fn signing_hash(chain_id: u64, challenge_id: &str) -> B256 {
+pub fn signing_hash(chain_id: u64, challenge_id: &str, wallet: Address) -> B256 {
     let domain = eip712_domain! {
         name: DOMAIN_NAME,
         version: DOMAIN_VERSION,
@@ -73,6 +74,7 @@ pub fn signing_hash(chain_id: u64, challenge_id: &str) -> B256 {
 
     Proof {
         challengeId: challenge_id.to_string(),
+        wallet,
     }
     .eip712_signing_hash(&domain)
 }
@@ -83,9 +85,10 @@ pub async fn sign_proof(
     signer: &impl alloy::signers::Signer,
     chain_id: u64,
     challenge_id: &str,
+    wallet: Address,
 ) -> crate::error::Result<String> {
     let signature = signer
-        .sign_hash(&signing_hash(chain_id, challenge_id))
+        .sign_hash(&signing_hash(chain_id, challenge_id, wallet))
         .await
         .mpp_http("failed to sign proof")?;
 
@@ -98,6 +101,7 @@ pub fn verify_proof(
     chain_id: u64,
     challenge_id: &str,
     signature_hex: &str,
+    wallet: Address,
     expected_signer: Address,
 ) -> bool {
     let signature_bytes = match signature_hex.parse::<alloy::primitives::Bytes>() {
@@ -110,7 +114,7 @@ pub fn verify_proof(
         Err(_) => return false,
     };
 
-    match signature.recover_address_from_prehash(&signing_hash(chain_id, challenge_id)) {
+    match signature.recover_address_from_prehash(&signing_hash(chain_id, challenge_id, wallet)) {
         Ok(recovered) => recovered == expected_signer,
         Err(_) => false,
     }
@@ -124,6 +128,7 @@ pub fn recover_proof_signer(
     chain_id: u64,
     challenge_id: &str,
     signature_hex: &str,
+    wallet: Address,
 ) -> Result<Address, crate::error::MppError> {
     let signature_bytes: alloy::primitives::Bytes = signature_hex
         .parse()
@@ -131,7 +136,7 @@ pub fn recover_proof_signer(
     let signature = alloy::signers::Signature::try_from(signature_bytes.as_ref())
         .map_err(|_| crate::error::MppError::invalid_payload("invalid proof signature"))?;
     signature
-        .recover_address_from_prehash(&signing_hash(chain_id, challenge_id))
+        .recover_address_from_prehash(&signing_hash(chain_id, challenge_id, wallet))
         .map_err(|_| crate::error::MppError::invalid_payload("proof signature recovery failed"))
 }
 
@@ -183,12 +188,15 @@ mod tests {
     #[tokio::test]
     async fn test_sign_and_verify_proof_roundtrip() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123").await.unwrap();
+        let signature = sign_proof(&signer, 42431, "challenge-123", signer.address())
+            .await
+            .unwrap();
 
         assert!(verify_proof(
             42431,
             "challenge-123",
             &signature,
+            signer.address(),
             signer.address(),
         ));
     }
@@ -196,12 +204,15 @@ mod tests {
     #[tokio::test]
     async fn test_verify_proof_rejects_wrong_challenge_id() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123").await.unwrap();
+        let signature = sign_proof(&signer, 42431, "challenge-123", signer.address())
+            .await
+            .unwrap();
 
         assert!(!verify_proof(
             42431,
             "challenge-456",
             &signature,
+            signer.address(),
             signer.address(),
         ));
     }
@@ -210,21 +221,50 @@ mod tests {
     async fn test_verify_proof_rejects_wrong_signer() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let other = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123").await.unwrap();
+        let signature = sign_proof(&signer, 42431, "challenge-123", signer.address())
+            .await
+            .unwrap();
 
         assert!(!verify_proof(
             42431,
             "challenge-123",
             &signature,
+            signer.address(),
             other.address(),
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_verify_proof_rejects_wrong_wallet() {
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let other_wallet = alloy::signers::local::PrivateKeySigner::random();
+        let signature = sign_proof(&signer, 42431, "challenge-123", signer.address())
+            .await
+            .unwrap();
+
+        assert!(!verify_proof(
+            42431,
+            "challenge-123",
+            &signature,
+            other_wallet.address(),
+            signer.address(),
         ));
     }
 
     #[test]
     fn test_signing_hash_depends_on_chain_id() {
+        let wallet = Address::repeat_byte(0x11);
         assert_ne!(
-            signing_hash(1, "challenge-123"),
-            signing_hash(42431, "challenge-123")
+            signing_hash(1, "challenge-123", wallet),
+            signing_hash(42431, "challenge-123", wallet)
+        );
+    }
+
+    #[test]
+    fn test_signing_hash_depends_on_wallet() {
+        assert_ne!(
+            signing_hash(42431, "challenge-123", Address::repeat_byte(0x11)),
+            signing_hash(42431, "challenge-123", Address::repeat_byte(0x22))
         );
     }
 }


### PR DESCRIPTION
## Summary

Zero-amount Tempo proof signatures were not bound to the wallet being authenticated.