### PR TITLE
fix: harden payment validation

### DIFF
--- a/src/body_digest.rs
+++ b/src/body_digest.rs
@@ -36,7 +36,7 @@ pub fn compute_json<T: serde::Serialize>(body: &T) -> BodyDigest {
 
 /// Verifies that a digest matches the given body bytes.
 pub fn verify(digest: &str, body: &[u8]) -> bool {
-    compute(body) == digest
+    crate::protocol::core::challenge::constant_time_eq(&compute(body), digest)
 }
 
 #[cfg(test)]

--- a/src/client/challenge_selection.rs
+++ b/src/client/challenge_selection.rs
@@ -4,7 +4,7 @@ use crate::protocol::core::PaymentChallenge;
 
 #[derive(Debug, Clone)]
 pub(crate) enum ChallengeSelectionError {
-    Expired(PaymentChallenge),
+    Expired(Box<PaymentChallenge>),
     NoSupportedChallenge(String),
 }
 
@@ -33,7 +33,9 @@ pub(crate) fn select_supported_challenge<'a>(
     }
 
     if let Some(challenge) = select_ranked_challenge(&supported, ranking_preferences.as_deref()) {
-        return Err(ChallengeSelectionError::Expired(challenge.clone()));
+        return Err(ChallengeSelectionError::Expired(Box::new(
+            challenge.clone(),
+        )));
     }
 
     let offered: Vec<_> = challenges

--- a/src/client/challenge_selection.rs
+++ b/src/client/challenge_selection.rs
@@ -1,0 +1,102 @@
+use crate::error::MppError;
+use crate::protocol::core::accept_payment::{self, Entry};
+use crate::protocol::core::PaymentChallenge;
+
+#[derive(Debug, Clone)]
+pub(crate) enum ChallengeSelectionError {
+    Expired(PaymentChallenge),
+    NoSupportedChallenge(String),
+}
+
+pub(crate) fn expired_payment_error(challenge: &PaymentChallenge) -> MppError {
+    MppError::PaymentExpired(challenge.expires.clone())
+}
+
+pub(crate) fn select_supported_challenge<'a>(
+    challenges: &'a [PaymentChallenge],
+    ranking_accept: Option<&str>,
+    mut supports: impl FnMut(&PaymentChallenge) -> bool,
+) -> Result<&'a PaymentChallenge, ChallengeSelectionError> {
+    let ranking_preferences = ranking_accept.and_then(|header| accept_payment::parse(header).ok());
+    let supported: Vec<_> = challenges
+        .iter()
+        .filter(|challenge| supports(challenge))
+        .collect();
+    let payable: Vec<_> = supported
+        .iter()
+        .copied()
+        .filter(|challenge| !challenge.is_expired())
+        .collect();
+
+    if let Some(challenge) = select_ranked_challenge(&payable, ranking_preferences.as_deref()) {
+        return Ok(challenge);
+    }
+
+    if let Some(challenge) = select_ranked_challenge(&supported, ranking_preferences.as_deref()) {
+        return Err(ChallengeSelectionError::Expired(challenge.clone()));
+    }
+
+    let offered: Vec<_> = challenges
+        .iter()
+        .map(|challenge| format!("{}.{}", challenge.method, challenge.intent))
+        .collect();
+    Err(ChallengeSelectionError::NoSupportedChallenge(format!(
+        "server offered [{}], but provider does not support any",
+        offered.join(", ")
+    )))
+}
+
+fn select_ranked_challenge<'a>(
+    challenges: &[&'a PaymentChallenge],
+    preferences: Option<&[Entry]>,
+) -> Option<&'a PaymentChallenge> {
+    match preferences {
+        Some(preferences) => accept_payment::select(challenges, preferences).copied(),
+        None => challenges.first().copied(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::core::Base64UrlJson;
+
+    fn challenge_with_expires(expires: Option<&str>) -> PaymentChallenge {
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
+        );
+
+        match expires {
+            Some(expires) => challenge.with_expires(expires),
+            None => challenge,
+        }
+    }
+
+    #[test]
+    fn select_supported_challenge_fails_closed_for_malformed_expiry() {
+        let challenges = vec![challenge_with_expires(Some("not-a-date"))];
+
+        let err = select_supported_challenge(&challenges, None, |challenge| {
+            challenge.method.as_str() == "tempo"
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, ChallengeSelectionError::Expired(_)));
+    }
+
+    #[test]
+    fn select_supported_challenge_rejects_past_expiry() {
+        let challenges = vec![challenge_with_expires(Some("2020-01-01T00:00:00Z"))];
+
+        let err = select_supported_challenge(&challenges, None, |challenge| {
+            challenge.method.as_str() == "tempo"
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, ChallengeSelectionError::Expired(_)));
+    }
+}

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -12,10 +12,21 @@ use super::events::{
     PaymentFailedContext, PaymentResponseContext,
 };
 use super::provider::PaymentProvider;
