### PR TITLE
feat(tempo): add T5 channel reserve precompile voucher helpers

### DIFF
--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -6,15 +6,21 @@
 //!
 //! Ported from the TypeScript SDK's `ChannelOps.ts`.
 
-use alloy::primitives::{Address, Bytes, TxKind, B256, U256};
+use alloy::consensus::SignableTransaction;
+use alloy::primitives::{keccak256, Address, Bytes, TxKind, Uint, B256, U256};
 use alloy::providers::Provider;
 use alloy::signers::Signer;
 use alloy::sol_types::{SolCall, SolValue};
+use tempo_alloy::contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
 use tempo_alloy::TempoNetwork;
+use tempo_primitives::transaction::{Call, TempoTransaction};
 
 use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
+use crate::protocol::methods::tempo::precompile_voucher::{
+    compute_precompile_channel_id, sign_precompile_voucher, PRECOMPILE_MAX_CUMULATIVE_AMOUNT,
+};
 use crate::protocol::methods::tempo::session::{SessionCredentialPayload, TempoSessionExt};
 use crate::protocol::methods::tempo::voucher::{compute_channel_id, sign_voucher};
 use crate::protocol::methods::tempo::MODERATO_CHAIN_ID;
@@ -307,6 +313,158 @@ where
     Ok((entry, payload))
 }
 
