### PR TITLE
feat: add `PaymentFailureReason::PreSigningExpired` for typed expiry observability

### DIFF
--- a/.changelog/payment-failed-context-non-exhaustive.md
+++ b/.changelog/payment-failed-context-non-exhaustive.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added a structured `reason: Option<PaymentFailureReason>` field to `PaymentFailedContext`, marked the struct `#[non_exhaustive]`, and added `PaymentFailedContext::new()` and `with_reason()` constructors. Downstream callers should construct it via `new()` and destructure it with `..` so future field additions remain non-breaking.

--- a/src/client/events.rs
+++ b/src/client/events.rs
@@ -108,6 +108,7 @@ pub enum PaymentFailureReason {
 
 /// Context for `payment.failed`.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct PaymentFailedContext {
     /// Selected challenge, when one was available.
     pub challenge: Option<PaymentChallenge>,
@@ -115,6 +116,23 @@ pub struct PaymentFailedContext {
     pub error: String,
     /// Structured reason, when classified.
     pub reason: Option<PaymentFailureReason>,
+}
+
+impl PaymentFailedContext {
+    /// Create a context with no structured reason.
+    pub fn new(challenge: Option<PaymentChallenge>, error: impl Into<String>) -> Self {
+        Self {
+            challenge,
+            error: error.into(),
+            reason: None,
+        }
+    }
+
+    /// Attach a structured failure reason.
+    pub fn with_reason(mut self, reason: PaymentFailureReason) -> Self {
+        self.reason = Some(reason);
+        self
+    }
 }
 
 /// Client payment event payload.
@@ -483,5 +501,19 @@ mod tests {
 
         assert!(credential.is_some());
         assert_eq!(*calls.lock().unwrap(), vec!["first", "any", "typed"]);
+    }
+
+    #[test]
+    fn test_payment_failed_context_constructors() {
+        let ctx = PaymentFailedContext::new(None, "boom");
+        assert_eq!(ctx.error, "boom");
+        assert!(ctx.challenge.is_none());
+        assert_eq!(ctx.reason, None);
+
+        let ctx = ctx.with_reason(PaymentFailureReason::PreSigningExpired { expires: None });
+        assert_eq!(
+            ctx.reason,
+            Some(PaymentFailureReason::PreSigningExpired { expires: None })
+        );
     }
 }

--- a/src/client/events.rs
+++ b/src/client/events.rs
@@ -97,6 +97,15 @@ pub struct PaymentResponseContext {
     pub status: StatusCode,
 }
 
+/// Structured reason for a `payment.failed` event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PaymentFailureReason {
+    /// Client refused before signing because the challenge was expired or had
+    /// an unparseable `expires`. `provider.pay()` was not called.
+    PreSigningExpired { expires: Option<String> },
+}
+
 /// Context for `payment.failed`.
 #[derive(Debug, Clone)]
 pub struct PaymentFailedContext {
@@ -104,6 +113,8 @@ pub struct PaymentFailedContext {
     pub challenge: Option<PaymentChallenge>,
     /// Human-readable failure.
     pub error: String,
+    /// Structured reason, when classified.
+    pub reason: Option<PaymentFailureReason>,
 }
 
 /// Client payment event payload.

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -9,7 +9,7 @@ use super::accept_payment_policy::AcceptPaymentPolicy;
 use super::error::HttpError;
 use super::events::{
     ChallengeReceivedContext, ClientEvent, ClientEvents, CredentialCreatedContext,
-    PaymentFailedContext, PaymentResponseContext,
+    PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
 use super::provider::PaymentProvider;
 use crate::client::challenge_selection::{
@@ -138,6 +138,7 @@ impl PaymentExt for RequestBuilder {
                 .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                     challenge: None,
                     error: HttpError::MissingChallenge.to_string(),
+                    reason: None,
                 }))
                 .await;
             return Err(HttpError::MissingChallenge);
@@ -156,10 +157,12 @@ impl PaymentExt for RequestBuilder {
                 Err(ChallengeSelectionError::Expired(challenge)) => {
                     let err = HttpError::Payment(expired_payment_error(&challenge));
                     let error = err.to_string();
+                    let expires = challenge.expires.clone();
                     events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(*challenge),
                             error,
+                            reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
                         }))
                         .await;
                     return Err(err);
