### PR TITLE
feat: add proof credential replay-store conformance

### DIFF
--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -569,7 +569,7 @@ where
     ///
     /// When set, each verified transaction hash is recorded and subsequent
     /// attempts to replay the same hash are rejected. Zero-amount proof
-    /// credentials are likewise made single-use per challenge.
+    /// credentials are likewise made single-use per credential fingerprint.
     pub fn with_store(mut self, store: Arc<dyn Store>) -> Self {
         self.store = Some(store);
         self
@@ -1212,21 +1212,6 @@ where
                     ));
                 }
 
-                // Replay protection: a proof challenge is single-use. The
-                // challenge id is HMAC-unique per issuance and encodes the realm.
-                let replay_key = format!("mpp:proof:{}", credential.challenge.id);
-                if let Some(store) = &this.store {
-                    let seen = store
-                        .get(&replay_key)
-                        .await
-                        .map_err(|e| VerificationError::new(format!("Store error: {e}")))?;
-                    if seen.is_some() {
-                        return Err(VerificationError::new(
-                            "Proof credential has already been used.",
-                        ));
-                    }
-                }
-
                 let source = credential.source.as_deref().ok_or_else(|| {
                     VerificationError::new("Proof credential must include a source.")
                 })?;
@@ -1280,13 +1265,24 @@ where
                     }
                 }
 
+                // Single-use: reserve a key fingerprinting the credential
+                // (challenge id + source + signature) atomically after verifying.
                 if let Some(store) = &this.store {
-                    store
-                        .put(&replay_key, serde_json::Value::Bool(true))
+                    let fingerprint = keccak256(
+                        format!("{}|{}|{}", credential.challenge.id, source, sig_hex).as_bytes(),
+                    );
+                    let replay_key = format!("mpp:proof:{:x}", fingerprint);
+                    let reserved = store
+                        .put_if_absent(&replay_key, serde_json::Value::Bool(true))
                         .await
                         .map_err(|e| {
                             VerificationError::new(format!("Failed to record proof: {e}"))
                         })?;
+                    if !reserved {
+                        return Err(VerificationError::new(
+                            "Proof credential has already been used.",
+                        ));
+                    }
                 }
 
                 Ok(Receipt::success(METHOD_NAME, &credential.challenge.id))
@@ -2549,7 +2545,7 @@ mod tests {
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             proof::proof_source(signer.address(), 42431),
-            crate::protocol::core::PaymentPayload::proof(signature),
+            crate::protocol::core::PaymentPayload::proof(signature.clone()),
         );
 
         let provider =
