### PR TITLE
Add changelog for mpp proof shape fix

### DIFF
--- a/.changelog/tempo-proof-shape.md
+++ b/.changelog/tempo-proof-shape.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Align Tempo zero-amount proof shape with the wallet proof flow.


### PR DESCRIPTION
## Summary
- add a patch changelog entry for the merged Tempo zero-amount proof shape fix from #272

## Release flow
Merging this should let the release workflow create/update the Version Packages PR for mpp 0.10.5.