### PR TITLE
feat: strip Set-Cookie and Stripe-Account in proxy

### DIFF
--- a/src/proxy/headers.rs
+++ b/src/proxy/headers.rs
@@ -29,7 +29,8 @@ fn eq_ascii_lower(name: &str, lower: &str) -> bool {
             .all(|(a, b)| a.to_ascii_lowercase() == b)
 }
 
-/// Returns true if `name` must be stripped from a proxy→upstream request.
+/// Returns true if `name` is always stripped from a proxy→upstream request.
+/// `Connection`-nominated headers are handled by [`scrub_request_headers`].
 pub fn is_request_header_stripped(name: &str) -> bool {
     if HOP_BY_HOP.iter().any(|h| eq_ascii_lower(name, h)) {
         return true;
@@ -37,7 +38,8 @@ pub fn is_request_header_stripped(name: &str) -> bool {
     if PAYMENT_HEADERS.iter().any(|h| eq_ascii_lower(name, h)) {
         return true;
     }
-    if eq_ascii_lower(name, "cookie")
+    if eq_ascii_lower(name, "host")
+        || eq_ascii_lower(name, "cookie")
         || eq_ascii_lower(name, "accept-encoding")
         || eq_ascii_lower(name, "content-length")
     {
@@ -47,19 +49,41 @@ pub fn is_request_header_stripped(name: &str) -> bool {
         && name.as_bytes()[.."x-forwarded-".len()].eq_ignore_ascii_case(b"x-forwarded-")
 }
 
-/// Returns true if `name` must be stripped from an upstream→client response.
+/// Returns true if `name` is always stripped from an upstream→client response.
+/// `Connection`-nominated headers are handled by [`scrub_response_headers`].
 pub fn is_response_header_stripped(name: &str) -> bool {
+    if HOP_BY_HOP.iter().any(|h| eq_ascii_lower(name, h)) {
+        return true;
+    }
     eq_ascii_lower(name, "set-cookie")
         || eq_ascii_lower(name, "content-encoding")
         || eq_ascii_lower(name, "content-length")
 }
 
+/// Lowercased header names nominated as hop-by-hop by any `Connection` header.
+fn connection_nominated(headers: &[(String, String)]) -> Vec<String> {
+    headers
+        .iter()
+        .filter(|(name, _)| eq_ascii_lower(name, "connection"))
+        .flat_map(|(_, value)| value.split(','))
+        .map(|token| token.trim().to_ascii_lowercase())
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
 pub fn scrub_request_headers(headers: &mut Vec<(String, String)>) {
-    headers.retain(|(name, _)| !is_request_header_stripped(name));
+    let nominated = connection_nominated(headers);
+    headers.retain(|(name, _)| {
+        !is_request_header_stripped(name) && !nominated.iter().any(|t| name.eq_ignore_ascii_case(t))
+    });
 }
 
 pub fn scrub_response_headers(headers: &mut Vec<(String, String)>) {
-    headers.retain(|(name, _)| !is_response_header_stripped(name));
+    let nominated = connection_nominated(headers);
+    headers.retain(|(name, _)| {
+        !is_response_header_stripped(name)
+            && !nominated.iter().any(|t| name.eq_ignore_ascii_case(t))
+    });
 }
 
 #[cfg(test)]
@@ -140,5 +164,57 @@ mod tests {
             names,
             vec!["content-type".to_string(), "user-agent".to_string()]
         );
+    }
+
+    #[test]
+    fn test_scrub_request_drops_host() {
+        assert!(is_request_header_stripped("Host"));
+
+        let mut headers = vec![
+            ("Host".into(), "proxy.example.com".into()),
+            ("Content-Type".into(), "application/json".into()),
+        ];
+        scrub_request_headers(&mut headers);
+
+        assert_eq!(names(&headers), vec!["content-type".to_string()]);
+    }
+
+    #[test]
+    fn test_scrub_request_drops_connection_nominated() {
+        let mut headers = vec![
+            ("Connection".into(), "close, X-Debug".into()),
+            ("X-Debug".into(), "1".into()),
+            ("Content-Type".into(), "application/json".into()),
+        ];
+        scrub_request_headers(&mut headers);
+
+        assert_eq!(names(&headers), vec!["content-type".to_string()]);
+    }
+
+    #[test]
+    fn test_scrub_request_drops_multiple_connection_nominated_case_insensitive() {
+        let mut headers = vec![
+            ("Connection".into(), " keep-alive, X-Debug ,, ".into()),
+            ("connection".into(), "x-trace".into()),
+            ("x-debug".into(), "1".into()),
+            ("X-Trace".into(), "2".into()),
+            ("Content-Type".into(), "application/json".into()),
+        ];
+        scrub_request_headers(&mut headers);
+
+        assert_eq!(names(&headers), vec!["content-type".to_string()]);
+    }
+
+    #[test]
+    fn test_scrub_response_drops_hop_by_hop_and_nominated() {
+        let mut headers = vec![
+            ("Connection".into(), "X-Custom".into()),
+            ("Keep-Alive".into(), "timeout=5".into()),
+            ("X-Custom".into(), "secret".into()),
+            ("Content-Type".into(), "text/html".into()),
+        ];
+        scrub_response_headers(&mut headers);
+
+        assert_eq!(names(&headers), vec!["content-type".to_string()]);
     }
 }

--- a/src/proxy/headers.rs
+++ b/src/proxy/headers.rs
@@ -1,0 +1,144 @@
+//! Header stripping for proxied requests and responses.
+
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "transfer-encoding",
+    "upgrade",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+];
+
+const PAYMENT_HEADERS: &[&str] = &[
+    "authorization",
+    "accept-payment",
+    "payment-receipt",
+    "payment-required",
+    "payment-response",
+    "payment-signature",
+    "www-authenticate",
+];
+
+fn eq_ascii_lower(name: &str, lower: &str) -> bool {
+    name.len() == lower.len()
+        && name
+            .bytes()
+            .zip(lower.bytes())
+            .all(|(a, b)| a.to_ascii_lowercase() == b)
+}
+
+/// Returns true if `name` must be stripped from a proxy→upstream request.
+pub fn is_request_header_stripped(name: &str) -> bool {
+    if HOP_BY_HOP.iter().any(|h| eq_ascii_lower(name, h)) {
+        return true;
+    }
+    if PAYMENT_HEADERS.iter().any(|h| eq_ascii_lower(name, h)) {
+        return true;
+    }
+    if eq_ascii_lower(name, "cookie")
+        || eq_ascii_lower(name, "accept-encoding")
+        || eq_ascii_lower(name, "content-length")
+    {
+        return true;
+    }
+    name.len() >= "x-forwarded-".len()
+        && name.as_bytes()[.."x-forwarded-".len()].eq_ignore_ascii_case(b"x-forwarded-")
+}
+
+/// Returns true if `name` must be stripped from an upstream→client response.
+pub fn is_response_header_stripped(name: &str) -> bool {
+    eq_ascii_lower(name, "set-cookie")
+        || eq_ascii_lower(name, "content-encoding")
+        || eq_ascii_lower(name, "content-length")
+}
+
+pub fn scrub_request_headers(headers: &mut Vec<(String, String)>) {
+    headers.retain(|(name, _)| !is_request_header_stripped(name));
+}
+
+pub fn scrub_response_headers(headers: &mut Vec<(String, String)>) {
+    headers.retain(|(name, _)| !is_response_header_stripped(name));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(h: &[(String, String)]) -> Vec<String> {
+        h.iter().map(|(n, _)| n.to_lowercase()).collect()
+    }
+
+    #[test]
+    fn test_scrub_response_drops_set_cookie() {
+        let mut headers = vec![
+            ("Content-Type".into(), "application/json".into()),
+            (
+                "Set-Cookie".into(),
+                "session=evil; Domain=.example.com".into(),
+            ),
+            ("Content-Encoding".into(), "gzip".into()),
+            ("Content-Length".into(), "42".into()),
+            ("X-Request-Id".into(), "req_abc".into()),
+        ];
+
+        scrub_response_headers(&mut headers);
+
+        let names = names(&headers);
+        assert!(!names.contains(&"set-cookie".to_string()));
+        assert!(!names.contains(&"content-encoding".to_string()));
+        assert!(!names.contains(&"content-length".to_string()));
+        assert!(names.contains(&"content-type".to_string()));
+        assert!(names.contains(&"x-request-id".to_string()));
+    }
+
+    #[test]
+    fn test_scrub_response_drops_all_set_cookie_values() {
+        let mut headers = vec![
+            ("Set-Cookie".into(), "a=1".into()),
+            ("set-cookie".into(), "b=2".into()),
+            ("SET-COOKIE".into(), "c=3".into()),
+            ("Content-Type".into(), "text/html".into()),
+        ];
+
+        scrub_response_headers(&mut headers);
+
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0, "Content-Type");
+    }
+
+    #[test]
+    fn test_scrub_request_drops_bare_x_forwarded() {
+        assert!(is_request_header_stripped("X-Forwarded-"));
+        assert!(is_request_header_stripped("x-forwarded-"));
+    }
+
+    #[test]
+    fn test_scrub_request_drops_hop_by_hop_payment_cookie() {
+        let mut headers = vec![
+            ("Connection".into(), "keep-alive".into()),
+            ("Transfer-Encoding".into(), "chunked".into()),
+            ("Proxy-Authorization".into(), "Basic xxx".into()),
+            ("Authorization".into(), "Payment …".into()),
+            ("Accept-Payment".into(), "tempo/charge".into()),
+            ("Payment-Receipt".into(), "…".into()),
+            ("WWW-Authenticate".into(), "…".into()),
+            ("Cookie".into(), "sid=abc".into()),
+            ("Accept-Encoding".into(), "gzip".into()),
+            ("Content-Length".into(), "13".into()),
+            ("X-Forwarded-For".into(), "1.2.3.4".into()),
+            ("x-forwarded-proto".into(), "https".into()),
+            ("Content-Type".into(), "application/json".into()),
+            ("User-Agent".into(), "mpp-rs/test".into()),
+        ];
+
+        scrub_request_headers(&mut headers);
+
+        let names = names(&headers);
+        assert_eq!(
+            names,
+            vec!["content-type".to_string(), "user-agent".to_string()]
+        );
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,14 +1,17 @@
 //! Paid API proxy that gates upstream services behind the 402 protocol.
 //!
-//! Routes incoming requests to upstream APIs (OpenAI, Anthropic, etc.),
-//! requires payment for configured endpoints, and provides service discovery.
-//!
-//! This module provides the routing/config/discovery layer only — actual HTTP
-//! proxying is left to the consumer (e.g., via `reqwest` or `hyper`).
+//! Provides routing/config/discovery plus header-stripping helpers. HTTP
+//! forwarding is left to the consumer.
 
+pub mod headers;
 pub mod service;
 pub mod services;
 
+pub use headers::{
+    is_request_header_stripped, is_response_header_stripped, scrub_request_headers,
+    scrub_response_headers,
+};
 pub use service::{
-    generate_openapi, Endpoint, PaidEndpoint, ProxyConfig, Route, Service, ServiceBuilder,
+    apply_proxy_request_headers, generate_openapi, Endpoint, PaidEndpoint, ProxyConfig, Route,
+    Service, ServiceBuilder,
 };

--- a/src/proxy/service.rs
+++ b/src/proxy/service.rs
@@ -1,5 +1,14 @@
+use crate::proxy::headers::scrub_request_headers;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+
+/// Canonical proxy→upstream request-header pipeline: generic scrub, then
+/// per-service strip/inject. Reversing the order would drop the injected
+/// `Authorization`.
+pub fn apply_proxy_request_headers(service: &Service, headers: &mut Vec<(String, String)>) {
+    scrub_request_headers(headers);
+    service.apply_request_headers(headers);
+}
 
 /// A proxied upstream service with route definitions.
 #[derive(Debug, Clone)]
@@ -12,6 +21,9 @@ pub struct Service {
     pub routes: Vec<Route>,
     /// Headers to inject on upstream requests.
     pub headers: HashMap<String, String>,
+    /// Caller-supplied request headers to drop before forwarding (vendor-specific
+    /// strips on top of [`crate::proxy::headers::scrub_request_headers`]).
+    pub strip_request_headers: Vec<String>,
     /// Human-readable title.
     pub title: Option<String>,
     /// Human-readable description.
@@ -67,8 +79,24 @@ impl Service {
             base_url: base_url.into(),
             routes: Vec::new(),
             headers: HashMap::new(),
+            strip_request_headers: Vec::new(),
             title: None,
             description: None,
+        }
+    }
+
+    /// Drop `strip_request_headers`, then upsert `headers`. Prefer
+    /// [`apply_proxy_request_headers`] which composes this with the generic scrub.
+    pub fn apply_request_headers(&self, headers: &mut Vec<(String, String)>) {
+        headers.retain(|(name, _)| {
+            !self
+                .strip_request_headers
+                .iter()
+                .any(|s| s.eq_ignore_ascii_case(name))
+        });
+        for (name, value) in &self.headers {
+            headers.retain(|(n, _)| !n.eq_ignore_ascii_case(name));
+            headers.push((name.clone(), value.clone()));
         }
     }
 }
@@ -80,6 +108,7 @@ pub struct ServiceBuilder {
     base_url: String,
     routes: Vec<Route>,
     headers: HashMap<String, String>,
+    strip_request_headers: Vec<String>,
     title: Option<String>,
     description: Option<String>,
 }
@@ -97,6 +126,12 @@ impl ServiceBuilder {
     /// Inject a custom header on upstream requests.
     pub fn header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.headers.insert(name.into(), value.into());
+        self
+    }
+
+    /// Mark a caller-supplied request header to drop before forwarding (e.g. `Stripe-Account`).
+    pub fn strip_request_header(mut self, name: impl Into<String>) -> Self {
+        self.strip_request_headers.push(name.into());
         self
     }
 
@@ -131,6 +166,7 @@ impl ServiceBuilder {
             base_url: self.base_url,
             routes: self.routes,
             headers: self.headers,
+            strip_request_headers: self.strip_request_headers,
             title: self.title,
             description: self.description,
         }

--- a/src/proxy/services/stripe.rs
+++ b/src/proxy/services/stripe.rs
@@ -29,7 +29,90 @@ pub fn service(api_key: &str, configure: impl FnOnce(ServiceBuilder) -> ServiceB
     let encoded = base64::engine::general_purpose::STANDARD.encode(format!("{api_key}:"));
     configure(
         Service::new("stripe", "https://api.stripe.com")
-            .header("Authorization", format!("Basic {encoded}")),
+            .header("Authorization", format!("Basic {encoded}"))
+            .strip_request_header("Stripe-Account"),
     )
     .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stripe_service_strips_caller_supplied_stripe_account() {
+        let svc = service("sk_test_abc", |r| r);
+
+        let mut headers = vec![
+            (
+                "Content-Type".into(),
+                "application/x-www-form-urlencoded".into(),
+            ),
+            ("Stripe-Account".into(), "acct_evil".into()),
+        ];
+        svc.apply_request_headers(&mut headers);
+
+        let names: Vec<String> = headers.iter().map(|(n, _)| n.to_lowercase()).collect();
+        assert!(
+            !names.contains(&"stripe-account".to_string()),
+            "Stripe-Account must be stripped, got: {names:?}"
+        );
+        let auth = headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("authorization"))
+            .expect("Authorization must be injected");
+        assert!(
+            auth.1.starts_with("Basic "),
+            "expected Basic auth, got: {}",
+            auth.1
+        );
+    }
+
+    #[test]
+    fn test_stripe_account_strip_is_case_insensitive() {
+        let svc = service("sk_test_abc", |r| r);
+        let mut headers = vec![("stripe-account".into(), "acct_evil".into())];
+        svc.apply_request_headers(&mut headers);
+        assert!(headers
+            .iter()
+            .all(|(n, _)| !n.eq_ignore_ascii_case("stripe-account")));
+    }
+
+    #[test]
+    fn test_apply_proxy_request_headers_pipeline() {
+        use crate::proxy::service::apply_proxy_request_headers;
+
+        let svc = service("sk_test_abc", |r| r);
+        let mut headers = vec![
+            ("Authorization".into(), "Payment evil".into()),
+            ("Stripe-Account".into(), "acct_evil".into()),
+            ("Connection".into(), "keep-alive".into()),
+            ("X-Forwarded-For".into(), "1.2.3.4".into()),
+            ("Cookie".into(), "sid=abc".into()),
+            (
+                "Content-Type".into(),
+                "application/x-www-form-urlencoded".into(),
+            ),
+        ];
+
+        apply_proxy_request_headers(&svc, &mut headers);
+
+        let names: Vec<String> = headers.iter().map(|(n, _)| n.to_lowercase()).collect();
+        for forbidden in ["stripe-account", "connection", "x-forwarded-for", "cookie"] {
+            assert!(
+                !names.contains(&forbidden.to_string()),
+                "{forbidden} must be stripped, got: {names:?}"
+            );
+        }
+        assert!(names.contains(&"content-type".to_string()));
+        let auth = headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case("authorization"))
+            .expect("injected Authorization must survive");
+        assert!(
+            auth.1.starts_with("Basic "),
+            "caller's Payment Authorization must be replaced with injected Basic, got: {}",
+            auth.1
+        );
+    }
 }


### PR DESCRIPTION
- Drops `Set-Cookie` (plus `Content-Encoding` / `Content-Length`) from upstream responses.
- Drops caller-supplied `Stripe-Account` from outbound requests; injected `Authorization: Basic …` is preserved.
- Adds public ABI for conformance harnesses: `scrub_request_headers`, `scrub_response_headers`, `is_request_header_stripped`, `is_response_header_stripped`, `apply_proxy_request_headers`, `ServiceBuilder::strip_request_header`.
- Generic request scrub also covers hop-by-hop, MPP payment, `Cookie`, `Accept-Encoding`, `Content-Length`, and `X-Forwarded-*`.

Closes OSS-331