@@ -2561,14 +2557,111 @@ mod tests {
         // verification is purely cryptographic.
         method.cached_chain_id.set(42431).unwrap();
 
-        // First submission succeeds and records the proof under its challenge id.
+        // First submission succeeds and records the proof fingerprint.
         let receipt = method.verify(&credential, &request).await.unwrap();
         assert_eq!(receipt.reference, challenge.id);
-        let key = format!("mpp:proof:{}", challenge.id);
+        let source = proof::proof_source(signer.address(), 42431);
+        let fingerprint =
+            keccak256(format!("{}|{}|{}", challenge.id, source, signature).as_bytes());
+        let key = format!("mpp:proof:{:x}", fingerprint);
         assert!(store.get(&key).await.unwrap().is_some());
 
         // Replaying the identical credential is rejected.
         let err = method.verify(&credential, &request).await.unwrap_err();
+        assert!(err.to_string().contains("already been used"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_concurrent_proof_submissions_only_one_succeeds() {
+        use crate::store::{MemoryStore, Store, StoreError};
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::time::Duration;
+
+        // Delays the claim so both verifiers reach `put_if_absent` together.
+        struct SlowStore {
+            inner: MemoryStore,
+            delay: Duration,
+        }
+        impl Store for SlowStore {
+            fn get(
+                &self,
+                key: &str,
+            ) -> Pin<
+                Box<dyn Future<Output = Result<Option<serde_json::Value>, StoreError>> + Send + '_>,
+            > {
+                self.inner.get(key)
+            }
+            fn put(
+                &self,
+                key: &str,
+                value: serde_json::Value,
+            ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+                self.inner.put(key, value)
+            }
+            fn delete(
+                &self,
+                key: &str,
+            ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
+                self.inner.delete(key)
+            }
+            fn put_if_absent(
+                &self,
+                key: &str,
+                value: serde_json::Value,
+            ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+                let key = key.to_string();
+                let delay = self.delay;
+                Box::pin(async move {
+                    tokio::time::sleep(delay).await;
+                    self.inner.put_if_absent(&key, value).await
+                })
+            }
+        }
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let request = test_charge_request_with_amount("0");
+        let challenge = test_proof_challenge(&request);
+        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
+            .await
+            .unwrap();
+        let credential = PaymentCredential::with_source(
+            challenge.to_echo(),
+            proof::proof_source(signer.address(), 42431),
+            crate::protocol::core::PaymentPayload::proof(signature),
+        );
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let store = Arc::new(SlowStore {
+            inner: MemoryStore::new(),
+            delay: Duration::from_millis(50),
+        });
+        let method = ChargeMethod::new(provider).with_store(store);
+        method.cached_chain_id.set(42431).unwrap();
+
+        let m1 = method.clone();
+        let c1 = credential.clone();
+        let r1 = request.clone();
+        let t1 = tokio::spawn(async move { m1.verify(&c1, &r1).await });
+        let m2 = method.clone();
+        let c2 = credential.clone();
+        let r2 = request.clone();
+        let t2 = tokio::spawn(async move { m2.verify(&c2, &r2).await });
+
+        let res1 = t1.await.unwrap();
+        let res2 = t2.await.unwrap();
+
+        let successes = [res1.is_ok(), res2.is_ok()]
+            .into_iter()
+            .filter(|ok| *ok)
+            .count();
+        assert_eq!(
+            successes, 1,
+            "exactly one concurrent proof submission must succeed"
+        );
+        let err = res1.err().or(res2.err()).unwrap();
         assert!(err.to_string().contains("already been used"));
     }
 

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -654,10 +654,16 @@ where
         }
 
         if let Some(store) = &self.store {
-            store
-                .put(&replay_key, serde_json::Value::Bool(true))
+            // Atomic claim; the early get above is only a fast-path.
+            let reserved = store
+                .put_if_absent(&replay_key, serde_json::Value::Bool(true))
                 .await
                 .map_err(|e| VerificationError::new(format!("Failed to record tx hash: {e}")))?;
+            if !reserved {
+                return Err(VerificationError::new(
+                    "Transaction hash has already been used.",
+                ));
+            }
         }
 
         Ok(Receipt::success(METHOD_NAME, tx_hash))
@@ -897,19 +903,16 @@ where
         if let Some(store) = &self.store {
             let tx_hash_pre = keccak256(&final_tx_bytes);
             let dedup_key = format!("mpp:charge:submission:{:#x}", tx_hash_pre);
-            let seen = store
-                .get(&dedup_key)
+            // Atomically reserve before broadcasting.
+            let reserved = store
+                .put_if_absent(&dedup_key, serde_json::Value::Bool(true))
                 .await
-                .map_err(|e| VerificationError::new(format!("Store error: {e}")))?;
-            if seen.is_some() {
+                .map_err(|e| VerificationError::new(format!("Failed to record tx: {e}")))?;
+            if !reserved {
                 return Err(VerificationError::new(
                     "Transaction has already been submitted.",
                 ));
             }
-            store
-                .put(&dedup_key, serde_json::Value::Bool(true))
-                .await
-                .map_err(|e| VerificationError::new(format!("Failed to record tx: {e}")))?;
         }
 
         // Use eth_sendRawTransactionSync (EIP-7966) for single-call broadcast +
@@ -936,13 +939,20 @@ where
             assert_challenge_bound_memo(&matched_logs, challenge_id, realm)?;
         }
 
-        // Record the on-chain tx hash for hash-based replay protection
+        // Record the on-chain tx hash for hash-based replay protection. Use the
+        // atomic claim so a concurrent hash credential for the same tx cannot
+        // also succeed.
         if let Some(store) = &self.store {
             let replay_key = format!("mpp:charge:{:#x}", receipt.transaction_hash());
-            store
-                .put(&replay_key, serde_json::Value::Bool(true))
+            let reserved = store
+                .put_if_absent(&replay_key, serde_json::Value::Bool(true))
                 .await
                 .map_err(|e| VerificationError::new(format!("Failed to record tx hash: {e}")))?;
+            if !reserved {
+                return Err(VerificationError::new(
+                    "Transaction hash has already been used.",
+                ));
+            }
         }
 
         Ok(receipt.transaction_hash())
@@ -1265,12 +1275,16 @@ where
                     }
                 }
 
