### PR TITLE
fix: disable pypi oidc for rust publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
           ecosystem: rust
           conventional-commit: true
           crate-token: ${{ steps.auth.outputs.token }}
+          pypi-token: unused-for-rust
         env:
-          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ""
-          ACTIONS_ID_TOKEN_REQUEST_URL: ""
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pass a harmless PyPI token placeholder to the shared changelogs action so Rust publish mode does not attempt PyPI OIDC.
- Keep the existing Rust ecosystem selection and crates.io token flow for publishing.