### PR TITLE
fix: allow release workflow to push tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
 
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1


### PR DESCRIPTION
## Summary
- Allow `actions/checkout` to persist the GitHub token credentials in the release workflow.
- This lets the changelogs action push release tags after publishing.