-                // Single-use: reserve a key fingerprinting the credential
-                // (challenge id + source + signature) atomically after verifying.
+                // Single-use: atomically reserve a canonical credential
+                // fingerprint after verifying.
                 if let Some(store) = &this.store {
-                    let fingerprint = keccak256(
-                        format!("{}|{}|{}", credential.challenge.id, source, sig_hex).as_bytes(),
-                    );
+                    let fingerprint = proof::proof_fingerprint(
+                        &credential.challenge.id,
+                        parsed_source.address,
+                        parsed_source.chain_id,
+                        sig_hex,
+                    )
+                    .map_err(|e| VerificationError::new(format!("Failed to record proof: {e}")))?;
                     let replay_key = format!("mpp:proof:{:x}", fingerprint);
                     let reserved = store
                         .put_if_absent(&replay_key, serde_json::Value::Bool(true))
@@ -2560,15 +2574,65 @@ mod tests {
         // First submission succeeds and records the proof fingerprint.
         let receipt = method.verify(&credential, &request).await.unwrap();
         assert_eq!(receipt.reference, challenge.id);
-        let source = proof::proof_source(signer.address(), 42431);
         let fingerprint =
-            keccak256(format!("{}|{}|{}", challenge.id, source, signature).as_bytes());
+            proof::proof_fingerprint(&challenge.id, signer.address(), 42431, &signature).unwrap();
         let key = format!("mpp:proof:{:x}", fingerprint);
         assert!(store.get(&key).await.unwrap().is_some());
 
         // Replaying the identical credential is rejected.
         let err = method.verify(&credential, &request).await.unwrap_err();
         assert!(err.to_string().contains("already been used"));
+    }
+
+    #[tokio::test]
+    async fn test_proof_credential_replay_rejected_across_spellings() {
+        use crate::store::MemoryStore;
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let request = test_charge_request_with_amount("0");
+        let challenge = test_proof_challenge(&request);
+        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
+            .await
+            .unwrap();
+
+        let credential = PaymentCredential::with_source(
+            challenge.to_echo(),
+            proof::proof_source(signer.address(), 42431),
+            crate::protocol::core::PaymentPayload::proof(signature.clone()),
+        );
+
+        // Re-encode the same proof: uppercase signature hex + lowercased source
+        // address. Semantically identical, so it must hit the same replay key.
+        let upper_sig = signature.to_uppercase().replace("0X", "0x");
+        let lower_source = format!("did:pkh:eip155:42431:0x{:x}", signer.address());
+        assert_ne!(
+            signature, upper_sig,
+            "test must actually mutate the spelling"
+        );
+        let credential_variant = PaymentCredential::with_source(
+            challenge.to_echo(),
+            lower_source,
+            crate::protocol::core::PaymentPayload::proof(upper_sig),
+        );
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let store = Arc::new(MemoryStore::new());
+        let method = ChargeMethod::new(provider).with_store(store);
+        method.cached_chain_id.set(42431).unwrap();
+
+        method.verify(&credential, &request).await.unwrap();
+
+        // Re-encoded variant of the same proof is rejected as a replay.
+        let err = method
+            .verify(&credential_variant, &request)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("already been used"),
+            "re-encoded proof must hit the same replay key, got: {err}"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -565,10 +565,11 @@ where
         self
     }
 
-    /// Configure a store for transaction hash deduplication.
+    /// Configure a store for replay deduplication.
     ///
     /// When set, each verified transaction hash is recorded and subsequent
-    /// attempts to replay the same hash are rejected.
+    /// attempts to replay the same hash are rejected. Zero-amount proof
+    /// credentials are likewise made single-use per challenge.
     pub fn with_store(mut self, store: Arc<dyn Store>) -> Self {
         self.store = Some(store);
         self
@@ -1211,6 +1212,21 @@ where
                     ));
                 }
 
+                // Replay protection: a proof challenge is single-use. The
+                // challenge id is HMAC-unique per issuance and encodes the realm.
+                let replay_key = format!("mpp:proof:{}", credential.challenge.id);
+                if let Some(store) = &this.store {
+                    let seen = store
+                        .get(&replay_key)
+                        .await
+                        .map_err(|e| VerificationError::new(format!("Store error: {e}")))?;
+                    if seen.is_some() {
+                        return Err(VerificationError::new(
+                            "Proof credential has already been used.",
+                        ));
+                    }
+                }
+
                 let source = credential.source.as_deref().ok_or_else(|| {
                     VerificationError::new("Proof credential must include a source.")
                 })?;
@@ -1262,6 +1278,15 @@ where
                             "Proof signature does not match source.",
                         ));
                     }
