### PR TITLE
ci: add MPP conformance gates

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -1,0 +1,41 @@
+name: Conformance
+
+on:
+  pull_request:
+    branches: [main]
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  conformance-policy:
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@main
+    with:
+      protocol-paths: |
+        Cargo.toml
+        src/body_digest.rs
+        src/client/**
+        src/error.rs
+        src/expires.rs
+        src/lib.rs
+        src/mcp.rs
+        src/protocol/**
+        src/server/**
+        crates/alloy-transport-mpp/**
+
+  conformance:
+    needs: conformance-policy
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@main
+    with:
+      adapter: rust
+      conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}


### PR DESCRIPTION
## Summary

- Add the shared mpp-tools conformance policy gate for protocol-sensitive Rust SDK paths.
- Add the shared mpp-tools Rust behavior gate to run vector and flow conformance against this SDK checkout.
- Route conformance runs to a referenced mpp-tools conformance PR when the policy gate finds one.