+use crate::error::MppError;
 use crate::protocol::core::accept_payment::{self, ACCEPT_PAYMENT_HEADER};
 use crate::protocol::core::{
-    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+    format_authorization, parse_www_authenticate_all, PaymentChallenge, AUTHORIZATION_HEADER,
 };
+
+fn reject_expired_challenge(challenge: &PaymentChallenge) -> Result<(), HttpError> {
+    if challenge.is_expired() {
+        return Err(HttpError::Payment(MppError::PaymentExpired(
+            challenge.expires.clone(),
+        )));
+    }
+
+    Ok(())
+}
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -188,6 +199,17 @@ impl PaymentExt for RequestBuilder {
             }
         };
 
+        if let Err(err) = reject_expired_challenge(&challenge) {
+            let error = err.to_string();
+            events
+                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                    challenge: Some(challenge),
+                    error,
+                }))
+                .await;
+            return Err(err);
+        }
+
         let override_credential = events
             .emit_challenge_received(ChallengeReceivedContext {
                 challenge: challenge.clone(),
@@ -270,6 +292,48 @@ impl PaymentExt for RequestBuilder {
         }
 
         Ok(retry_resp)
+    }
+}
+
+#[cfg(test)]
+mod expiry_tests {
+    use super::*;
+    use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
+
+    #[test]
+    fn reject_expired_challenge_fails_closed_for_malformed_expiry() {
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
+        )
+        .with_expires("not-a-date");
+
+        let err = reject_expired_challenge(&challenge).unwrap_err();
+        assert!(matches!(
+            err,
+            HttpError::Payment(MppError::PaymentExpired(_))
+        ));
+    }
+
+    #[test]
+    fn reject_expired_challenge_rejects_past_expiry() {
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
+        )
+        .with_expires("2020-01-01T00:00:00Z");
+
+        let err = reject_expired_challenge(&challenge).unwrap_err();
+        assert!(matches!(
+            err,
+            HttpError::Payment(MppError::PaymentExpired(_))
+        ));
     }
 }
 

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -158,7 +158,7 @@ impl PaymentExt for RequestBuilder {
                     let error = err.to_string();
                     events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: Some(challenge),
+                            challenge: Some(*challenge),
                             error,
                         }))
                         .await;

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -12,31 +12,13 @@ use super::events::{
     PaymentFailedContext, PaymentResponseContext,
 };
 use super::provider::PaymentProvider;
