### PR TITLE
fix: stop websocket payment retry amplification

### DIFF
--- a/.changelog/ws-close-retry-guard.md
+++ b/.changelog/ws-close-retry-guard.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Stopped WebSocket reconnect retries after a payment credential is sent without a receipt.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
       - run: cargo update -p native-tls
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Pin pnpm for Tempo Lints
+        run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
         uses: tempoxyz/lints@03cac25d02c1aaa0c6ca87860183879069abb921 # main
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Patch Changes
 
+- Stopped WebSocket reconnect retries after a payment credential is sent without a receipt. (by @BrendanRyan, [#254](https://github.com/tempoxyz/mpp-rs/pull/254))
+
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### Patch Changes
 
-- Stopped WebSocket reconnect retries after a payment credential is sent without a receipt. (by @BrendanRyan, [#254](https://github.com/tempoxyz/mpp-rs/pull/254))
-
 - Made the `axum` extractor use route-aware expected-request verification by default. High-level `MppCharge` extraction now forwards the route amount into verification so built-in Tempo and Stripe challengers compare incoming credentials against the route's expected charge request instead of trusting the echoed request alone. (by @BrendanRyan, [#213](https://github.com/tempoxyz/mpp-rs/pull/213))
 
 ## 0.10.0 (2026-04-20)

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -49,7 +49,7 @@ use tokio::{
 };
 use tokio_tungstenite::{
     connect_async_with_config,
-    tungstenite::{self, client::IntoClientRequest, Message},
+    tungstenite::{self, client::IntoClientRequest, protocol::frame::coding::CloseCode, Message},
     MaybeTlsStream, WebSocketStream,
 };
 use url::Url;
@@ -406,6 +406,7 @@ async fn run_translator<P, V>(
     // `false` until the first credential has been sent; gates outbound JSON-RPC
     // so application traffic never races the initial challenge.
     let mut handshake_complete = false;
+    let mut credential_awaiting_receipt = false;
     let keepalive = sleep(keepalive_interval);
     pin!(keepalive);
 
@@ -463,6 +464,7 @@ async fn run_translator<P, V>(
                             break;
                         }
                         handshake_complete = true;
+                        credential_awaiting_receipt = true;
                     }
                     Ok(Err(err)) => {
                         error!(?err, "MPP payment provider failed");
@@ -493,6 +495,7 @@ async fn run_translator<P, V>(
                             break;
                         }
                         handshake_complete = true;
+                        credential_awaiting_receipt = true;
                     }
                     Ok(Err(err)) => {
                         error!(?err, "MPP voucher provider failed");
@@ -557,6 +560,7 @@ async fn run_translator<P, V>(
                             &events_tx,
                             &mut pending_pay,
                             &mut pending_voucher,
+                            &mut credential_awaiting_receipt,
                         ).await {
                             Ok(()) => {
                                 // Reset the handshake deadline when a new
@@ -578,12 +582,20 @@ async fn run_translator<P, V>(
                     }
                     Some(Err(err)) => {
                         error!(%err, "WS connection error");
-                        termination = Some(TerminationReason::Transient);
+                        termination = Some(if credential_awaiting_receipt {
+                            TerminationReason::Fatal
+                        } else {
+                            TerminationReason::Transient
+                        });
                         break;
                     }
                     None => {
                         error!("WS server has gone away");
-                        termination = Some(TerminationReason::Transient);
+                        termination = Some(if credential_awaiting_receipt {
+                            TerminationReason::Fatal
+                        } else {
+                            TerminationReason::Transient
+                        });
                         break;
                     }
                 }
@@ -669,6 +681,7 @@ async fn handle_message<P: PaymentProvider + 'static, V: VoucherProvider>(
     events_tx: &broadcast::Sender<MppEvent>,
     pending_pay: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
     pending_voucher: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+    credential_awaiting_receipt: &mut bool,
 ) -> Result<(), TerminationReason> {
     match msg {
         Message::Text(text) => {
@@ -681,12 +694,17 @@ async fn handle_message<P: PaymentProvider + 'static, V: VoucherProvider>(
                 events_tx,
                 pending_pay,
                 pending_voucher,
+                credential_awaiting_receipt,
             )
             .await
         }
         Message::Close(frame) => {
             error!(?frame, "Received WS close frame");
-            Err(TerminationReason::Transient)
+            if *credential_awaiting_receipt || is_fatal_close(frame.as_ref().map(|f| f.code)) {
+                Err(TerminationReason::Fatal)
+            } else {
+                Err(TerminationReason::Transient)
+            }
         }
         Message::Binary(_) => {
             error!("Received binary WS frame; expected text");
@@ -694,6 +712,10 @@ async fn handle_message<P: PaymentProvider + 'static, V: VoucherProvider>(
         }
         Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => Ok(()),
     }
+}
+
+fn is_fatal_close(code: Option<CloseCode>) -> bool {
+    !matches!(code, Some(CloseCode::Restart) | Some(CloseCode::Again))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -706,6 +728,7 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
     events_tx: &broadcast::Sender<MppEvent>,
     pending_pay: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
     pending_voucher: &mut Option<JoinHandle<Result<PaymentCredential, MppError>>>,
+    credential_awaiting_receipt: &mut bool,
 ) -> Result<(), TerminationReason> {
     let server_msg: WsServerMessage = match json_from_str(text) {
         Ok(m) => m,
@@ -820,6 +843,7 @@ async fn handle_text<P: PaymentProvider + 'static, V: VoucherProvider>(
             debug!(?parsed, "MPP receipt received");
             let _ = receipt_tx.send(Some(parsed.clone()));
             let _ = events_tx.send(MppEvent::Receipt(parsed));
+            *credential_awaiting_receipt = false;
             Ok(())
         }
         WsServerMessage::Error { error } => {

--- a/crates/alloy-transport-mpp/tests/ws_integration.rs
+++ b/crates/alloy-transport-mpp/tests/ws_integration.rs
@@ -1035,6 +1035,65 @@ async fn fatal_provider_error_does_not_re_invoke_pay() {
 }
 
 #[tokio::test]
+async fn close_after_credential_does_not_re_invoke_pay() {
+    #[derive(Clone, Default)]
+    struct CountingProvider(Arc<AtomicUsize>);
+    impl PaymentProvider for CountingProvider {
+        fn supports(&self, _: &str, _: &str) -> bool {
+            true
+        }
+        async fn pay(&self, ch: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Ok(PaymentCredential::new(
+                ch.to_echo(),
+                PaymentPayload::hash("0xdeadbeef"),
+            ))
+        }
+    }
+
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let accepts_srv = accepts.clone();
+    spawn(async move {
+        loop {
+            let (stream, _) = match listener.accept().await {
+                Ok(p) => p,
+                Err(_) => return,
+            };
+            accepts_srv.fetch_add(1, Ordering::SeqCst);
+            spawn(async move {
+                if let Ok(mut ws) = accept_async(stream).await {
+                    send_text(&mut ws, challenge_frame()).await;
+                    let _ = timeout(Duration::from_millis(500), ws.next()).await;
+                    let _ = ws.send(Message::Close(None)).await;
+                }
+            });
+        }
+    });
+    let url = format!("ws://127.0.0.1:{port}");
+
+    let pay_calls = Arc::new(AtomicUsize::new(0));
+    let connect = MppWsConnect::new(url, CountingProvider(pay_calls.clone()))
+        .with_max_retries(5)
+        .with_retry_interval(Duration::from_millis(10));
+    let _frontend = connect.into_service().await.unwrap();
+
+    sleep(Duration::from_millis(800)).await;
+
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "close after credential must not trigger reconnects"
+    );
+    assert_eq!(
+        pay_calls.load(Ordering::SeqCst),
+        1,
+        "pay() must not be re-invoked after credential was sent"
+    );
+}
+
+#[tokio::test]
 async fn shutdown_during_in_flight_payment_breaks_promptly() {
     // Dropping the handle while pay() is parked must close the socket
     // without waiting for the keepalive interval or handshake timeout.


### PR DESCRIPTION
## Summary

WebSocket payment retries could continue after a credential was sent without a receipt.