### PR TITLE
Fix axum extractor example secret default

### DIFF
--- a/examples/axum-extractor/README.md
+++ b/examples/axum-extractor/README.md
@@ -66,3 +66,4 @@ async fn expensive(charge: MppCharge<OneDollar>) -> WithReceipt<&'static str> {
 | `PRIVATE_KEY` | Random | Client's private key (hex, with or without `0x` prefix) |
 | `BASE_URL` | `http://localhost:3000` | Client's base URL for the server |
 | `RPC_URL` | `https://rpc.moderato.tempo.xyz` | Tempo RPC endpoint |
+| `MPP_SECRET_KEY` | `axum-example-secret` | Server secret key for challenge verification |

--- a/examples/axum-extractor/src/server.rs
+++ b/examples/axum-extractor/src/server.rs
@@ -87,6 +87,9 @@ async fn main() {
             recipient: &recipient,
         })
         .rpc_url(&rpc_url)
+        .secret_key(
+            &std::env::var("MPP_SECRET_KEY").unwrap_or_else(|_| "axum-example-secret".to_string()),
+        )
         .fee_payer(true)
         .fee_payer_signer(signer),
     )


### PR DESCRIPTION
## Summary
- add a local demo fallback for `MPP_SECRET_KEY` in the axum extractor server example
- document `MPP_SECRET_KEY` in the axum extractor README

## Test
- `cargo check -p axum-extractor-example`

Prompted by: @SuperFluffy