-use crate::error::MppError;
-use crate::protocol::core::accept_payment::{self, ACCEPT_PAYMENT_HEADER};
-use crate::protocol::core::{
-    format_authorization, parse_www_authenticate_all, PaymentChallenge, AUTHORIZATION_HEADER,
+use crate::client::challenge_selection::{
+    expired_payment_error, select_supported_challenge, ChallengeSelectionError,
 };
-
-fn reject_expired_challenge(challenge: &PaymentChallenge) -> Result<(), HttpError> {
-    if challenge.is_expired() {
-        return Err(HttpError::Payment(MppError::PaymentExpired(
-            challenge.expires.clone(),
-        )));
-    }
-
-    Ok(())
-}
-
-fn select_ranked_challenge<'a>(
-    challenges: &[&'a PaymentChallenge],
-    preferences: Option<&[accept_payment::Entry]>,
-) -> Option<&'a PaymentChallenge> {
-    match preferences {
-        Some(prefs) => accept_payment::select(challenges, prefs).copied(),
-        None => challenges.first().copied(),
-    }
-}
+use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
+use crate::protocol::core::{
+    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+};
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -166,32 +148,13 @@ impl PaymentExt for RequestBuilder {
             .filter_map(|r| r.ok())
             .collect();
 
-        let ranking_preferences = ranking_accept
-            .as_ref()
-            .and_then(|header| accept_payment::parse(header).ok());
-        let supported: Vec<_> = challenges
-            .iter()
-            .filter(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
-            .collect();
-        let payable: Vec<_> = supported
-            .iter()
-            .copied()
-            .filter(|challenge| !challenge.is_expired())
-            .collect();
-
-        // Rank payable challenges by the caller's preferences (if set) or the
-        // provider's. Falls back to first-supported on preference parse failure.
-        let challenge = select_ranked_challenge(&payable, ranking_preferences.as_deref()).cloned();
-
-        let challenge = match challenge {
-            Some(challenge) => challenge,
-            None => {
-                if let Some(expired) =
-                    select_ranked_challenge(&supported, ranking_preferences.as_deref())
-                {
-                    let challenge = expired.clone();
-                    let err = reject_expired_challenge(&challenge)
-                        .expect_err("expired challenge selected after payable filtering");
+        let challenge =
+            match select_supported_challenge(&challenges, ranking_accept.as_deref(), |challenge| {
+                provider.supports(challenge.method.as_str(), challenge.intent.as_str())
+            }) {
+                Ok(challenge) => challenge.clone(),
+                Err(ChallengeSelectionError::Expired(challenge)) => {
+                    let err = HttpError::Payment(expired_payment_error(&challenge));
                     let error = err.to_string();
                     events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
@@ -201,24 +164,17 @@ impl PaymentExt for RequestBuilder {
                         .await;
                     return Err(err);
                 }
-
-                let offered: Vec<_> = challenges
-                    .iter()
-                    .map(|c| format!("{}.{}", c.method, c.intent))
-                    .collect();
-                let err = HttpError::NoSupportedChallenge(format!(
-                    "server offered [{}], but provider does not support any",
-                    offered.join(", ")
-                ));
-                events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: None,
-                        error: err.to_string(),
-                    }))
-                    .await;
-                return Err(err);
-            }
-        };
+                Err(ChallengeSelectionError::NoSupportedChallenge(message)) => {
+                    let err = HttpError::NoSupportedChallenge(message);
+                    events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: None,
+                            error: err.to_string(),
+                        }))
+                        .await;
+                    return Err(err);
+                }
+            };
 
         let override_credential = events
             .emit_challenge_received(ChallengeReceivedContext {
@@ -302,48 +258,6 @@ impl PaymentExt for RequestBuilder {
         }
 
         Ok(retry_resp)
-    }
-}
-
-#[cfg(test)]
-mod expiry_tests {
-    use super::*;
-    use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
-
-    #[test]
-    fn reject_expired_challenge_fails_closed_for_malformed_expiry() {
-        let challenge = PaymentChallenge::new(
-            "challenge-123",
-            "api.example.com",
-            "tempo",
-            "charge",
-            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
-        )
-        .with_expires("not-a-date");
-
-        let err = reject_expired_challenge(&challenge).unwrap_err();
-        assert!(matches!(
-            err,
-            HttpError::Payment(MppError::PaymentExpired(_))
-        ));
-    }
-
-    #[test]
-    fn reject_expired_challenge_rejects_past_expiry() {
-        let challenge = PaymentChallenge::new(
-            "challenge-123",
-            "api.example.com",
-            "tempo",
-            "charge",
-            Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
-        )
-        .with_expires("2020-01-01T00:00:00Z");
-
-        let err = reject_expired_challenge(&challenge).unwrap_err();
-        assert!(matches!(
-            err,
-            HttpError::Payment(MppError::PaymentExpired(_))
-        ));
     }
 }
 

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -28,6 +28,16 @@ fn reject_expired_challenge(challenge: &PaymentChallenge) -> Result<(), HttpErro
     Ok(())
 }
 