+/// Whether `addr` is the T5 TIP-1034 reserve channel precompile.
+pub fn is_precompile_escrow(addr: Address) -> bool {
+    addr == TIP20_CHANNEL_RESERVE_ADDRESS
+}
+
+/// Compute the precompile's `expiringNonceHash` =
+/// `keccak256(encode_for_signing(unsigned_tx) || sender)`. Must be called
+/// before signing; mutating `unsigned_tx` after invalidates the channel id.
+#[cfg(feature = "tempo")]
+pub fn compute_expiring_nonce_hash(unsigned_tx: &TempoTransaction, sender: Address) -> B256 {
+    let mut buf = Vec::with_capacity(unsigned_tx.payload_len_for_signature() + 20);
+    unsigned_tx.encode_for_signing(&mut buf);
+    buf.extend_from_slice(sender.as_slice());
+    keccak256(buf)
+}
+
+/// Options for [`create_precompile_open_payload`]. Replaces `escrow_contract`
+/// (always the precompile) with `operator`. `deposit` and `initial_amount`
+/// must fit `uint96`.
+pub struct OpenPrecompilePayloadOptions {
+    /// Optional relayer for `settle`/`close`; `Address::ZERO` = payee-only.
+    pub operator: Address,
+    /// Voucher signer; defaults to `payer` if `None`.
+    pub authorized_signer: Option<Address>,
+    pub payee: Address,
+    pub currency: Address,
+    pub deposit: u128,
+    pub initial_amount: u128,
+    pub chain_id: u64,
+    pub fee_payer: bool,
+}
+
+/// Open payload targeting the TIP-1034 reserve precompile. Single-call tx
+/// (no `approve` needed: precompile is on the TIP-1035 implicit approvals
+/// list). Channel id is derived against the unsigned tx's `expiringNonceHash`.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_open_payload<P, S>(
+    provider: &P,
+    signer: &S,
+    signing_mode: Option<&crate::client::tempo::signing::TempoSigningMode>,
+    payer: Address,
+    options: OpenPrecompilePayloadOptions,
+) -> Result<(ChannelEntry, SessionCredentialPayload), MppError>
+where
+    P: Provider<TempoNetwork>,
+    S: Signer + Clone,
+{
+    if options.deposit > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+        return Err(MppError::InvalidConfig(format!(
+            "deposit {} exceeds precompile uint96 max",
+            options.deposit
+        )));
+    }
+    if options.initial_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+        return Err(MppError::InvalidConfig(format!(
+            "initial_amount {} exceeds precompile uint96 max",
+            options.initial_amount
+        )));
+    }
+
+    let default_mode = crate::client::tempo::signing::TempoSigningMode::Direct;
+    let signing_mode = signing_mode.unwrap_or(&default_mode);
+
+    let authorized_signer = options.authorized_signer.unwrap_or(payer);
+    let salt = B256::random();
+
+    let open_data = ITIP20ChannelReserve::openCall::new((
+        options.payee,
+        options.operator,
+        options.currency,
+        Uint::<96, 2>::from(options.deposit),
+        salt,
+        authorized_signer,
+    ))
+    .abi_encode();
+
+    let calls = vec![Call {
+        to: TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS),
+        value: U256::ZERO,
+        input: Bytes::from(open_data),
+    }];
+
+    let nonce = provider
+        .get_transaction_count(payer)
+        .await
+        .mpp_http("failed to get nonce")?;
+
+    let gas_price = provider
+        .get_gas_price()
+        .await
+        .mpp_http("failed to get gas price")?;
+
+    let unsigned_tx = crate::client::tempo::charge::tx_builder::build_tempo_tx(
+        crate::client::tempo::charge::tx_builder::TempoTxOptions {
+            calls,
+            chain_id: options.chain_id,
+            fee_token: options.currency,
+            nonce,
+            nonce_key: U256::ZERO,
+            gas_limit: 2_000_000,
+            max_fee_per_gas: gas_price,
+            max_priority_fee_per_gas: gas_price,
+            fee_payer: options.fee_payer,
+            valid_before: None,
+            key_authorization: signing_mode.key_authorization().cloned(),
+        },
+    );
+
+    // Derive id from the unsigned tx before signing; expiringNonceHash binds
+    // the signing-payload bytes.
+    let expiring_nonce_hash = compute_expiring_nonce_hash(&unsigned_tx, payer);
+    let channel_id = compute_precompile_channel_id(
+        payer,
+        options.payee,
+        options.operator,
+        options.currency,
+        salt,
+        authorized_signer,
+        expiring_nonce_hash,
+        options.chain_id,
+    );
+
+    let tx_bytes =
+        crate::client::tempo::signing::sign_and_encode_async(unsigned_tx, signer, signing_mode)
+            .await?;
+    let signed_tx_hex = alloy::hex::encode_prefixed(&tx_bytes);
+
+    let voucher_sig =
+        sign_precompile_voucher(signer, channel_id, options.initial_amount, options.chain_id)
+            .await?;
+
+    let entry = ChannelEntry {
+        channel_id,
+        salt,
+        cumulative_amount: options.initial_amount,
+        escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id: options.chain_id,
+        opened: true,
+    };
+
+    let payload = SessionCredentialPayload::Open {
+        payload_type: "transaction".to_string(),
+        channel_id: channel_id.to_string(),
+        transaction: signed_tx_hex,
+        authorized_signer: Some(authorized_signer.to_string()),
+        cumulative_amount: options.initial_amount.to_string(),
+        signature: alloy::hex::encode_prefixed(&voucher_sig),
+    };
+
+    Ok((entry, payload))
+}
+
 /// On-chain channel state returned by the escrow contract.
 #[derive(Debug, Clone)]
 pub struct OnChainChannel {
@@ -438,6 +596,97 @@ mod tests {
         assert!(default_escrow_contract(4217).is_some());
         assert!(default_escrow_contract(42431).is_some());
         assert!(default_escrow_contract(1).is_none());
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_is_precompile_escrow() {
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+        assert!(is_precompile_escrow(TIP20_CHANNEL_RESERVE_ADDRESS));
+        assert!(is_precompile_escrow(
+            "0x4D50500000000000000000000000000000000000"
+                .parse()
+                .unwrap()
+        ));
+        assert!(!is_precompile_escrow(
+            default_escrow_contract(4217).unwrap()
+        ));
+        assert!(!is_precompile_escrow(
+            default_escrow_contract(42431).unwrap()
+        ));
+        assert!(!is_precompile_escrow(Address::ZERO));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_compute_expiring_nonce_hash_matches_on_chain_formula() {
+        // Mirrors tempo `unique_tx_identifier_from_signable`
+        // (crates/primitives/src/transaction/mod.rs L37-L45).
+        use alloy::consensus::SignableTransaction;
+        use alloy::primitives::keccak256;
+        use tempo_primitives::transaction::TempoTransaction;
+
+        let payer = Address::repeat_byte(0xAA);
+        let calls = vec![tempo_primitives::transaction::Call {
+            to: TxKind::Call(Address::repeat_byte(0x11)),
+            value: U256::ZERO,
+            input: alloy::primitives::Bytes::new(),
+        }];
+
+        let tx: TempoTransaction = crate::client::tempo::charge::tx_builder::build_tempo_tx(
+            crate::client::tempo::charge::tx_builder::TempoTxOptions {
+                calls,
+                chain_id: 4217,
+                fee_token: Address::repeat_byte(0x22),
+                nonce: 7,
+                nonce_key: U256::ZERO,
+                gas_limit: 500_000,
+                max_fee_per_gas: 1_000_000_000,
+                max_priority_fee_per_gas: 100_000_000,
+                fee_payer: false,
+                valid_before: None,
+                key_authorization: None,
+            },
+        );
+
+        let got = compute_expiring_nonce_hash(&tx, payer);
+
+        let mut expected_buf = Vec::with_capacity(tx.payload_len_for_signature() + 20);
+        tx.encode_for_signing(&mut expected_buf);
+        expected_buf.extend_from_slice(payer.as_slice());
+        assert_eq!(got, keccak256(expected_buf));
+
+        let other_sender = Address::repeat_byte(0xBB);
+        assert_ne!(compute_expiring_nonce_hash(&tx, other_sender), got);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn test_create_precompile_open_payload_rejects_uint96_overflow() {
+        use crate::protocol::methods::tempo::precompile_voucher::PRECOMPILE_MAX_CUMULATIVE_AMOUNT;
+        use alloy::providers::ProviderBuilder;
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let payer = signer.address();
+        // Validation runs before any network IO.
+        let provider = ProviderBuilder::<_, _, TempoNetwork>::default()
+            .connect_http("http://localhost:1".parse().unwrap());
+
+        let opts = OpenPrecompilePayloadOptions {
+            operator: Address::ZERO,
+            authorized_signer: None,
+            payee: Address::repeat_byte(0x11),
+            currency: Address::repeat_byte(0x22),
+            deposit: PRECOMPILE_MAX_CUMULATIVE_AMOUNT + 1,
+            initial_amount: 1,
+            chain_id: 4217,
+            fee_payer: false,
+        };
+        let err = create_precompile_open_payload(&provider, &signer, None, payer, opts)
+            .await
+            .expect_err("deposit > uint96 must be rejected");
+        assert!(matches!(err, MppError::InvalidConfig(_)));
     }
 
     #[test]

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -15,6 +15,7 @@ use tempo_alloy::contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RE
 use tempo_alloy::TempoNetwork;
 use tempo_primitives::transaction::{Call, TempoTransaction};
 
+use crate::client::tempo::charge::tx_builder::{build_tempo_tx, TempoTxOptions};
 use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
@@ -132,6 +133,24 @@ pub async fn create_voucher_payload(
     })
 }
 
+/// Voucher payload for TIP-1034 precompile escrow (EIP-712 domain pinned to
+/// `TIP20_CHANNEL_RESERVE_ADDRESS`).
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_voucher_payload(
+    signer: &impl Signer,
+    channel_id: B256,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    let sig = sign_precompile_voucher(signer, channel_id, cumulative_amount, chain_id).await?;
+
+    Ok(SessionCredentialPayload::Voucher {
+        channel_id: channel_id.to_string(),
+        cumulative_amount: cumulative_amount.to_string(),
+        signature: alloy::hex::encode_prefixed(&sig),
+    })
+}
+
 /// Create a close payload by signing a voucher with close action.
 pub async fn create_close_payload(
     signer: &impl Signer,
@@ -148,6 +167,23 @@ pub async fn create_close_payload(
         chain_id,
     )
     .await?;
+
+    Ok(SessionCredentialPayload::Close {
+        channel_id: channel_id.to_string(),
+        cumulative_amount: cumulative_amount.to_string(),
+        signature: alloy::hex::encode_prefixed(&sig),
+    })
+}
+
+/// Close payload for TIP-1034 precompile escrow.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_close_payload(
+    signer: &impl Signer,
+    channel_id: B256,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    let sig = sign_precompile_voucher(signer, channel_id, cumulative_amount, chain_id).await?;
 
     Ok(SessionCredentialPayload::Close {
         channel_id: channel_id.to_string(),
@@ -261,21 +297,19 @@ where
         .await
         .mpp_http("failed to get gas price")?;
 
-    let tempo_tx = crate::client::tempo::charge::tx_builder::build_tempo_tx(
-        crate::client::tempo::charge::tx_builder::TempoTxOptions {
-            calls,
-            chain_id: options.chain_id,
-            fee_token: options.currency,
-            nonce,
-            nonce_key: U256::ZERO,
-            gas_limit: 2_000_000,
-            max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: gas_price,
-            fee_payer: options.fee_payer,
-            valid_before: None,
-            key_authorization: signing_mode.key_authorization().cloned(),
-        },
-    );
+    let tempo_tx = build_tempo_tx(TempoTxOptions {
+        calls,
+        chain_id: options.chain_id,
+        fee_token: options.currency,
+        nonce,
+        nonce_key: U256::ZERO,
+        gas_limit: 2_000_000,
+        max_fee_per_gas: gas_price,
+        max_priority_fee_per_gas: gas_price,
+        fee_payer: options.fee_payer,
+        valid_before: None,
+        key_authorization: signing_mode.key_authorization().cloned(),
+    });
 
     let tx_bytes =
         crate::client::tempo::signing::sign_and_encode_async(tempo_tx, signer, signing_mode)
@@ -405,21 +439,19 @@ where
         .await
         .mpp_http("failed to get gas price")?;
 
-    let unsigned_tx = crate::client::tempo::charge::tx_builder::build_tempo_tx(
-        crate::client::tempo::charge::tx_builder::TempoTxOptions {
-            calls,
-            chain_id: options.chain_id,
-            fee_token: options.currency,
-            nonce,
-            nonce_key: U256::ZERO,
-            gas_limit: 2_000_000,
-            max_fee_per_gas: gas_price,
-            max_priority_fee_per_gas: gas_price,
-            fee_payer: options.fee_payer,
-            valid_before: None,
-            key_authorization: signing_mode.key_authorization().cloned(),
-        },
-    );
+    let unsigned_tx = build_tempo_tx(TempoTxOptions {
+        calls,
+        chain_id: options.chain_id,
+        fee_token: options.currency,
+        nonce,
+        nonce_key: U256::ZERO,
+        gas_limit: 2_000_000,
+        max_fee_per_gas: gas_price,
+        max_priority_fee_per_gas: gas_price,
+        fee_payer: options.fee_payer,
+        valid_before: None,
+        key_authorization: signing_mode.key_authorization().cloned(),
+    });
 
     // Derive id from the unsigned tx before signing; expiringNonceHash binds
     // the signing-payload bytes.
@@ -633,21 +665,19 @@ mod tests {
             input: alloy::primitives::Bytes::new(),
         }];
 
-        let tx: TempoTransaction = crate::client::tempo::charge::tx_builder::build_tempo_tx(
-            crate::client::tempo::charge::tx_builder::TempoTxOptions {
-                calls,
-                chain_id: 4217,
-                fee_token: Address::repeat_byte(0x22),
-                nonce: 7,
-                nonce_key: U256::ZERO,
-                gas_limit: 500_000,
-                max_fee_per_gas: 1_000_000_000,
-                max_priority_fee_per_gas: 100_000_000,
-                fee_payer: false,
-                valid_before: None,
-                key_authorization: None,
-            },
-        );
+        let tx: TempoTransaction = build_tempo_tx(TempoTxOptions {
+            calls,
+            chain_id: 4217,
+            fee_token: Address::repeat_byte(0x22),
+            nonce: 7,
+            nonce_key: U256::ZERO,
+            gas_limit: 500_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 100_000_000,
+            fee_payer: false,
+            valid_before: None,
+            key_authorization: None,
+        });
 
         let got = compute_expiring_nonce_hash(&tx, payer);
 

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -160,8 +160,31 @@ impl TempoSessionProvider {
         }
     }
 
-    fn channel_key(payee: &Address, currency: &Address, escrow: &Address) -> String {
-        format!("{:#x}:{:#x}:{:#x}", payee, currency, escrow)
+    /// Cache key identifying a channel. Precompile channel ids bind `operator`,
+    /// so it is appended for precompile channels; legacy keys are unchanged.
+    fn channel_key(
+        payee: &Address,
+        currency: &Address,
+        escrow: &Address,
+        operator: Option<Address>,
+    ) -> String {
+        match operator {
+            Some(op) => format!("{:#x}:{:#x}:{:#x}:{:#x}", payee, currency, escrow, op),
+            None => format!("{:#x}:{:#x}:{:#x}", payee, currency, escrow),
+        }
+    }
+
+    /// Operator identity for the cache key: the parsed operator for precompile
+    /// escrow, `None` for legacy escrow.
+    fn key_operator(
+        escrow: &Address,
+        session_req: &SessionRequest,
+    ) -> Result<Option<Address>, MppError> {
+        if is_precompile_escrow(*escrow) {
+            Ok(Some(Self::parse_operator(session_req)?))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Parse `methodDetails.operator` from a precompile session request.
@@ -206,8 +229,10 @@ impl TempoSessionProvider {
             .parse()
             .map_err(|_| MppError::InvalidConfig("invalid currency address".to_string()))?;
 
+        let operator = Self::key_operator(&escrow_contract, &session_req)?;
+
         Ok((
-            Self::channel_key(&payee, &currency, &escrow_contract),
+            Self::channel_key(&payee, &currency, &escrow_contract, operator),
             chain_id,
         ))
     }
@@ -484,7 +509,8 @@ impl PaymentProvider for TempoSessionProvider {
         let amount: u128 = session_req.parse_amount()?;
         let payer = self.signing_mode.from_address(self.signer.address());
         let precompile = is_precompile_escrow(escrow_contract);
-        let key = Self::channel_key(&payee, &currency, &escrow_contract);
+        let operator = Self::key_operator(&escrow_contract, &session_req)?;
+        let key = Self::channel_key(&payee, &currency, &escrow_contract, operator);
 
         // Check if we already have a channel
         let existing = self.channels.lock().unwrap().get(&key).cloned();
@@ -581,7 +607,7 @@ impl PaymentProvider for TempoSessionProvider {
                 Some(&self.signing_mode),
                 payer,
                 OpenPrecompilePayloadOptions {
-                    operator: Self::parse_operator(&session_req)?,
+                    operator: operator.unwrap_or(Address::ZERO),
                     authorized_signer: self.authorized_signer,
                     payee,
                     currency,
@@ -754,11 +780,19 @@ mod tests {
             .parse()
             .unwrap();
 
-        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow);
-        // Should be lowercase
+        // Legacy: no operator → 3 fields.
+        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, None);
         assert_eq!(key, key.to_lowercase());
-        // Should contain all three addresses separated by colons
         assert_eq!(key.matches(':').count(), 2);
+
+        // Precompile: operator appended → 4 fields, distinct per operator.
+        let op_a = Address::repeat_byte(0x01);
+        let op_b = Address::repeat_byte(0x02);
+        let key_a = TempoSessionProvider::channel_key(&payee, &currency, &escrow, Some(op_a));
+        let key_b = TempoSessionProvider::channel_key(&payee, &currency, &escrow, Some(op_b));
+        assert_eq!(key_a.matches(':').count(), 3);
+        assert_ne!(key_a, key_b);
+        assert_ne!(key_a, key);
     }
 
     #[test]
@@ -1109,7 +1143,7 @@ mod tests {
         *provider.last_challenge.lock().unwrap() =
             Some(make_scoped_challenge(expected_payee, currency, escrow));
 
-        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow);
+        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, None);
         provider
             .channel_id_to_key
             .lock()
@@ -1175,7 +1209,7 @@ mod tests {
         *provider.last_challenge.lock().unwrap() =
             Some(make_scoped_challenge(expected_payee, currency, escrow));
 
-        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow);
+        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, None);
         provider.channels.lock().unwrap().insert(
             other_key,
             ChannelEntry {
@@ -1310,6 +1344,31 @@ mod tests {
     }
 
     #[cfg(feature = "tempo")]
+    #[test]
+    fn key_operator_only_applies_to_precompile_escrow() {
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        let op = Address::repeat_byte(0x42);
+        let req = SessionRequest {
+            method_details: Some(serde_json::json!({ "operator": op.to_string() })),
+            ..Default::default()
+        };
+
+        // Legacy escrow ignores operator → None (keeps legacy key shape).
+        let legacy = Address::repeat_byte(0x44);
+        assert_eq!(
+            TempoSessionProvider::key_operator(&legacy, &req).unwrap(),
+            None
+        );
+
+        // Precompile escrow binds operator → Some.
+        assert_eq!(
+            TempoSessionProvider::key_operator(&TIP20_CHANNEL_RESERVE_ADDRESS, &req).unwrap(),
+            Some(op)
+        );
+    }
+
+    #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn pay_branches_to_precompile_voucher_for_existing_precompile_channel() {
         use alloy::signers::local::PrivateKeySigner;
@@ -1346,8 +1405,12 @@ mod tests {
             TempoSessionProvider::new(signer.clone(), "https://rpc.example.com").unwrap();
 
         // Pre-seed an open precompile channel under the registry key.
-        let key =
-            TempoSessionProvider::channel_key(&payee, &currency, &TIP20_CHANNEL_RESERVE_ADDRESS);
+        let key = TempoSessionProvider::channel_key(
+            &payee,
+            &currency,
+            &TIP20_CHANNEL_RESERVE_ADDRESS,
+            Some(operator),
+        );
         provider.channels.lock().unwrap().insert(
             key,
             ChannelEntry {

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -13,8 +13,10 @@ use std::sync::{Arc, Mutex};
 use alloy::primitives::{Address, B256};
 
 use self::channel_ops::{
-    build_credential, create_close_payload, create_open_payload, create_voucher_payload,
-    resolve_chain_id, resolve_escrow, try_recover_channel, ChannelEntry, OpenPayloadOptions,
+    build_credential, create_close_payload, create_open_payload, create_precompile_close_payload,
+    create_precompile_open_payload, create_precompile_voucher_payload, create_voucher_payload,
+    is_precompile_escrow, resolve_chain_id, resolve_escrow, try_recover_channel, ChannelEntry,
+    OpenPayloadOptions, OpenPrecompilePayloadOptions,
 };
 use crate::client::PaymentProvider;
 use crate::error::{MppError, ResultExt};
@@ -162,6 +164,25 @@ impl TempoSessionProvider {
         format!("{:#x}:{:#x}:{:#x}", payee, currency, escrow)
     }
 
+    /// Parse `methodDetails.operator` from a precompile session request.
+    /// Missing → `Address::ZERO` (payee-only operator).
+    fn parse_operator(session_req: &SessionRequest) -> Result<Address, MppError> {
+        match session_req
+            .method_details
+            .as_ref()
+            .and_then(|v| v.get("operator"))
+        {
+            None => Ok(Address::ZERO),
+            Some(v) => {
+                let s = v.as_str().ok_or_else(|| {
+                    MppError::InvalidConfig("methodDetails.operator must be a string".to_string())
+                })?;
+                s.parse::<Address>()
+                    .map_err(|_| MppError::InvalidConfig(format!("invalid operator address: {s}")))
+            }
+        }
+    }
+
     fn expected_channel_key(
         &self,
         challenge: &PaymentChallenge,
@@ -256,14 +277,24 @@ impl TempoSessionProvider {
             entry.cumulative_amount = required_cumulative;
         }
 
-        let payload = create_voucher_payload(
-            &self.signer,
-            entry.channel_id,
-            entry.cumulative_amount,
-            entry.escrow_contract,
-            entry.chain_id,
-        )
-        .await?;
+        let payload = if is_precompile_escrow(entry.escrow_contract) {
+            create_precompile_voucher_payload(
+                &self.signer,
+                entry.channel_id,
+                entry.cumulative_amount,
+                entry.chain_id,
+            )
+            .await?
+        } else {
+            create_voucher_payload(
+                &self.signer,
+                entry.channel_id,
+                entry.cumulative_amount,
+                entry.escrow_contract,
+                entry.chain_id,
+            )
+            .await?
+        };
 
         // Update the registry
         self.channels.lock().unwrap().insert(key, entry.clone());
@@ -342,14 +373,24 @@ impl TempoSessionProvider {
 
         let payer = self.signer.address();
 
-        let payload = create_close_payload(
-            &self.signer,
-            entry.channel_id,
-            entry.cumulative_amount,
-            entry.escrow_contract,
-            entry.chain_id,
-        )
-        .await?;
+        let payload = if is_precompile_escrow(entry.escrow_contract) {
+            create_precompile_close_payload(
+                &self.signer,
+                entry.channel_id,
+                entry.cumulative_amount,
+                entry.chain_id,
+            )
+            .await?
+        } else {
+            create_close_payload(
+                &self.signer,
+                entry.channel_id,
+                entry.cumulative_amount,
+                entry.escrow_contract,
+                entry.chain_id,
+            )
+            .await?
+        };
 
         let credential = build_credential(&challenge, payload, entry.chain_id, payer);
 
@@ -442,6 +483,7 @@ impl PaymentProvider for TempoSessionProvider {
 
         let amount: u128 = session_req.parse_amount()?;
         let payer = self.signing_mode.from_address(self.signer.address());
+        let precompile = is_precompile_escrow(escrow_contract);
         let key = Self::channel_key(&payee, &currency, &escrow_contract);
 
         // Check if we already have a channel
@@ -452,14 +494,24 @@ impl PaymentProvider for TempoSessionProvider {
                 // Increment cumulative and sign a voucher
                 entry.cumulative_amount += amount;
 
-                let payload = create_voucher_payload(
-                    &self.signer,
-                    entry.channel_id,
-                    entry.cumulative_amount,
-                    escrow_contract,
-                    chain_id,
-                )
-                .await?;
+                let payload = if precompile {
+                    create_precompile_voucher_payload(
+                        &self.signer,
+                        entry.channel_id,
+                        entry.cumulative_amount,
+                        chain_id,
+                    )
+                    .await?
+                } else {
+                    create_voucher_payload(
+                        &self.signer,
+                        entry.channel_id,
+                        entry.cumulative_amount,
+                        escrow_contract,
+                        chain_id,
+                    )
+                    .await?
+                };
 
                 // Update the registry
                 self.channels.lock().unwrap().insert(key, entry.clone());
@@ -469,46 +521,49 @@ impl PaymentProvider for TempoSessionProvider {
             }
         }
 
-        // Try to recover a channel from on-chain state if suggested
-        let suggested_channel_id = session_req.channel_id();
-        if let Some(ref cid_str) = suggested_channel_id {
-            if let Ok(cid) = cid_str.parse::<B256>() {
-                let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-                    .connect_http(self.rpc_url.clone());
+        // Try to recover a channel from on-chain state if suggested. Precompile
+        // escrow has a different read ABI (TIP-1034); recovery is legacy-only.
+        if !precompile {
+            let suggested_channel_id = session_req.channel_id();
+            if let Some(ref cid_str) = suggested_channel_id {
+                if let Ok(cid) = cid_str.parse::<B256>() {
+                    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+                        .connect_http(self.rpc_url.clone());
 
-                let expected_authorized_signer = self.authorized_signer.unwrap_or(payer);
-                if let Some(mut recovered) = try_recover_channel(
-                    &provider,
-                    escrow_contract,
-                    cid,
-                    chain_id,
-                    payer,
-                    payee,
-                    currency,
-                    expected_authorized_signer,
-                )
-                .await
-                {
-                    // Start from recovered settled amount + request amount
-                    recovered.cumulative_amount += amount;
-
-                    let payload = create_voucher_payload(
-                        &self.signer,
-                        recovered.channel_id,
-                        recovered.cumulative_amount,
+                    let expected_authorized_signer = self.authorized_signer.unwrap_or(payer);
+                    if let Some(mut recovered) = try_recover_channel(
+                        &provider,
                         escrow_contract,
+                        cid,
                         chain_id,
+                        payer,
+                        payee,
+                        currency,
+                        expected_authorized_signer,
                     )
-                    .await?;
+                    .await
+                    {
+                        // Start from recovered settled amount + request amount
+                        recovered.cumulative_amount += amount;
 
-                    self.channel_id_to_key
-                        .lock()
-                        .unwrap()
-                        .insert(recovered.channel_id.to_string(), key.clone());
-                    self.channels.lock().unwrap().insert(key, recovered.clone());
-                    self.notify_update(&recovered);
+                        let payload = create_voucher_payload(
+                            &self.signer,
+                            recovered.channel_id,
+                            recovered.cumulative_amount,
+                            escrow_contract,
+                            chain_id,
+                        )
+                        .await?;
 
-                    return Ok(build_credential(challenge, payload, chain_id, payer));
+                        self.channel_id_to_key
+                            .lock()
+                            .unwrap()
+                            .insert(recovered.channel_id.to_string(), key.clone());
+                        self.channels.lock().unwrap().insert(key, recovered.clone());
+                        self.notify_update(&recovered);
+
+                        return Ok(build_credential(challenge, payload, chain_id, payer));
+                    }
                 }
             }
         }
@@ -519,23 +574,43 @@ impl PaymentProvider for TempoSessionProvider {
         let provider =
             ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(self.rpc_url.clone());
 
-        let (entry, payload) = create_open_payload(
-            &provider,
-            &self.signer,
-            Some(&self.signing_mode),
-            payer,
-            OpenPayloadOptions {
-                authorized_signer: self.authorized_signer,
-                escrow_contract,
-                payee,
-                currency,
-                deposit,
-                initial_amount: amount,
-                chain_id,
-                fee_payer: session_req.fee_payer(),
-            },
-        )
-        .await?;
+        let (entry, payload) = if precompile {
+            create_precompile_open_payload(
+                &provider,
+                &self.signer,
+                Some(&self.signing_mode),
+                payer,
+                OpenPrecompilePayloadOptions {
+                    operator: Self::parse_operator(&session_req)?,
+                    authorized_signer: self.authorized_signer,
+                    payee,
+                    currency,
+                    deposit,
+                    initial_amount: amount,
+                    chain_id,
+                    fee_payer: session_req.fee_payer(),
+                },
+            )
+            .await?
+        } else {
+            create_open_payload(
+                &provider,
+                &self.signer,
+                Some(&self.signing_mode),
+                payer,
+                OpenPayloadOptions {
+                    authorized_signer: self.authorized_signer,
+                    escrow_contract,
+                    payee,
+                    currency,
+                    deposit,
+                    initial_amount: amount,
+                    chain_id,
+                    fee_payer: session_req.fee_payer(),
+                },
+            )
+            .await?
+        };
 
         self.channel_id_to_key
             .lock()
@@ -1205,5 +1280,130 @@ mod tests {
             5000,
             "cumulative should only count the opened channel"
         );
+    }
+
+    #[test]
+    fn parse_operator_handles_missing_present_and_malformed() {
+        // Missing methodDetails → ZERO.
+        let req = SessionRequest::default();
+        assert_eq!(
+            TempoSessionProvider::parse_operator(&req).unwrap(),
+            Address::ZERO
+        );
+
+        // Present → parsed.
+        let op = Address::repeat_byte(0x42);
+        let req = SessionRequest {
+            method_details: Some(serde_json::json!({ "operator": op.to_string() })),
+            ..Default::default()
+        };
+        assert_eq!(TempoSessionProvider::parse_operator(&req).unwrap(), op);
+
+        // Malformed string and non-string → error.
+        for v in [serde_json::json!("not-an-address"), serde_json::json!(42)] {
+            let req = SessionRequest {
+                method_details: Some(serde_json::json!({ "operator": v })),
+                ..Default::default()
+            };
+            assert!(TempoSessionProvider::parse_operator(&req).is_err());
+        }
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn pay_branches_to_precompile_voucher_for_existing_precompile_channel() {
+        use alloy::signers::local::PrivateKeySigner;
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        use crate::client::tempo::session::channel_ops::ChannelEntry;
+        use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
+        use crate::protocol::methods::tempo::precompile_voucher::{
+            compute_precompile_channel_id, sign_precompile_voucher,
+        };
+
+        let signer = PrivateKeySigner::random();
+        let payer = signer.address();
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let operator = Address::repeat_byte(0x33);
+        let salt = B256::repeat_byte(0xab);
+        let authorized_signer = payer;
+        let chain_id = 42431u64;
+        let expiring_nonce_hash = B256::repeat_byte(0xcd);
+
+        let channel_id = compute_precompile_channel_id(
+            payer,
+            payee,
+            operator,
+            currency,
+            salt,
+            authorized_signer,
+            expiring_nonce_hash,
+            chain_id,
+        );
+
+        let provider =
+            TempoSessionProvider::new(signer.clone(), "https://rpc.example.com").unwrap();
+
+        // Pre-seed an open precompile channel under the registry key.
+        let key =
+            TempoSessionProvider::channel_key(&payee, &currency, &TIP20_CHANNEL_RESERVE_ADDRESS);
+        provider.channels.lock().unwrap().insert(
+            key,
+            ChannelEntry {
+                channel_id,
+                salt,
+                cumulative_amount: 1_000,
+                escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+                chain_id,
+                opened: true,
+            },
+        );
+
+        let req = SessionRequest {
+            amount: "500".to_string(),
+            currency: currency.to_string(),
+            recipient: Some(payee.to_string()),
+            method_details: Some(serde_json::json!({
+                "chainId": chain_id,
+                "escrowContract": TIP20_CHANNEL_RESERVE_ADDRESS.to_string(),
+                "operator": operator.to_string(),
+            })),
+            ..Default::default()
+        };
+        let challenge = PaymentChallenge::new(
+            "test-challenge",
+            "rpc.example.com",
+            crate::protocol::methods::tempo::METHOD_NAME,
+            crate::protocol::methods::tempo::INTENT_SESSION,
+            Base64UrlJson::from_typed(&req).unwrap(),
+        );
+
+        let credential = provider.pay(&challenge).await.expect("pay succeeds");
+
+        // Expected: precompile EIP-712 voucher signed over cumulative 1500.
+        let expected_sig = sign_precompile_voucher(&signer, channel_id, 1_500, chain_id)
+            .await
+            .unwrap();
+        let expected_hex = alloy::hex::encode_prefixed(&expected_sig);
+
+        match credential
+            .payload_as::<crate::protocol::methods::tempo::session::SessionCredentialPayload>()
+            .unwrap()
+        {
+            crate::protocol::methods::tempo::session::SessionCredentialPayload::Voucher {
+                signature,
+                cumulative_amount,
+                channel_id: cid,
+            } => {
+                assert_eq!(cumulative_amount, "1500");
+                assert_eq!(cid, channel_id.to_string());
+                assert_eq!(
+                    signature, expected_hex,
+                    "voucher must use precompile EIP-712 domain"
+                );
+            }
+            other => panic!("expected voucher payload, got {other:?}"),
+        }
     }
 }

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -99,6 +99,8 @@
 pub mod charge;
 pub mod fee_payer_envelope;
 pub mod network;
+#[cfg(feature = "tempo")]
+pub mod precompile_voucher;
 pub(crate) mod proof;
 pub mod session;
 pub mod session_receipt;
@@ -125,6 +127,11 @@ pub use session_receipt as stream_receipt;
 /// Deprecated: use [`SessionReceipt`] instead. Remove in next major version.
 #[deprecated(since = "0.5.0", note = "renamed to SessionReceipt")]
 pub type StreamReceipt = SessionReceipt;
+#[cfg(feature = "tempo")]
+pub use precompile_voucher::{
+    compute_precompile_channel_id, sign_precompile_voucher, PRECOMPILE_DOMAIN_NAME,
+    PRECOMPILE_DOMAIN_VERSION, PRECOMPILE_MAX_CUMULATIVE_AMOUNT,
+};
 pub use transaction::{
     Call, SignatureType, TempoTransaction, TempoTransactionRequest, TEMPO_SEND_TRANSACTION_METHOD,
     TEMPO_TX_TYPE_ID,

--- a/src/protocol/methods/tempo/precompile_voucher.rs
+++ b/src/protocol/methods/tempo/precompile_voucher.rs
@@ -1,0 +1,294 @@
+//! T5 TIP-1034 reserve channel precompile voucher signing and channel-id
+//! computation. Companion to [`voucher`](super::voucher) for the legacy
+//! Solidity escrow.
+
+#[cfg(feature = "tempo")]
+use alloy::primitives::{keccak256, Address, Bytes, Uint, B256, U256};
+#[cfg(feature = "tempo")]
+use alloy::signers::Signer;
+#[cfg(feature = "tempo")]
+use alloy::sol_types::{eip712_domain, SolStruct, SolValue};
+#[cfg(feature = "tempo")]
+use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+#[cfg(feature = "tempo")]
+use crate::error::{MppError, Result};
+
+/// EIP-712 domain name verified by the precompile.
+pub const PRECOMPILE_DOMAIN_NAME: &str = "TIP20 Channel Reserve";
+
+/// EIP-712 domain version verified by the precompile.
+pub const PRECOMPILE_DOMAIN_VERSION: &str = "1";
+
+/// Compute a TIP-1034 channel id. `expiring_nonce_hash` must come from the
+/// unsigned open tx via [`compute_expiring_nonce_hash`](crate::client::tempo::session::channel_ops::compute_expiring_nonce_hash).
+#[cfg(feature = "tempo")]
+#[allow(clippy::too_many_arguments)]
+pub fn compute_precompile_channel_id(
+    payer: Address,
+    payee: Address,
+    operator: Address,
+    token: Address,
+    salt: B256,
+    authorized_signer: Address,
+    expiring_nonce_hash: B256,
+    chain_id: u64,
+) -> B256 {
+    let encoded = (
+        payer,
+        payee,
+        operator,
+        token,
+        salt,
+        authorized_signer,
+        expiring_nonce_hash,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        U256::from(chain_id),
+    )
+        .abi_encode();
+    keccak256(&encoded)
+}
+
+#[cfg(feature = "tempo")]
+alloy::sol! {
+    /// EIP-712 voucher struct. `uint96` (legacy escrow uses `uint128`).
+    #[derive(Debug)]
+    struct PrecompileVoucher {
+        bytes32 channelId;
+        uint96 cumulativeAmount;
+    }
+}
+
+/// Maximum cumulative amount the precompile accepts (2^96 − 1).
+#[cfg(feature = "tempo")]
+pub const PRECOMPILE_MAX_CUMULATIVE_AMOUNT: u128 = (1u128 << 96) - 1;
+
+/// Sign a TIP-1034 voucher (EIP-712). Returns 65-byte ECDSA signature.
+/// Rejects `cumulative_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT` with
+/// [`MppError::InvalidConfig`](crate::error::MppError::InvalidConfig).
+#[cfg(feature = "tempo")]
+pub async fn sign_precompile_voucher(
+    signer: &impl Signer,
+    channel_id: B256,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<Bytes> {
+    if cumulative_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+        return Err(MppError::InvalidConfig(format!(
+            "cumulative_amount {cumulative_amount} exceeds precompile uint96 max"
+        )));
+    }
+
+    let domain = eip712_domain! {
+        name: PRECOMPILE_DOMAIN_NAME,
+        version: PRECOMPILE_DOMAIN_VERSION,
+        chain_id: chain_id,
+        verifying_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+    };
+
+    let voucher = PrecompileVoucher {
+        channelId: channel_id,
+        cumulativeAmount: Uint::<96, 2>::from(cumulative_amount),
+    };
+
+    let signing_hash = voucher.eip712_signing_hash(&domain);
+    let signature = signer.sign_hash(&signing_hash).await.map_err(|e| {
+        MppError::InvalidSignature(Some(format!("failed to sign precompile voucher: {e}")))
+    })?;
+
+    Ok(Bytes::from(signature.as_bytes().to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn compute_precompile_channel_id_matches_precompile_formula() {
+        use alloy::primitives::{Address, B256};
+
+        // Reference vector: tempo @ 32bb1d4 crates/precompiles/src/tip20_channel_reserve/mod.rs L589-L613
+        let payer: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let payee: Address = "0x2222222222222222222222222222222222222222"
+            .parse()
+            .unwrap();
+        let operator: Address = "0x3333333333333333333333333333333333333333"
+            .parse()
+            .unwrap();
+        let token: Address = "0x4444444444444444444444444444444444444444"
+            .parse()
+            .unwrap();
+        let salt = B256::repeat_byte(0x55);
+        let authorized_signer: Address = "0x6666666666666666666666666666666666666666"
+            .parse()
+            .unwrap();
+        let expiring_nonce_hash = B256::repeat_byte(0x77);
+        let chain_id = 4217u64;
+
+        let id = compute_precompile_channel_id(
+            payer,
+            payee,
+            operator,
+            token,
+            salt,
+            authorized_signer,
+            expiring_nonce_hash,
+            chain_id,
+        );
+
+        let again = compute_precompile_channel_id(
+            payer,
+            payee,
+            operator,
+            token,
+            salt,
+            authorized_signer,
+            expiring_nonce_hash,
+            chain_id,
+        );
+        assert_eq!(id, again);
+        assert_ne!(id, B256::ZERO);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn compute_precompile_channel_id_differs_from_legacy_formula() {
+        // Precompile binds operator + expiringNonceHash + precompile addr; legacy doesn't.
+        use alloy::primitives::{Address, B256};
+
+        let payer: Address = "0x1111111111111111111111111111111111111111"
+            .parse()
+            .unwrap();
+        let payee: Address = "0x2222222222222222222222222222222222222222"
+            .parse()
+            .unwrap();
+        let token: Address = "0x3333333333333333333333333333333333333333"
+            .parse()
+            .unwrap();
+        let salt = B256::repeat_byte(0x44);
+        let authorized_signer: Address = "0x5555555555555555555555555555555555555555"
+            .parse()
+            .unwrap();
+        let chain_id = 4217u64;
+
+        let precompile_id = compute_precompile_channel_id(
+            payer,
+            payee,
+            Address::ZERO,
+            token,
+            salt,
+            authorized_signer,
+            B256::ZERO,
+            chain_id,
+        );
+
+        let legacy_escrow: Address = "0x33b901018174DDabE4841042ab76ba85D4e24f25"
+            .parse()
+            .unwrap();
+        let legacy_id = super::super::voucher::compute_channel_id(
+            payer,
+            payee,
+            token,
+            salt,
+            authorized_signer,
+            legacy_escrow,
+            chain_id,
+        );
+
+        assert_ne!(precompile_id, legacy_id);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn sign_precompile_voucher_roundtrips_via_eip712() {
+        use alloy::primitives::{Bytes, B256};
+        use alloy::signers::local::PrivateKeySigner;
+        use alloy::sol_types::{eip712_domain, SolStruct};
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        let signer = PrivateKeySigner::random();
+        let channel_id = B256::repeat_byte(0xAB);
+        let cumulative: u128 = 12_345;
+        let chain_id = 4217u64;
+
+        let sig: Bytes = sign_precompile_voucher(&signer, channel_id, cumulative, chain_id)
+            .await
+            .unwrap();
+        assert_eq!(sig.len(), 65);
+
+        let domain = eip712_domain! {
+            name: PRECOMPILE_DOMAIN_NAME,
+            version: PRECOMPILE_DOMAIN_VERSION,
+            chain_id: chain_id,
+            verifying_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+        };
+        let voucher = PrecompileVoucher {
+            channelId: channel_id,
+            cumulativeAmount: alloy::primitives::Uint::<96, 2>::from(cumulative),
+        };
+        let hash = voucher.eip712_signing_hash(&domain);
+        let parsed = alloy::signers::Signature::try_from(sig.as_ref()).unwrap();
+        let recovered = parsed.recover_address_from_prehash(&hash).unwrap();
+        assert_eq!(recovered, signer.address());
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn sign_precompile_voucher_rejects_uint96_overflow() {
+        use alloy::primitives::B256;
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let too_big = PRECOMPILE_MAX_CUMULATIVE_AMOUNT + 1;
+        let err = sign_precompile_voucher(&signer, B256::ZERO, too_big, 4217)
+            .await
+            .expect_err("must reject u128 values that overflow uint96");
+        assert!(matches!(err, crate::error::MppError::InvalidConfig(_)));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn sign_precompile_voucher_accepts_uint96_max() {
+        use alloy::primitives::B256;
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        sign_precompile_voucher(&signer, B256::ZERO, PRECOMPILE_MAX_CUMULATIVE_AMOUNT, 4217)
+            .await
+            .expect("uint96 max must be accepted");
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn sign_precompile_voucher_domain_differs_from_legacy() {
+        // Guards against cross-wiring the two EIP-712 domains.
+        use alloy::primitives::{Address, B256};
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let channel_id = B256::repeat_byte(0xCD);
+        let amount: u128 = 1_000;
+        let chain_id = 4217u64;
+        let legacy_escrow: Address = "0x33b901018174DDabE4841042ab76ba85D4e24f25"
+            .parse()
+            .unwrap();
+
+        let precompile_sig = sign_precompile_voucher(&signer, channel_id, amount, chain_id)
+            .await
+            .unwrap();
+        let legacy_sig = super::super::voucher::sign_voucher(
+            &signer,
+            channel_id,
+            amount,
+            legacy_escrow,
+            chain_id,
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(precompile_sig, legacy_sig);
+    }
+}


### PR DESCRIPTION
Part of OSS-266

## Summary

Adds client-side support for the T5 TIP-1034 channel reserve precompile alongside the legacy Solidity escrow path. The precompile uses a different channel-id formula (binds `operator`, `expiringNonceHash`, precompile address), EIP-712 domain (`"TIP20 Channel Reserve"` v1, `verifyingContract = TIP20_CHANNEL_RESERVE_ADDRESS`), `uint96` cumulative amount, and single-call `open` (no `approve`, via TIP-1035), so legacy helpers can't produce signatures the precompile accepts.

## Usage

Downstream MPP clients (e.g. Foundry's MPP transport) branch on `is_precompile_escrow(escrow)` once per 402 challenge:

- **precompile branch** → `create_precompile_open_payload` for the open tx, `sign_precompile_voucher` for the initial and cached vouchers.
- **legacy branch** → existing `create_open_payload` / `sign_voucher`, untouched.