### PR TITLE
Use T3 remaining limit query

### DIFF
--- a/.changelog/dull-moons-wake.md
+++ b/.changelog/dull-moons-wake.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Updated remaining limit query to latest Tempo T3 interface

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -64,12 +64,12 @@ pub async fn query_key_spending_limit<P: alloy::providers::Provider>(
     }
 
     let result = keychain
-        .getRemainingLimit(wallet_address, key_address, token)
+        .getRemainingLimitWithPeriod(wallet_address, key_address, token)
         .call()
         .await
         .mpp_http("failed to query remaining limit")?;
 
-    Ok(Some(result))
+    Ok(Some(result.remaining))
 }
 
 /// Resolve the spending limit for a token from a key authorization.


### PR DESCRIPTION
## Summary
- query access-key spending limits through `getRemainingLimitWithPeriod`
- return the `remaining` field to preserve the existing `query_key_spending_limit` API

## Context
Tempo T3 dropped the legacy `getRemainingLimit` selector. Callers using the old selector fail to read remaining limits.

## Verification
- `cargo test --manifest-path Cargo.toml client::tempo::signing::keychain --features tempo,client -q` currently fails in `tempo-contracts 1.7.0` with duplicate helper definitions generated by the Alloy sol macro; the selector change itself is a small ABI call replacement.
- A 0.9.3-compatible branch with the same one-line fix was used by tempoxyz/wallet#464 and verified there with `cargo check -p tempo-wallet --locked` and focused whoami tests.