+fn select_ranked_challenge<'a>(
+    challenges: &[&'a PaymentChallenge],
+    preferences: Option<&[accept_payment::Entry]>,
+) -> Option<&'a PaymentChallenge> {
+    match preferences {
+        Some(prefs) => accept_payment::select(challenges, prefs).copied(),
+        None => challenges.first().copied(),
+    }
+}
+
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
 /// This trait adds a `.send_with_payment()` method that automatically handles
@@ -156,39 +166,50 @@ impl PaymentExt for RequestBuilder {
             .filter_map(|r| r.ok())
             .collect();
 
-        // Rank challenges by the caller's preferences (if set) or the
-        // provider's. Falls back to first-supported on parse failure.
-        let challenge = if let Some(ref header) = ranking_accept {
-            if let Ok(prefs) = accept_payment::parse(header) {
-                let supported: Vec<_> = challenges
-                    .iter()
-                    .filter(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
-                    .collect();
-                accept_payment::select(&supported, &prefs).copied()
-            } else {
-                challenges
-                    .iter()
-                    .find(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
-            }
-        } else {
-            challenges
-                .iter()
-                .find(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
-        }
-        .ok_or_else(|| {
-            let offered: Vec<_> = challenges
-                .iter()
-                .map(|c| format!("{}.{}", c.method, c.intent))
-                .collect();
-            HttpError::NoSupportedChallenge(format!(
-                "server offered [{}], but provider does not support any",
-                offered.join(", ")
-            ))
-        });
+        let ranking_preferences = ranking_accept
+            .as_ref()
+            .and_then(|header| accept_payment::parse(header).ok());
+        let supported: Vec<_> = challenges
+            .iter()
+            .filter(|c| provider.supports(c.method.as_str(), c.intent.as_str()))
+            .collect();
+        let payable: Vec<_> = supported
+            .iter()
+            .copied()
+            .filter(|challenge| !challenge.is_expired())
+            .collect();
+
+        // Rank payable challenges by the caller's preferences (if set) or the
+        // provider's. Falls back to first-supported on preference parse failure.
+        let challenge = select_ranked_challenge(&payable, ranking_preferences.as_deref()).cloned();
 
         let challenge = match challenge {
-            Ok(challenge) => challenge.clone(),
-            Err(err) => {
+            Some(challenge) => challenge,
+            None => {
+                if let Some(expired) =
+                    select_ranked_challenge(&supported, ranking_preferences.as_deref())
+                {
+                    let challenge = expired.clone();
+                    let err = reject_expired_challenge(&challenge)
+                        .expect_err("expired challenge selected after payable filtering");
+                    let error = err.to_string();
+                    events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: Some(challenge),
+                            error,
+                        }))
+                        .await;
+                    return Err(err);
+                }
+
+                let offered: Vec<_> = challenges
+                    .iter()
+                    .map(|c| format!("{}.{}", c.method, c.intent))
+                    .collect();
+                let err = HttpError::NoSupportedChallenge(format!(
+                    "server offered [{}], but provider does not support any",
+                    offered.join(", ")
+                ));
                 events
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: None,
@@ -198,17 +219,6 @@ impl PaymentExt for RequestBuilder {
                 return Err(err);
             }
         };
-
-        if let Err(err) = reject_expired_challenge(&challenge) {
-            let error = err.to_string();
-            events
-                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                    challenge: Some(challenge),
-                    error,
-                }))
-                .await;
-            return Err(err);
-        }
 
         let override_credential = events
             .emit_challenge_received(ChallengeReceivedContext {
@@ -839,9 +849,22 @@ mod tests {
 
         /// Build a challenge header for a specific method and intent.
         fn challenge_header(id: &str, method: &str, intent: &str) -> String {
+            challenge_header_with_expires(id, method, intent, None)
+        }
+
+        fn challenge_header_with_expires(
+            id: &str,
+            method: &str,
+            intent: &str,
+            expires: Option<&str>,
+        ) -> String {
             let request =
                 Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
-            let challenge = PaymentChallenge::new(id, "test.example.com", method, intent, request);
+            let mut challenge =
+                PaymentChallenge::new(id, "test.example.com", method, intent, request);
+            if let Some(expires) = expires {
+                challenge = challenge.with_expires(expires);
+            }
             format_www_authenticate(&challenge).unwrap()
         }
 
@@ -924,6 +947,113 @@ mod tests {
 
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(provider.call_count(), 1);
+        }
+
+        #[tokio::test]
+        async fn test_multi_challenge_skips_expired_preferred_supported() {
+            // Caller prefers tempo, but that challenge is expired; stripe is
+            // still supported and valid, so the request should continue.
+            let tempo_header = challenge_header_with_expires(
+                "t1",
+                "tempo",
+                "charge",
+                Some("2020-01-01T00:00:00Z"),
+            );
+            let stripe_header = challenge_header("s1", "stripe", "charge");
+            let combined = format!("{}, {}", tempo_header, stripe_header);
+
+            let picked: Arc<std::sync::Mutex<Option<String>>> = Arc::new(Default::default());
+            let picked_clone = picked.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let combined = combined.clone();
+                    let picked = picked_clone.clone();
+                    async move {
+                        if let Some(auth) = req.headers().get("authorization") {
+                            *picked.lock().unwrap() =
+                                Some(auth.to_str().unwrap_or_default().to_string());
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, combined)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge"), ("stripe", "charge")]);
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .header("Accept-Payment", "tempo/charge, stripe/charge;q=0.5")
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+            let used = picked.lock().unwrap().clone().unwrap_or_default();
+            let cred = crate::protocol::core::parse_authorization(&used).unwrap();
+            assert_eq!(cred.challenge.id, "s1");
+        }
+
+        #[tokio::test]
+        async fn test_multi_challenge_skips_malformed_expiry_first_supported() {
+            // A bad expires value fails closed for that challenge, but should
+            // not block a later valid challenge for the same method/intent.
+            let bad_header =
+                challenge_header_with_expires("bad", "tempo", "charge", Some("not-a-date"));
+            let valid_header = challenge_header("valid", "tempo", "charge");
+            let combined = format!("{}, {}", bad_header, valid_header);
+
+            let picked: Arc<std::sync::Mutex<Option<String>>> = Arc::new(Default::default());
+            let picked_clone = picked.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let combined = combined.clone();
+                    let picked = picked_clone.clone();
+                    async move {
+                        if let Some(auth) = req.headers().get("authorization") {
+                            *picked.lock().unwrap() =
+                                Some(auth.to_str().unwrap_or_default().to_string());
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, combined)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = SelectiveProvider::new(vec![("tempo", "charge")]);
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(provider.call_count(), 1);
+            let used = picked.lock().unwrap().clone().unwrap_or_default();
+            let cred = crate::protocol::core::parse_authorization(&used).unwrap();
+            assert_eq!(cred.challenge.id, "valid");
         }
 
         #[tokio::test]

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -9,12 +9,15 @@ use reqwest::{Request, Response, StatusCode};
 use reqwest_middleware::{Middleware, Next};
 
 use crate::client::accept_payment_policy::AcceptPaymentPolicy;
+use crate::client::challenge_selection::{
+    expired_payment_error, select_supported_challenge, ChallengeSelectionError,
+};
 use crate::client::events::{
     ChallengeReceivedContext, ClientEvent, ClientEventSubscription, ClientEvents,
     CredentialCreatedContext, PaymentFailedContext, PaymentResponseContext,
 };
 use crate::client::provider::PaymentProvider;
-use crate::protocol::core::accept_payment::{self, ACCEPT_PAYMENT_HEADER};
+use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
 use crate::protocol::core::{
     format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
 };
@@ -193,39 +196,36 @@ where
             .filter_map(|r| r.ok())
             .collect();
 
-        // Rank challenges by the caller's preferences (if set) or the
-        // provider's.
-        let challenge = if let Some(ref header) = ranking_accept {
-            if let Ok(prefs) = accept_payment::parse(header) {
-                let supported: Vec<_> = challenges
-                    .iter()
-                    .filter(|c| self.provider.supports(c.method.as_str(), c.intent.as_str()))
-                    .collect();
-                accept_payment::select(&supported, &prefs).copied()
-            } else {
-                challenges
-                    .iter()
-                    .find(|c| self.provider.supports(c.method.as_str(), c.intent.as_str()))
-            }
-        } else {
-            challenges
-                .iter()
-                .find(|c| self.provider.supports(c.method.as_str(), c.intent.as_str()))
-        }
-        .context("no challenge matches provider's supported methods");
-
-        let challenge = match challenge {
-            Ok(challenge) => challenge.clone(),
-            Err(err) => {
-                self.events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: None,
-                        error: err.to_string(),
-                    }))
-                    .await;
-                return Err(reqwest_middleware::Error::Middleware(err));
-            }
-        };
+        let challenge =
+            match select_supported_challenge(&challenges, ranking_accept.as_deref(), |challenge| {
+                self.provider
+                    .supports(challenge.method.as_str(), challenge.intent.as_str())
+            }) {
+                Ok(challenge) => challenge.clone(),
+                Err(ChallengeSelectionError::Expired(challenge)) => {
+                    let mpp_error = expired_payment_error(&challenge);
+                    let error = mpp_error.to_string();
+                    self.events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: Some(challenge),
+                            error,
+                        }))
+                        .await;
+                    return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                        mpp_error
+                    )));
+                }
+                Err(ChallengeSelectionError::NoSupportedChallenge(message)) => {
+                    let err = anyhow::anyhow!(message);
+                    self.events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: None,
+                            error: err.to_string(),
+                        }))
+                        .await;
+                    return Err(reqwest_middleware::Error::Middleware(err));
+                }
+            };
 
         let override_credential = self
             .events
