### PR TITLE
feat: strip sponsor access-list

### DIFF
--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -6,8 +6,12 @@
 
 pub mod keychain;
 
-use alloy::primitives::Address;
-use tempo_primitives::transaction::SignedKeyAuthorization;
+use alloy::eips::eip2930::AccessList;
+use alloy::eips::Encodable2718;
+use alloy::primitives::{Address, U256};
+use tempo_primitives::transaction::{
+    KeychainSignature, PrimitiveSignature, SignedKeyAuthorization, TempoSignature,
+};
 
 // Re-export so callers can set the version without importing tempo_primitives directly.
 pub use tempo_primitives::transaction::KeychainVersion;
@@ -72,8 +76,6 @@ fn effective_signing_hash(
     sig_hash: alloy::primitives::B256,
     mode: &TempoSigningMode,
 ) -> alloy::primitives::B256 {
-    use tempo_primitives::transaction::KeychainSignature;
-
     match mode {
         TempoSigningMode::Direct => sig_hash,
         TempoSigningMode::Keychain {
@@ -89,9 +91,7 @@ fn effective_signing_hash(
 fn build_tempo_signature(
     inner_signature: alloy::signers::Signature,
     mode: &TempoSigningMode,
-) -> tempo_primitives::transaction::TempoSignature {
-    use tempo_primitives::transaction::{KeychainSignature, PrimitiveSignature, TempoSignature};
-
+) -> TempoSignature {
     match mode {
         TempoSigningMode::Direct => {
             TempoSignature::Primitive(PrimitiveSignature::Secp256k1(inner_signature))
@@ -118,8 +118,6 @@ pub fn sign_and_encode(
     signer: &impl alloy::signers::SignerSync,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
-    use alloy::eips::Encodable2718;
-
     let sig_hash = tx.signature_hash();
     let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
@@ -134,13 +132,14 @@ pub fn sign_and_encode(
 ///
 /// The resulting bytes start with `0x78` and are meant to be sent to an MPPx server
 /// (or fee payer proxy) which will co-sign and broadcast.
+///
+/// `tx.access_list` is stripped before signing so the signature binds the
+/// shape the sponsor reconstructs (see [`FeePayerEnvelope78::to_recoverable_signed`]).
 pub fn sign_and_encode_fee_payer_envelope(
-    tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_primitives::transaction::TempoTransaction,
     signer: &(impl alloy::signers::SignerSync + alloy::signers::Signer),
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
-    use alloy::primitives::U256;
-
     let sender = mode.from_address(signer.address());
     if tx.fee_payer_signature.is_none() {
         return Err(MppError::InvalidConfig(
@@ -163,6 +162,8 @@ pub fn sign_and_encode_fee_payer_envelope(
             "fee payer envelope must include valid_before".to_string(),
         ));
     }
+
+    tx.access_list = AccessList::default();
 
     let sig_hash = tx.signature_hash();
     let hash_to_sign = effective_signing_hash(sig_hash, mode);
@@ -179,8 +180,6 @@ pub async fn sign_and_encode_async(
     signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
-    use alloy::eips::Encodable2718;
-
     let sig_hash = tx.signature_hash();
     let hash_to_sign = effective_signing_hash(sig_hash, mode);
     let inner_signature = signer
@@ -194,12 +193,10 @@ pub async fn sign_and_encode_async(
 
 /// Async version of [`sign_and_encode_fee_payer_envelope`].
 pub async fn sign_and_encode_fee_payer_envelope_async(
-    tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
-    use alloy::primitives::U256;
-
     let sender = mode.from_address(signer.address());
     if tx.fee_payer_signature.is_none() {
         return Err(MppError::InvalidConfig(
@@ -222,6 +219,8 @@ pub async fn sign_and_encode_fee_payer_envelope_async(
             "fee payer envelope must include valid_before".to_string(),
         ));
     }
+
+    tx.access_list = AccessList::default();
 
     let sig_hash = tx.signature_hash();
     let hash_to_sign = effective_signing_hash(sig_hash, mode);

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -62,6 +62,8 @@ impl FeePayerEnvelope78 {
     /// The provided `tx` is expected to be in the “fee payer signing shape”:
     /// - `fee_token == None` (server chooses fee token)
     /// - `fee_payer_signature.is_some()` placeholder (so `signature_hash()` skips fee_token)
+    ///
+    /// Any `tx.access_list` is dropped; see [`Self::to_recoverable_signed`].
     pub fn from_signing_tx(
         tx: tempo_primitives::transaction::TempoTransaction,
         sender: Address,
@@ -73,7 +75,7 @@ impl FeePayerEnvelope78 {
             max_fee_per_gas: tx.max_fee_per_gas,
             gas_limit: tx.gas_limit,
             calls: tx.calls,
-            access_list: tx.access_list,
+            access_list: AccessList::default(),
             nonce_key: tx.nonce_key,
             nonce: tx.nonce,
             valid_before: tx.valid_before.map(|v| v.get()),
@@ -118,6 +120,10 @@ impl FeePayerEnvelope78 {
     ///
     /// This sets the `fee_payer_signature` placeholder so Tempo's signing hash
     /// skips `fee_token` (the user did not commit to a particular fee token).
+    ///
+    /// `access_list` is always reconstructed empty: honest clients sign over
+    /// the empty shape, so a tampered wire access list is structurally
+    /// stripped and a malicious access-list-bound signature fails recovery.
     #[must_use]
     pub fn to_recoverable_signed(&self) -> tempo_primitives::AASigned {
         let tx = tempo_primitives::TempoTransaction {
@@ -129,7 +135,7 @@ impl FeePayerEnvelope78 {
             max_priority_fee_per_gas: self.max_priority_fee_per_gas,
             fee_token: self.fee_token,
             calls: self.calls.clone(),
-            access_list: self.access_list.clone(),
+            access_list: AccessList::default(),
             fee_payer_signature: Some(alloy::primitives::Signature::new(
                 U256::ZERO,
                 U256::ZERO,

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1004,11 +1004,8 @@ where
             ));
         }
 
-        if !tx.access_list.is_empty() {
-            return Err(VerificationError::new(
-                "Fee payer transaction must not include an access list",
-            ));
-        }
+        // Stripped by `to_recoverable_signed`; guard against regression.
+        debug_assert!(tx.access_list.is_empty());
 
         if tx.nonce_key != TEMPO_EXPIRING_NONCE_KEY {
             return Err(VerificationError::new(
@@ -2286,9 +2283,10 @@ mod tests {
         );
     }
 
-    /// cosign_fee_payer_transaction rejects txs with non-empty access lists.
+    /// A client that signs over a non-empty access list fails recovery
+    /// (sponsor strips before ecrecover → recovered ≠ envelope.sender).
     #[test]
-    fn test_cosign_rejects_non_empty_access_list() {
+    fn test_cosign_rejects_access_list_signed_by_client() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_token: Address = "0x20c0000000000000000000000000000000000000"
@@ -2316,10 +2314,10 @@ mod tests {
             fee_token,
         );
 
-        let err = result.expect_err("should reject access list");
+        let err = result.expect_err("malicious access-list signature must not cosign");
         assert!(
-            err.to_string().contains("access list"),
-            "error should mention access list, got: {err}"
+            err.to_string().to_lowercase().contains("sender mismatch"),
+            "expected sender mismatch, got: {err}"
         );
     }
 
@@ -2808,5 +2806,76 @@ mod tests {
             moderato.max_validity_window_seconds,
             tempo_mainnet.max_validity_window_seconds
         );
+    }
+
+    /// Sponsor MUST strip an attacker-injected wire access list: an honest
+    /// client signature over an empty-access-list tx is still cosigned, and
+    /// the broadcast 0x76 carries an empty access list.
+    #[test]
+    fn test_cosign_strips_tampered_access_list() {
+        use alloy::eips::eip2930::{AccessList, AccessListItem};
+        use alloy::eips::Decodable2718;
+        use alloy::primitives::B256;
+        use alloy::signers::local::PrivateKeySigner;
+        use alloy::signers::SignerSync;
+
+        use crate::protocol::methods::tempo::FeePayerEnvelope78;
+
+        let client_signer = PrivateKeySigner::random();
+        let fee_payer_signer = PrivateKeySigner::random();
+        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+
+        // Honest tx with empty access list, signed by the client.
+        let tx = make_fee_payer_tx(60);
+        let signature: tempo_primitives::transaction::TempoSignature = client_signer
+            .sign_hash_sync(&tx.signature_hash())
+            .unwrap()
+            .into();
+
+        // Build envelope directly (from_signing_tx would strip) and inject
+        // an attacker-controlled access list into the wire field.
+        let envelope = FeePayerEnvelope78 {
+            chain_id: tx.chain_id,
+            max_priority_fee_per_gas: tx.max_priority_fee_per_gas,
+            max_fee_per_gas: tx.max_fee_per_gas,
+            gas_limit: tx.gas_limit,
+            calls: tx.calls.clone(),
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::repeat_byte(0xaa),
+                storage_keys: vec![B256::ZERO],
+            }]),
+            nonce_key: tx.nonce_key,
+            nonce: tx.nonce,
+            valid_before: tx.valid_before.map(|v| v.get()),
+            valid_after: tx.valid_after.map(|v| v.get()),
+            fee_token: tx.fee_token,
+            sender: client_signer.address(),
+            tempo_authorization_list: tx.tempo_authorization_list.clone(),
+            key_authorization: tx.key_authorization.clone(),
+            signature,
+        };
+        let envelope_bytes = envelope.encoded_envelope();
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+
+        let cosigned = method
+            .cosign_fee_payer_transaction(
+                &envelope_bytes,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect("sponsor must cosign tampered envelope");
+
+        let signed = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
+        assert!(
+            signed.tx().access_list.is_empty(),
+            "broadcast tx must have empty access list"
+        );
+        assert_eq!(signed.tx().fee_token, Some(fee_token));
     }
 }


### PR DESCRIPTION
Fee-payer envelope now strips `access_list` at client signing and sponsor decode; broadcast 0x76 always carries an empty access list.

Closes OSS-317