### PR TITLE
fix: repair rust release automation

### DIFF
--- a/.changelog/payment-validation-hardening.md
+++ b/.changelog/payment-validation-hardening.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Hardened payment validation for expired challenges, body digest checks, and Tempo charge verification.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Changelogs
         uses: tempoxyz/changelogs@de0250123a1d70a2b64a458bd5efcf313986df7a # master
         with:
+          ecosystem: rust
           conventional-commit: true
           crate-token: ${{ steps.auth.outputs.token }}
         env:


### PR DESCRIPTION
## Summary
- Force the shared changelogs release action to use the Rust ecosystem so publish mode does not try PyPI OIDC.
- Add the missing patch changelog entry for the merged payment-validation hardening batch.