@@ -418,14 +418,21 @@ mod tests {
         }
 
         fn test_challenge() -> (PaymentChallenge, String) {
+            test_challenge_with_expires(None)
+        }
+
+        fn test_challenge_with_expires(expires: Option<&str>) -> (PaymentChallenge, String) {
             let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "500"})).unwrap();
-            let challenge = PaymentChallenge::new(
+            let mut challenge = PaymentChallenge::new(
                 "mw-test-id",
                 "middleware.example.com",
                 "tempo",
                 "charge",
                 request,
             );
+            if let Some(expires) = expires {
+                challenge = challenge.with_expires(expires);
+            }
             let header = format_www_authenticate(&challenge).unwrap();
             (challenge, header)
         }
@@ -714,6 +721,72 @@ mod tests {
                 "expected WWW-Authenticate error, got: {}",
                 err
             );
+        }
+
+        #[tokio::test]
+        async fn test_middleware_rejects_expired_challenge_before_hooks() {
+            let (_, www_auth) = test_challenge_with_expires(Some("2020-01-01T00:00:00Z"));
+
+            let app = Router::new().route(
+                "/paid",
+                get(move |req: axum::http::Request<axum::body::Body>| {
+                    let www_auth = www_auth.clone();
+                    async move {
+                        if req.headers().get("authorization").is_some() {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth)],
+                                "pay up",
+                            )
+                                .into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let events = ClientEvents::default();
+            let challenge_count = Arc::new(AtomicU32::new(0));
+            let failed_count = Arc::new(AtomicU32::new(0));
+
+            let _challenge_sub = events.on_challenge_received({
+                let challenge_count = challenge_count.clone();
+                move |_| {
+                    challenge_count.fetch_add(1, Ordering::SeqCst);
+                    async { None }
+                }
+            });
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                move |ctx| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        assert!(ctx.challenge.is_some());
+                        assert!(ctx.error.contains("Payment expired"));
+                    }
+                }
+            });
+
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_events(events))
+                .build();
+
+            let err = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap_err();
+
+            assert!(
+                err.to_string().contains("Payment expired"),
+                "expected payment expired error, got: {err}"
+            );
+            assert_eq!(provider.call_count(), 0);
+            assert_eq!(challenge_count.load(Ordering::SeqCst), 0);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
         }
 
         /// Advertises a known header value so tests can observe injection.

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -207,7 +207,7 @@ where
                     let error = mpp_error.to_string();
                     self.events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: Some(challenge),