@@ -170,6 +173,7 @@ impl PaymentExt for RequestBuilder {
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: None,
                             error: err.to_string(),
+                            reason: None,
                         }))
                         .await;
                     return Err(err);
@@ -193,6 +197,7 @@ impl PaymentExt for RequestBuilder {
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
                             error: http_err.to_string(),
+                            reason: None,
                         }))
                         .await;
                     return Err(http_err);
@@ -215,6 +220,7 @@ impl PaymentExt for RequestBuilder {
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
                         error: http_err.to_string(),
+                        reason: None,
                     }))
                     .await;
                 return Err(http_err);
@@ -233,6 +239,7 @@ impl PaymentExt for RequestBuilder {
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
                         error: http_err.to_string(),
+                        reason: None,
                     }))
                     .await;
                 return Err(http_err);
@@ -253,6 +260,7 @@ impl PaymentExt for RequestBuilder {
                 .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                     challenge: Some(challenge),
                     error: format!("payment retry returned unsuccessful status: {status}"),
+                    reason: None,
                 }))
                 .await;
         }
@@ -719,6 +727,65 @@ mod tests {
                 .unwrap_err();
 
             assert!(matches!(err, HttpError::Payment(_)));
+        }
+
+        #[tokio::test]
+        async fn test_fetch_rejects_expired_challenge_with_pre_signing_reason() {
+            let www_auth = challenge_header_with_expires(
+                "exp",
+                "tempo",
+                "charge",
+                Some("2020-01-01T00:00:00Z"),
+            );
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let www_auth = www_auth.clone();
+                    async move {
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let events = ClientEvents::default();
+            let failed_count = Arc::new(AtomicU32::new(0));
+            let captured_reason: Arc<std::sync::Mutex<Option<PaymentFailureReason>>> =
+                Arc::new(Default::default());
+
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                let captured_reason = captured_reason.clone();
+                move |ctx| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    *captured_reason.lock().unwrap() = ctx.reason.clone();
+                    async {}
+                }
+            });
+
+            let err = reqwest::Client::new()
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_options(&provider, &AcceptPaymentPolicy::Always, events)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                err,
+                HttpError::Payment(MppError::PaymentExpired(_))
+            ));
+            assert_eq!(provider.call_count(), 0);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                captured_reason.lock().unwrap().clone(),
+                Some(PaymentFailureReason::PreSigningExpired {
+                    expires: Some("2020-01-01T00:00:00Z".to_string()),
+                }),
+            );
         }
 
         /// Provider that only supports specific method/intent pairs.

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -14,7 +14,7 @@ use crate::client::challenge_selection::{
 };
 use crate::client::events::{
     ChallengeReceivedContext, ClientEvent, ClientEventSubscription, ClientEvents,
-    CredentialCreatedContext, PaymentFailedContext, PaymentResponseContext,
+    CredentialCreatedContext, PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
 use crate::client::provider::PaymentProvider;
 use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
@@ -166,6 +166,7 @@ where
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: None,
                         error: err.to_string(),
+                        reason: None,
                     }))
                     .await;
                 return Err(reqwest_middleware::Error::Middleware(err));
@@ -184,6 +185,7 @@ where
                 .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                     challenge: None,
                     error: "402 response missing WWW-Authenticate header".to_string(),
+                    reason: None,
                 }))
                 .await;
             return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
@@ -205,10 +207,12 @@ where
                 Err(ChallengeSelectionError::Expired(challenge)) => {
                     let mpp_error = expired_payment_error(&challenge);
                     let error = mpp_error.to_string();
+                    let expires = challenge.expires.clone();
                     self.events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(*challenge),
                             error,
+                            reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
                         }))
                         .await;
                     return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