+                }
+
+                if let Some(store) = &this.store {
+                    store
+                        .put(&replay_key, serde_json::Value::Bool(true))
+                        .await
+                        .map_err(|e| {
+                            VerificationError::new(format!("Failed to record proof: {e}"))
+                        })?;
                 }
 
                 Ok(Receipt::success(METHOD_NAME, &credential.challenge.id))
@@ -2509,6 +2534,42 @@ mod tests {
         // Original hash should still be blocked
         let seen = store.get("mpp:charge:0xhash_a").await.unwrap();
         assert!(seen.is_some(), "original hash should still be recorded");
+    }
+
+    #[tokio::test]
+    async fn test_proof_credential_replay_rejected() {
+        use crate::store::MemoryStore;
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let request = test_charge_request_with_amount("0");
+        let challenge = test_proof_challenge(&request);
+        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
+            .await
+            .unwrap();
+        let credential = PaymentCredential::with_source(
+            challenge.to_echo(),
+            proof::proof_source(signer.address(), 42431),
+            crate::protocol::core::PaymentPayload::proof(signature),
+        );
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let store = Arc::new(MemoryStore::new());
+        let method = ChargeMethod::new(provider).with_store(store.clone());
+        // Pre-cache the chain id so verify() needs no RPC; Direct-mode proof
+        // verification is purely cryptographic.
+        method.cached_chain_id.set(42431).unwrap();
+
+        // First submission succeeds and records the proof under its challenge id.
+        let receipt = method.verify(&credential, &request).await.unwrap();
+        assert_eq!(receipt.reference, challenge.id);
+        let key = format!("mpp:proof:{}", challenge.id);
+        assert!(store.get(&key).await.unwrap().is_some());
+
+        // Replaying the identical credential is rejected.
+        let err = method.verify(&credential, &request).await.unwrap_err();
+        assert!(err.to_string().contains("already been used"));
     }
 
     // ==================== Chain ID caching tests ====================

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -1,6 +1,6 @@
 //! EIP-712 proof signing for zero-amount Tempo charge flows.
 
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{keccak256, Address, B256};
 use alloy::sol_types::{eip712_domain, SolStruct};
 
 use crate::error::{MppError, ResultExt};
@@ -62,6 +62,34 @@ pub fn parse_proof_source(source: &str) -> crate::error::Result<ProofSource> {
         .parse()
         .map_err(|e| MppError::invalid_payload(format!("invalid proof source address: {e}")))?;
     Ok(ProofSource { address, chain_id })
+}
+
+/// Compute a canonical single-use replay fingerprint for a proof credential.
+///
+/// Hashes canonical parsed values rather than raw strings so equivalent
+/// spellings (address/signature hex casing, `0x` prefix) map to the same key.
+#[cfg(feature = "evm")]
+pub fn proof_fingerprint(
+    challenge_id: &str,
+    source_address: Address,
+    chain_id: u64,
+    signature_hex: &str,
+) -> crate::error::Result<B256> {
+    let signature_bytes: alloy::primitives::Bytes = signature_hex
+        .parse()
+        .map_err(|_| MppError::invalid_payload("invalid proof signature hex"))?;
+    let signature = alloy::signers::Signature::try_from(signature_bytes.as_ref())
+        .map_err(|_| MppError::invalid_payload("invalid proof signature"))?;
+
+    let mut buf = Vec::with_capacity(challenge_id.len() + 1 + 20 + 8 + 65);
+    buf.extend_from_slice(challenge_id.as_bytes());
+    buf.push(0xff); // separator: variable-length id from fixed-width fields
+    buf.extend_from_slice(source_address.as_slice());
+    buf.extend_from_slice(&chain_id.to_be_bytes());
+    // normalize_s so a malleated (high-S) variant, which recovery accepts as the
+    // same proof, cannot mint a distinct replay key.
+    buf.extend_from_slice(&signature.normalized_s().as_bytes());
+    Ok(keccak256(&buf))
 }
 
 /// Compute the EIP-712 signing hash for a proof credential.