+                            challenge: Some(*challenge),
                             error,
                         }))
                         .await;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,6 +19,8 @@
 
 #[cfg(feature = "client")]
 mod accept_payment_policy;
+#[cfg(feature = "client")]
+mod challenge_selection;
 mod error;
 mod events;
 mod provider;

--- a/src/client/stripe/provider.rs
+++ b/src/client/stripe/provider.rs
@@ -98,6 +98,8 @@ impl PaymentProvider for StripeProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        challenge.validate_for_charge(METHOD_NAME)?;
+
         let request: ChargeRequest = challenge
             .request
             .decode()
@@ -149,6 +151,11 @@ impl PaymentProvider for StripeProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::protocol::core::Base64UrlJson;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
 
     #[test]
     fn test_supports() {
@@ -159,5 +166,39 @@ mod tests {
         assert!(provider.supports("stripe", "charge"));
         assert!(!provider.supports("tempo", "charge"));
         assert!(!provider.supports("stripe", "session"));
+    }
+
+    #[tokio::test]
+    async fn test_pay_rejects_expired_challenge_before_creating_token() {
+        let called = Arc::new(AtomicBool::new(false));
+        let provider = StripeProvider::new({
+            let called = called.clone();
+            move |_| {
+                called.store(true, Ordering::SeqCst);
+                Box::pin(async { Ok(CreateTokenResult::from("spt_test".to_string())) })
+            }
+        });
+        let request = ChargeRequest {
+            amount: "1000".to_string(),
+            currency: "usd".to_string(),
+            method_details: Some(serde_json::json!({
+                "networkId": "internal",
+                "paymentMethodTypes": ["card"]
+            })),
+            ..Default::default()
+        };
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "stripe",
+            "charge",
+            Base64UrlJson::from_typed(&request).unwrap(),
+        )
+        .with_expires("2020-01-01T00:00:00Z");
+
+        let err = provider.pay(&challenge).await.unwrap_err();
+
+        assert!(matches!(err, MppError::PaymentExpired(_)));
+        assert!(!called.load(Ordering::SeqCst));
     }
 }

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -414,6 +414,8 @@ impl PaymentProvider for TempoSessionProvider {
         use alloy::providers::ProviderBuilder;
         use tempo_alloy::TempoNetwork;
 
+        challenge.validate_for_session(crate::protocol::methods::tempo::METHOD_NAME)?;
+
         *self.last_challenge.lock().unwrap() = Some(challenge.clone());
 
         let chain_id = resolve_chain_id(challenge);
@@ -579,6 +581,18 @@ mod tests {
         assert!(provider.supports("tempo", "session"));
         assert!(!provider.supports("tempo", "charge"));
         assert!(!provider.supports("stripe", "session"));
+    }
+
+    #[tokio::test]
+    async fn test_pay_rejects_expired_challenge_before_state_mutation() {
+        let provider = make_test_provider();
+        let challenge = make_test_challenge().with_expires("2020-01-01T00:00:00Z");
+
+        let err = provider.pay(&challenge).await.unwrap_err();
+
+        assert!(matches!(err, MppError::PaymentExpired(_)));
+        assert!(provider.last_challenge.lock().unwrap().is_none());
+        assert!(provider.channels.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1004,6 +1004,12 @@ where
             ));
         }
 
