### PR TITLE
chore: bump Alloy and Tempo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,14 +80,14 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "2.0", features = ["full"], optional = true }
-alloy-sol-type-parser = { version = "=1.5.7", optional = true }
-alloy-sol-types = { version = "=1.5.7", optional = true }
+alloy = { version = "2.0.5", features = ["full"], optional = true }
+alloy-sol-type-parser = { version = "=1.6.0", optional = true }
+alloy-sol-types = { version = "=1.6.0", optional = true }
 
 # Tempo dependencies (optional)
-tempo-alloy = { version = "=1.6.0", optional = true }
-tempo-primitives = { version = "=1.6.0", optional = true }
-tempo-contracts = { version = "=1.6.0", optional = true }
+tempo-alloy = { version = "=1.7.2", optional = true }
+tempo-primitives = { version = "=1.7.2", optional = true }
+tempo-contracts = { version = "=1.7.2", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -21,10 +21,10 @@ rustdoc-args = [
 ]
 
 [dependencies]
-alloy-json-rpc = { version = "2.0", default-features = false }
-alloy-pubsub = { version = "2.0", default-features = false }
-alloy-transport = { version = "2.0", default-features = false }
-alloy-transport-ws = { version = "2.0", default-features = false }
+alloy-json-rpc = { version = "2.0.5", default-features = false }
+alloy-pubsub = { version = "2.0.5", default-features = false }
+alloy-transport = { version = "2.0.5", default-features = false }
+alloy-transport-ws = { version = "2.0.5", default-features = false }
 
 mpp = { path = "../..", default-features = false, features = ["ws"] }
 

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -305,6 +305,7 @@ mod tests {
             expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
+            witness: None,
         };
         let sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed_auth = auth.into_signed(PrimitiveSignature::Secp256k1(sig));

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -118,6 +118,7 @@ mod tests {
             expiry: NonZeroU64::new(9999999999),
             limits,
             allowed_calls: None,
+            witness: None,
         };
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig))

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -329,6 +329,7 @@ mod tests {
             expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
+            witness: None,
         };
         let sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed = auth.into_signed(PrimitiveSignature::Secp256k1(sig));
@@ -581,6 +582,7 @@ mod tests {
             expiry: NonZeroU64::new(9999999999),
             limits: None,
             allowed_calls: None,
+            witness: None,
         };
         let sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         let signed_auth = auth.into_signed(PrimitiveSignature::Secp256k1(sig));

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -364,6 +364,7 @@ mod tests {
                 period: 0,
             }]),
             allowed_calls: None,
+            witness: None,
         };
         let inner_sig = signer.sign_hash_sync(&auth.signature_hash()).unwrap();
         auth.into_signed(PrimitiveSignature::Secp256k1(inner_sig))


### PR DESCRIPTION
## Summary
- bump Alloy dependencies to 2.0.5
- pin alloy-sol-type-parser and alloy-sol-types to 1.6.0
- bump alloy-transport-mpp Alloy crates to 2.0.5
- bump Tempo crates to 1.7.2 so they compile with alloy-sol-types 1.6.0
- update test-only `KeyAuthorization` initializers for the new optional `witness` field

## Testing
- cargo fmt --check
- cargo test -p alloy-transport-mpp
- cargo check --all-features
- cargo check --workspace --exclude mpp
- cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws --no-run

This PR contains dependency bumps plus the minimal test compatibility update needed for Tempo 1.7.2.