@@ -221,6 +225,7 @@ where
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: None,
                             error: err.to_string(),
+                            reason: None,
                         }))
                         .await;
                     return Err(reqwest_middleware::Error::Middleware(err));
@@ -245,6 +250,7 @@ where
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
                             error: err.to_string(),
+                            reason: None,
                         }))
                         .await;
                     return Err(reqwest_middleware::Error::Middleware(err));
@@ -267,6 +273,7 @@ where
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
                             error: err.to_string(),
+                            reason: None,
                         }))
                         .await;
                     return Err(reqwest_middleware::Error::Middleware(err));
@@ -281,6 +288,7 @@ where
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
                         error: err.to_string(),
+                        reason: None,
                     }))
                     .await;
                 return Err(reqwest_middleware::Error::Middleware(err));
@@ -307,6 +315,7 @@ where
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
                             error: format!("payment retry returned unsuccessful status: {status}"),
+                            reason: None,
                         }))
                         .await;
                 }
@@ -317,6 +326,7 @@ where
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
                         error: err.to_string(),
+                        reason: None,
                     }))
                     .await;
                 Err(err)
@@ -751,6 +761,8 @@ mod tests {
             let events = ClientEvents::default();
             let challenge_count = Arc::new(AtomicU32::new(0));
             let failed_count = Arc::new(AtomicU32::new(0));
+            let captured_reason: Arc<std::sync::Mutex<Option<PaymentFailureReason>>> =
+                Arc::new(Default::default());
 
             let _challenge_sub = events.on_challenge_received({
                 let challenge_count = challenge_count.clone();
@@ -761,8 +773,10 @@ mod tests {
             });
             let _failed_sub = events.on_payment_failed({
                 let failed_count = failed_count.clone();
+                let captured_reason = captured_reason.clone();
                 move |ctx| {
                     failed_count.fetch_add(1, Ordering::SeqCst);
+                    *captured_reason.lock().unwrap() = ctx.reason.clone();
                     async move {
                         assert!(ctx.challenge.is_some());
                         assert!(ctx.error.contains("Payment expired"));
@@ -787,6 +801,12 @@ mod tests {
             assert_eq!(provider.call_count(), 0);
             assert_eq!(challenge_count.load(Ordering::SeqCst), 0);
             assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                captured_reason.lock().unwrap().clone(),
+                Some(PaymentFailureReason::PreSigningExpired {
+                    expires: Some("2020-01-01T00:00:00Z".to_string()),
+                }),
+            );
         }
 
         /// Advertises a known header value so tests can observe injection.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -47,7 +47,7 @@ pub use accept_payment_policy::AcceptPaymentPolicy;
 #[cfg(feature = "client")]
 pub use events::{
     ChallengeReceivedContext, ClientEvent, ClientEventKind, ClientEventSubscription, ClientEvents,
-    CredentialCreatedContext, PaymentFailedContext, PaymentResponseContext,
+    CredentialCreatedContext, PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
 
 #[cfg(feature = "client")]


### PR DESCRIPTION
Pre-signing expiry rejection already happens in `select_supported_challenge`, but conformance harnesses could only observe it via `error.contains("Payment expired")` string matching — fragile and indistinguishable from downstream failures.

- New `PaymentFailureReason` enum (`#[non_exhaustive]`) with `PreSigningExpired { expires: Option<String> }`.
- New `reason: Option<PaymentFailureReason>` field on `PaymentFailedContext`.
- Middleware and `Fetch::send_with_payment_options` emit `PreSigningExpired` from the `ChallengeSelectionError::Expired` arm; all other failure sites pass `reason: None` (additive).
- Strengthened `test_middleware_rejects_expired_challenge_before_hooks` to assert on the typed reason; added parallel `test_fetch_rejects_expired_challenge_with_pre_signing_reason`.

Harnesses now assert `(reason == PreSigningExpired) ∧ (provider.pay never called)` for an irrefutable pre-signing rejection signal.

Closes OSS-321