+        if !tx.access_list.is_empty() {
+            return Err(VerificationError::new(
+                "Fee payer transaction must not include an access list",
+            ));
+        }
+
         if tx.nonce_key != TEMPO_EXPIRING_NONCE_KEY {
             return Err(VerificationError::new(
                 "Fee payer envelope must use expiring nonce key (U256::MAX)",
@@ -2277,6 +2283,43 @@ mod tests {
         assert!(
             err.to_string().contains("must include valid_before"),
             "error should mention valid_before, got: {err}"
+        );
+    }
+
+    /// cosign_fee_payer_transaction rejects txs with non-empty access lists.
+    #[test]
+    fn test_cosign_rejects_non_empty_access_list() {
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.access_list =
+            alloy::eips::eip2930::AccessList(vec![alloy::eips::eip2930::AccessListItem {
+                address: Address::repeat_byte(0xaa),
+                storage_keys: vec![],
+            }]);
+
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let result = method.cosign_fee_payer_transaction(
+            &encoded,
+            method.fee_payer_signer.as_ref().unwrap(),
+            fee_token,
+        );
+
+        let err = result.expect_err("should reject access list");
+        assert!(
+            err.to_string().contains("access list"),
+            "error should mention access list, got: {err}"
         );
     }
 

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -293,6 +293,13 @@ where
             ));
         }
 
