### PR TITLE
fix: use released changelogs pypi gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,10 @@ jobs:
         id: auth
 
       - name: Changelogs
-        uses: tempoxyz/changelogs@de0250123a1d70a2b64a458bd5efcf313986df7a # master
+        uses: tempoxyz/changelogs@d51df19b0b52cd0916d64dea99da63fe1705c2dd # v0.8.1
         with:
           ecosystem: rust
           conventional-commit: true
           crate-token: ${{ steps.auth.outputs.token }}
-          pypi-token: unused-for-rust
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Update the release workflow to the released `tempoxyz/changelogs` v0.8.1 commit that gates PyPI auth to Python workflows.
- Remove the temporary dummy `pypi-token` workaround from the Rust release workflow.