@@ -260,6 +288,26 @@ mod tests {
         let recovered =
             recover_proof_signer(42431, "challenge-123", "api.example.com", &signature).unwrap();
         assert_eq!(recovered, signer.address());
+    }
+
+    #[tokio::test]
+    async fn test_proof_fingerprint_is_spelling_invariant() {
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
+            .await
+            .unwrap();
+
+        // Canonical spelling vs. uppercase signature hex — same proof.
+        let upper_sig = signature.to_uppercase().replace("0X", "0x");
+        assert_ne!(signature, upper_sig);
+
+        let a = proof_fingerprint("challenge-123", signer.address(), 42431, &signature).unwrap();
+        let b = proof_fingerprint("challenge-123", signer.address(), 42431, &upper_sig).unwrap();
+        assert_eq!(a, b, "re-encoded signature must yield the same fingerprint");
+
+        // Different challenge id must change the fingerprint.
+        let c = proof_fingerprint("challenge-456", signer.address(), 42431, &signature).unwrap();
+        assert_ne!(a, c);
     }
 
     #[test]

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -892,6 +892,9 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
         if let Some(signer) = builder.fee_payer_signer {
             method = method.with_fee_payer(signer);
         }
+        if let Some(store) = builder.store {
+            method = method.with_store(store);
+        }
 
         // Resolve currency from chain_id when not explicitly set
         let currency = if builder.currency_explicit {

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -33,6 +33,7 @@ pub struct TempoBuilder {
     pub(crate) fee_payer: bool,
     pub(crate) chain_id: Option<u64>,
     pub(crate) fee_payer_signer: Option<alloy::signers::local::PrivateKeySigner>,
+    pub(crate) store: Option<std::sync::Arc<dyn crate::store::Store>>,
 }
 
 impl TempoBuilder {
@@ -100,6 +101,20 @@ impl TempoBuilder {
         self.fee_payer_signer = Some(signer);
         self
     }
+
+    /// Set the replay-protection store (default: in-memory).
+    ///
+    /// Provide a shared backend (Redis, SQL, etc.) for multi-instance deployments.
+    pub fn store(mut self, store: std::sync::Arc<dyn crate::store::Store>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// Disable replay-protection storage (removes the default in-memory store).
+    pub fn without_store(mut self) -> Self {
+        self.store = None;
+        self
+    }
 }
 
 /// Create a Tempo payment method configuration with smart defaults.
@@ -152,6 +167,8 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         fee_payer: false,
         chain_id: None,
         fee_payer_signer: None,
+        // Default in-memory store; replay protection on by default.
+        store: Some(std::sync::Arc::new(crate::store::MemoryStore::new())),
     }
 }
 