+        if credential.challenge.opaque.is_some() {
+            return Err(VerificationError::with_code(
+                "credential opaque data does not match this route's requirements",
+                crate::protocol::traits::ErrorCode::CredentialMismatch,
+            ));
+        }
+
         // Request-level core fields: currency, recipient
         if let Some(ref expected_currency) = self.currency {
             if request.currency != *expected_currency {
@@ -1729,6 +1736,37 @@ mod tests {
         let result = mpp.verify_credential(&credential).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().message.contains("chainId"));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn test_pinned_opaque_mismatch_rejected() {
+        let mpp = create_hmac_test_mpp();
+        let challenge = mpp.charge("0.10").unwrap();
+
+        let mut echo = challenge.to_echo();
+        echo.opaque = Some(
+            crate::protocol::core::Base64UrlJson::from_value(
+                &serde_json::json!({"route": "other"}),
+            )
+            .unwrap(),
+        );
+        echo.id = crate::protocol::core::compute_challenge_id(
+            "test-secret",
+            "MPP Payment",
+            "tempo",
+            "charge",
+            echo.request.raw(),
+            echo.expires.as_deref(),
+            echo.digest.as_deref(),
+            echo.opaque.as_ref().map(|o| o.raw()),
+        );
+
+        let credential = PaymentCredential::new(echo, PaymentPayload::hash("0xdeadbeef"));
+        let result = mpp.verify_credential(&credential).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("opaque"));
     }
 
     #[cfg(feature = "tempo")]


### PR DESCRIPTION
## Summary

- Use constant-time comparison for body digest verification.
- Reject unexpected opaque challenge echoes during server pinned-field verification.
- Reject fee-payer transactions with non-empty access lists before co-signing.
- Reject expired client challenges before hooks/provider signing, and validate Stripe challenges before token creation.
- Confirmed `cargo fmt --all -- --check` and `cargo test --all-features --lib` pass.