### PR TITLE
Ignore unpublished packages in changelogs

### DIFF
--- a/.changelog/config.toml
+++ b/.changelog/config.toml
@@ -16,7 +16,13 @@ format = "root"
 # members = ["sdk-core", "sdk-macros"]
 
 # Packages to ignore
-ignore = []
+ignore = [
+  "alloy-transport-mpp",
+  "axum-extractor-example",
+  "basic-example",
+  "stripe-example",
+  "ws-example",
+]
 
 # AI-assisted changelog generation
 # [ai]


### PR DESCRIPTION
## Summary
- ignore publish=false workspace members in changelogs release config
- prevents the generated GitHub release PR/title/tag from selecting example/alloy-transport versions like 0.1.x instead of the published mpp crate version 0.10.x

## Verification
- inspected workspace Cargo.toml files for publish=false members
- local changelogs CLI is not installed in this sandbox