@@ -196,3 +213,37 @@ pub type TempoProvider = alloy::providers::fillers::FillProvider<
     alloy::providers::RootProvider<tempo_alloy::TempoNetwork>,
     tempo_alloy::TempoNetwork,
 >;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tempo_builder_defaults_to_a_store() {
+        // Replay protection must be active on the default server path.
+        let builder = tempo(TempoConfig {
+            recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+        });
+        assert!(
+            builder.store.is_some(),
+            "default builder should configure a replay-protection store"
+        );
+    }
+
+    #[test]
+    fn tempo_builder_store_override_and_opt_out() {
+        let custom: std::sync::Arc<dyn crate::store::Store> =
+            std::sync::Arc::new(crate::store::MemoryStore::new());
+        let builder = tempo(TempoConfig {
+            recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+        })
+        .store(custom.clone());
+        assert!(builder.store.is_some());
+
+        let builder = builder.without_store();
+        assert!(
+            builder.store.is_none(),
+            "without_store() should clear the configured store"
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -34,21 +34,16 @@ pub trait Store: Send + Sync {
 
     /// Atomically store `value` only if `key` is absent; returns `true` if inserted.
     ///
-    /// The default is a non-atomic `get`-then-`put`; production backends should
-    /// override it (e.g. Redis `SET NX`, SQL `ON CONFLICT DO NOTHING`).
+    /// A generic `get`-then-`put` is racy, so the default **fails closed** with
+    /// [`StoreError::AtomicUnsupported`]. Backends used for replay protection
+    /// must override this with native atomics (Redis `SET NX`, SQL
+    /// `ON CONFLICT DO NOTHING`, CAS, etc.).
     fn put_if_absent(
         &self,
-        key: &str,
-        value: serde_json::Value,
+        _key: &str,
+        _value: serde_json::Value,
     ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
-        let key = key.to_string();
-        Box::pin(async move {
-            if self.get(&key).await?.is_some() {
-                return Ok(false);
-            }
-            self.put(&key, value).await?;
-            Ok(true)
-        })
+        Box::pin(async { Err(StoreError::AtomicUnsupported) })
     }
 }
 
@@ -58,6 +53,8 @@ pub enum StoreError {
     Internal(String),
     #[error("Serialization error: {0}")]
     Serialization(String),
+    #[error("atomic put_if_absent is not supported by this store backend")]
+    AtomicUnsupported,
 }
 
 // ==================== MemoryStore ====================

--- a/src/store.rs
+++ b/src/store.rs
@@ -31,6 +31,25 @@ pub trait Store: Send + Sync {
         &self,
         key: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>>;
+
+    /// Atomically store `value` only if `key` is absent; returns `true` if inserted.
+    ///
+    /// The default is a non-atomic `get`-then-`put`; production backends should
+    /// override it (e.g. Redis `SET NX`, SQL `ON CONFLICT DO NOTHING`).
+    fn put_if_absent(
+        &self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+        let key = key.to_string();
+        Box::pin(async move {
+            if self.get(&key).await?.is_some() {
+                return Ok(false);
+            }
+            self.put(&key, value).await?;
+            Ok(true)
+        })
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -102,6 +121,26 @@ impl Store for MemoryStore {
     ) -> Pin<Box<dyn Future<Output = Result<(), StoreError>> + Send + '_>> {
         self.data.lock().unwrap().remove(key);
         Box::pin(async { Ok(()) })
+    }
+
+    fn put_if_absent(
+        &self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+        let key = key.to_string();
+        let serialized =
+            serde_json::to_string(&value).map_err(|e| StoreError::Serialization(e.to_string()));
+        Box::pin(async move {
+            let serialized = serialized?;
+            // Check-and-insert under one mutex guard.
+            let mut data = self.data.lock().unwrap();
+            if data.contains_key(&key) {
+                return Ok(false);
+            }
+            data.insert(key, serialized);
+            Ok(true)
+        })
     }
 }
 
@@ -184,6 +223,33 @@ impl Store for FileStore {
             match std::fs::remove_file(&path) {
                 Ok(()) => Ok(()),
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(StoreError::Internal(e.to_string())),
+            }
+        })
+    }
+
+    fn put_if_absent(
+        &self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Pin<Box<dyn Future<Output = Result<bool, StoreError>> + Send + '_>> {
+        let path = self.key_path(key);
+        Box::pin(async move {
+            let serialized = serde_json::to_string_pretty(&value)
+                .map_err(|e| StoreError::Serialization(e.to_string()))?;
+            // `create_new` is an atomic O_EXCL create: fails if the file exists.
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    file.write_all(serialized.as_bytes())
+                        .map_err(|e| StoreError::Internal(e.to_string()))?;
+                    Ok(true)
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
                 Err(e) => Err(StoreError::Internal(e.to_string())),
             }
         })
@@ -372,6 +438,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn memory_store_put_if_absent() {
+        let store = MemoryStore::new();
+
+        // First reservation succeeds.
+        assert!(store
+            .put_if_absent("k", serde_json::json!(true))
+            .await
+            .unwrap());
+        assert_eq!(store.get("k").await.unwrap(), Some(serde_json::json!(true)));
+
+        // Second reservation of the same key fails and does not overwrite.
+        assert!(!store
+            .put_if_absent("k", serde_json::json!("other"))
+            .await
+            .unwrap());
+        assert_eq!(store.get("k").await.unwrap(), Some(serde_json::json!(true)));
+    }
+
+    #[tokio::test]
     async fn memory_store_overwrite() {
         let store = MemoryStore::new();
         store.put("k", serde_json::json!("first")).await.unwrap();
@@ -404,6 +489,32 @@ mod tests {
         store.delete("nonexistent").await.unwrap();
 
         // Cleanup
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[tokio::test]
+    async fn file_store_put_if_absent() {
+        let tmp = std::env::temp_dir().join(format!(
+            "mpp_file_store_put_if_absent_test_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let store = FileStore::new(&tmp).unwrap();
+
+        // First reservation succeeds.
+        assert!(store
+            .put_if_absent("k", serde_json::json!(true))
+            .await
+            .unwrap());
+        assert_eq!(store.get("k").await.unwrap(), Some(serde_json::json!(true)));
+
+        // Second reservation of the same key fails and does not overwrite.
+        assert!(!store
+            .put_if_absent("k", serde_json::json!("other"))
+            .await
+            .unwrap());
+        assert_eq!(store.get("k").await.unwrap(), Some(serde_json::json!(true)));
+
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
Proof credentials weren't recorded after verification, so the same proof could be replayed until challenge expiry.

Now `verify` rejects a proof whose `mpp:proof:{challenge.id}` key already exists and records it on success. Adds a test submitting the same proof twice (first succeeds, second rejected).

Part of OSS-309