### PR TITLE
feat: add fee payer token allowlist

### DIFF
--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -478,6 +478,7 @@ pub struct ChargeMethod<P> {
     store: Option<Arc<dyn Store>>,
     cached_chain_id: Arc<OnceCell<u64>>,
     fee_payer_policy_override: Option<FeePayerPolicyOverride>,
+    fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
 }
 
 #[derive(Debug, Clone)]
@@ -487,7 +488,6 @@ pub struct FeePayerPolicy {
     pub max_priority_fee_per_gas: u128,
     pub max_total_fee: u128,
     pub max_validity_window_seconds: u64,
-    pub allowed_fee_tokens: Vec<Address>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -497,7 +497,6 @@ pub struct FeePayerPolicyOverride {
     pub max_priority_fee_per_gas: Option<u128>,
     pub max_total_fee: Option<u128>,
     pub max_validity_window_seconds: Option<u64>,
-    pub allowed_fee_tokens: Option<Vec<Address>>,
 }
 
 impl Default for FeePayerPolicy {
@@ -520,39 +519,52 @@ impl FeePayerPolicy {
             policy.max_validity_window_seconds = o
                 .max_validity_window_seconds
                 .unwrap_or(policy.max_validity_window_seconds);
-            if let Some(allowed_fee_tokens) = &o.allowed_fee_tokens {
-                policy.allowed_fee_tokens = allowed_fee_tokens.clone();
-            }
         }
         policy
     }
 
-    pub fn allows_fee_token(&self, fee_token: Address) -> bool {
-        self.allowed_fee_tokens
-            .iter()
-            .any(|allowed| *allowed == fee_token)
+    /// Return the default sponsor fee-token allowlist for a transaction chain.
+    ///
+    /// Known Tempo chains allow their default currency. Unknown chains use the
+    /// mainnet default, matching the server-side charge verifier fallback.
+    pub fn default_allowed_fee_tokens(chain_id: u64) -> Vec<Address> {
+        default_fee_payer_allowed_fee_tokens(chain_id)
+    }
+
+    /// Check whether the default sponsor allowlist accepts `fee_token`.
+    pub fn default_allows_fee_token(chain_id: u64, fee_token: Address) -> bool {
+        fee_token_allowed(&Self::default_allowed_fee_tokens(chain_id), fee_token)
     }
 
     fn get_by_chain_id(chain_id: u64) -> Self {
-        let network =
-            KnownTempoNetwork::from_chain_id(chain_id).unwrap_or(KnownTempoNetwork::Mainnet);
+        let network = KnownTempoNetwork::from_chain_id(chain_id);
         let mut policy = Self {
             max_gas: MAX_FEE_PAYER_GAS_LIMIT,
             max_fee_per_gas: MAX_FEE_PER_GAS_DEFAULT,
             max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS_DEFAULT,
             max_total_fee: MAX_TOTAL_FEE_DEFAULT,
             max_validity_window_seconds: MAX_VALIDITY_WINDOW_SECS_DEFAULT,
-            allowed_fee_tokens: vec![network
-                .default_currency()
-                .parse()
-                .expect("default Tempo fee token is a valid address")],
         };
-        if network == KnownTempoNetwork::Moderato {
+        if network == Some(KnownTempoNetwork::Moderato) {
             // Moderato regularly needs a higher priority fee than mainnet.
             policy.max_priority_fee_per_gas = 50_000_000_000;
         }
         policy
     }
+}
+
+fn default_fee_payer_allowed_fee_tokens(chain_id: u64) -> Vec<Address> {
+    let network = KnownTempoNetwork::from_chain_id(chain_id).unwrap_or(KnownTempoNetwork::Mainnet);
+    vec![network
+        .default_currency()
+        .parse()
+        .expect("default Tempo fee token is a valid address")]
+}
+
+fn fee_token_allowed(allowed_fee_tokens: &[Address], fee_token: Address) -> bool {
+    allowed_fee_tokens
+        .iter()
+        .any(|allowed| *allowed == fee_token)
 }
 
 impl<P> ChargeMethod<P>
@@ -570,17 +582,27 @@ where
             store: None,
             cached_chain_id: Arc::new(OnceCell::new()),
             fee_payer_policy_override: None,
+            fee_payer_allowed_fee_tokens: None,
         }
     }
 
-    /// Override the fee-sponsor policy applied to fee-payer envelopes.
+    /// Override fee-sponsor limit policy applied to fee-payer envelopes.
     ///
     /// Each unset field falls back to the per-chain default. Use to raise or
     /// lower `max_gas`, `max_fee_per_gas`, `max_priority_fee_per_gas`,
-    /// `max_total_fee`, or `max_validity_window_seconds` per server, or to
-    /// replace the sponsor fee-token allowlist.
+    /// `max_total_fee`, or `max_validity_window_seconds` per server.
     pub fn with_fee_payer_policy_override(mut self, overrides: FeePayerPolicyOverride) -> Self {
         self.fee_payer_policy_override = Some(overrides);
+        self
+    }
+
+    /// Replace the default sponsor fee-token allowlist.
+    ///
+    /// By default, fee-payer co-signing accepts the known default currency for
+    /// the transaction chain ID. Use this to restrict or widen the accepted
+    /// fee tokens for a server.
+    pub fn with_fee_payer_allowed_fee_tokens(mut self, allowed_fee_tokens: Vec<Address>) -> Self {
+        self.fee_payer_allowed_fee_tokens = Some(allowed_fee_tokens);
         self
     }
 
@@ -1055,7 +1077,11 @@ where
 
         let policy = FeePayerPolicy::resolve(tx.chain_id, self.fee_payer_policy_override.as_ref());
 
-        if !policy.allows_fee_token(fee_token) {
+        let allowed_fee_tokens = self
+            .fee_payer_allowed_fee_tokens
+            .clone()
+            .unwrap_or_else(|| FeePayerPolicy::default_allowed_fee_tokens(tx.chain_id));
+        if !fee_token_allowed(&allowed_fee_tokens, fee_token) {
             return Err(VerificationError::new(format!(
                 "Fee token {:#x} is not allowed by fee payer policy",
                 fee_token
@@ -1163,6 +1189,7 @@ where
         let store = self.store.clone();
         let cached_chain_id = Arc::clone(&self.cached_chain_id);
         let fee_payer_policy_override = self.fee_payer_policy_override.clone();
+        let fee_payer_allowed_fee_tokens = self.fee_payer_allowed_fee_tokens.clone();
 
         async move {
             let this = ChargeMethod {
@@ -1171,6 +1198,7 @@ where
                 store,
                 cached_chain_id,
                 fee_payer_policy_override,
+                fee_payer_allowed_fee_tokens,
             };
 
             if credential.challenge.method.as_str() != METHOD_NAME {
@@ -2771,7 +2799,7 @@ mod tests {
         );
     }
 
-    /// All five policy override fields are respected when set together.
+    /// All five limit policy override fields are respected when set together.
     #[test]
     fn test_policy_override_all_fields_applied() {
         // Generous overrides — tx should pass all checks.
@@ -2781,10 +2809,6 @@ mod tests {
             max_priority_fee_per_gas: Some(2_000_000_000),
             max_total_fee: Some(40_000_000_000_000_000),
             max_validity_window_seconds: Some(600),
-            allowed_fee_tokens: Some(vec![KnownTempoNetwork::Mainnet
-                .default_currency()
-                .parse::<Address>()
-                .unwrap()]),
         };
         let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
@@ -2844,25 +2868,29 @@ mod tests {
             moderato.max_validity_window_seconds,
             tempo_mainnet.max_validity_window_seconds
         );
-        assert!(tempo_mainnet.allows_fee_token(
+        assert!(FeePayerPolicy::default_allows_fee_token(
+            CHAIN_ID,
             KnownTempoNetwork::Mainnet
                 .default_currency()
                 .parse::<Address>()
                 .unwrap()
         ));
-        assert!(!tempo_mainnet.allows_fee_token(
+        assert!(!FeePayerPolicy::default_allows_fee_token(
+            CHAIN_ID,
             KnownTempoNetwork::Moderato
                 .default_currency()
                 .parse::<Address>()
                 .unwrap()
         ));
-        assert!(moderato.allows_fee_token(
+        assert!(FeePayerPolicy::default_allows_fee_token(
+            MODERATO_CHAIN_ID,
             KnownTempoNetwork::Moderato
                 .default_currency()
                 .parse::<Address>()
                 .unwrap()
         ));
-        assert!(!moderato.allows_fee_token(
+        assert!(!FeePayerPolicy::default_allows_fee_token(
+            MODERATO_CHAIN_ID,
             KnownTempoNetwork::Mainnet
                 .default_currency()
                 .parse::<Address>()
@@ -2872,14 +2900,12 @@ mod tests {
 
     #[test]
     fn test_cosign_rejects_non_allowlisted_fee_token() {
-        let overrides = FeePayerPolicyOverride {
-            allowed_fee_tokens: Some(vec![KnownTempoNetwork::Mainnet
-                .default_currency()
-                .parse::<Address>()
-                .unwrap()]),
-            ..Default::default()
-        };
-        let (method, client_signer, _) = make_cosign_method(Some(overrides));
+        let allowed_fee_tokens = vec![KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
+            .unwrap()];
+        let (method, client_signer, _) = make_cosign_method(None);
+        let method = method.with_fee_payer_allowed_fee_tokens(allowed_fee_tokens);
 
         let tx = make_fee_payer_tx(60);
         let encoded = sign_and_encode_0x78(tx, &client_signer);
@@ -2899,6 +2925,27 @@ mod tests {
                 .contains("is not allowed by fee payer policy"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn test_cosign_uses_custom_fee_token_allowlist() {
+        let allowed_fee_tokens = vec![KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
+            .unwrap()];
+        let (method, client_signer, fee_token) = make_cosign_method(None);
+        let method = method.with_fee_payer_allowed_fee_tokens(allowed_fee_tokens);
+
+        let tx = make_fee_payer_tx(60);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect("cosign should accept a custom allowlisted fee token");
     }
 
     /// Sponsor MUST strip an attacker-injected wire access list: an honest

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -606,6 +606,11 @@ where
         self
     }
 
+    #[cfg(test)]
+    pub(crate) fn fee_payer_allowed_fee_tokens(&self) -> Option<&[Address]> {
+        self.fee_payer_allowed_fee_tokens.as_deref()
+    }
+
     /// Configure a store for transaction hash deduplication.
     ///
     /// When set, each verified transaction hash is recorded and subsequent

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -39,10 +39,13 @@ use crate::protocol::core::{PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
 use crate::protocol::traits::{ChargeMethod as ChargeMethodTrait, VerificationError};
 use crate::store::Store;
-use crate::tempo::{attribution, MODERATO_CHAIN_ID};
+use crate::tempo::attribution;
 
 use super::transfers::{get_request_transfers, Transfer};
-use super::{proof, TempoChargeExt, CHAIN_ID, INTENT_CHARGE, METHOD_NAME};
+use super::{
+    network::TempoNetwork as KnownTempoNetwork, proof, TempoChargeExt, CHAIN_ID, INTENT_CHARGE,
+    METHOD_NAME,
+};
 
 const MAX_FEE_PAYER_GAS_LIMIT: u64 = 2_000_000;
 const MAX_FEE_PER_GAS_DEFAULT: u128 = 100_000_000_000;
@@ -484,6 +487,7 @@ pub struct FeePayerPolicy {
     pub max_priority_fee_per_gas: u128,
     pub max_total_fee: u128,
     pub max_validity_window_seconds: u64,
+    pub allowed_fee_tokens: Vec<Address>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -493,47 +497,61 @@ pub struct FeePayerPolicyOverride {
     pub max_priority_fee_per_gas: Option<u128>,
     pub max_total_fee: Option<u128>,
     pub max_validity_window_seconds: Option<u64>,
+    pub allowed_fee_tokens: Option<Vec<Address>>,
 }
 
 impl Default for FeePayerPolicy {
     fn default() -> FeePayerPolicy {
-        FeePayerPolicy {
-            max_gas: MAX_FEE_PAYER_GAS_LIMIT,
-            max_fee_per_gas: MAX_FEE_PER_GAS_DEFAULT,
-            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS_DEFAULT,
-            max_total_fee: MAX_TOTAL_FEE_DEFAULT,
-            max_validity_window_seconds: MAX_VALIDITY_WINDOW_SECS_DEFAULT,
-        }
+        Self::get_by_chain_id(CHAIN_ID)
     }
 }
 
 impl FeePayerPolicy {
     /// Merge overrides onto the per-chain default.
     pub fn resolve(chain_id: u64, overrides: Option<&FeePayerPolicyOverride>) -> Self {
-        let base = Self::get_by_chain_id(chain_id);
-        let Some(o) = overrides else { return base };
-        Self {
-            max_gas: o.max_gas.unwrap_or(base.max_gas),
-            max_fee_per_gas: o.max_fee_per_gas.unwrap_or(base.max_fee_per_gas),
-            max_priority_fee_per_gas: o
+        let mut policy = Self::get_by_chain_id(chain_id);
+        if let Some(o) = overrides {
+            policy.max_gas = o.max_gas.unwrap_or(policy.max_gas);
+            policy.max_fee_per_gas = o.max_fee_per_gas.unwrap_or(policy.max_fee_per_gas);
+            policy.max_priority_fee_per_gas = o
                 .max_priority_fee_per_gas
-                .unwrap_or(base.max_priority_fee_per_gas),
-            max_total_fee: o.max_total_fee.unwrap_or(base.max_total_fee),
-            max_validity_window_seconds: o
+                .unwrap_or(policy.max_priority_fee_per_gas);
+            policy.max_total_fee = o.max_total_fee.unwrap_or(policy.max_total_fee);
+            policy.max_validity_window_seconds = o
                 .max_validity_window_seconds
-                .unwrap_or(base.max_validity_window_seconds),
+                .unwrap_or(policy.max_validity_window_seconds);
+            if let Some(allowed_fee_tokens) = &o.allowed_fee_tokens {
+                policy.allowed_fee_tokens = allowed_fee_tokens.clone();
+            }
         }
+        policy
+    }
+
+    pub fn allows_fee_token(&self, fee_token: Address) -> bool {
+        self.allowed_fee_tokens
+            .iter()
+            .any(|allowed| *allowed == fee_token)
     }
 
     fn get_by_chain_id(chain_id: u64) -> Self {
-        match chain_id {
+        let network =
+            KnownTempoNetwork::from_chain_id(chain_id).unwrap_or(KnownTempoNetwork::Mainnet);
+        let mut policy = Self {
+            max_gas: MAX_FEE_PAYER_GAS_LIMIT,
+            max_fee_per_gas: MAX_FEE_PER_GAS_DEFAULT,
+            max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS_DEFAULT,
+            max_total_fee: MAX_TOTAL_FEE_DEFAULT,
+            max_validity_window_seconds: MAX_VALIDITY_WINDOW_SECS_DEFAULT,
+            allowed_fee_tokens: vec![network
+                .default_currency()
+                .parse()
+                .expect("default Tempo fee token is a valid address")],
+        };
+        if network == KnownTempoNetwork::Moderato {
             // Moderato regularly needs a higher priority fee than mainnet.
-            MODERATO_CHAIN_ID => Self {
-                max_priority_fee_per_gas: 50_000_000_000,
-                ..Self::default()
-            },
-            _ => Self::default(),
+            policy.max_priority_fee_per_gas = 50_000_000_000;
         }
+        policy
     }
 }
 
@@ -559,7 +577,8 @@ where
     ///
     /// Each unset field falls back to the per-chain default. Use to raise or
     /// lower `max_gas`, `max_fee_per_gas`, `max_priority_fee_per_gas`,
-    /// `max_total_fee`, or `max_validity_window_seconds` per server.
+    /// `max_total_fee`, or `max_validity_window_seconds` per server, or to
+    /// replace the sponsor fee-token allowlist.
     pub fn with_fee_payer_policy_override(mut self, overrides: FeePayerPolicyOverride) -> Self {
         self.fee_payer_policy_override = Some(overrides);
         self
@@ -1035,6 +1054,13 @@ where
         };
 
         let policy = FeePayerPolicy::resolve(tx.chain_id, self.fee_payer_policy_override.as_ref());
+
+        if !policy.allows_fee_token(fee_token) {
+            return Err(VerificationError::new(format!(
+                "Fee token {:#x} is not allowed by fee payer policy",
+                fee_token
+            )));
+        }
 
         if tx.max_fee_per_gas > policy.max_fee_per_gas {
             return Err(VerificationError::new(format!(
@@ -1768,8 +1794,9 @@ mod tests {
 
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let tx = make_fee_payer_tx(60);
@@ -2222,8 +2249,9 @@ mod tests {
     fn test_cosign_rejects_wrong_nonce_key() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let mut tx = make_fee_payer_tx(60);
@@ -2255,8 +2283,9 @@ mod tests {
     fn test_cosign_rejects_missing_valid_before() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let mut tx = make_fee_payer_tx(60);
@@ -2289,8 +2318,9 @@ mod tests {
     fn test_cosign_rejects_access_list_signed_by_client() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let mut tx = make_fee_payer_tx(60);
@@ -2326,8 +2356,9 @@ mod tests {
     fn test_cosign_rejects_expired_valid_before() {
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         // Build a tx with valid_before in the past
@@ -2365,8 +2396,9 @@ mod tests {
     #[test]
     fn test_cosign_rejects_empty_input() {
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let provider =
@@ -2392,8 +2424,9 @@ mod tests {
     #[test]
     fn test_cosign_rejects_wrong_type_byte() {
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         let provider =
@@ -2599,8 +2632,9 @@ mod tests {
         Address,
     ) {
         let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
         let provider =
             alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
@@ -2747,6 +2781,10 @@ mod tests {
             max_priority_fee_per_gas: Some(2_000_000_000),
             max_total_fee: Some(40_000_000_000_000_000),
             max_validity_window_seconds: Some(600),
+            allowed_fee_tokens: Some(vec![KnownTempoNetwork::Mainnet
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()]),
         };
         let (method, client_signer, fee_token) = make_cosign_method(Some(overrides));
 
@@ -2806,6 +2844,61 @@ mod tests {
             moderato.max_validity_window_seconds,
             tempo_mainnet.max_validity_window_seconds
         );
+        assert!(tempo_mainnet.allows_fee_token(
+            KnownTempoNetwork::Mainnet
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()
+        ));
+        assert!(!tempo_mainnet.allows_fee_token(
+            KnownTempoNetwork::Moderato
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()
+        ));
+        assert!(moderato.allows_fee_token(
+            KnownTempoNetwork::Moderato
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()
+        ));
+        assert!(!moderato.allows_fee_token(
+            KnownTempoNetwork::Mainnet
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()
+        ));
+    }
+
+    #[test]
+    fn test_cosign_rejects_non_allowlisted_fee_token() {
+        let overrides = FeePayerPolicyOverride {
+            allowed_fee_tokens: Some(vec![KnownTempoNetwork::Mainnet
+                .default_currency()
+                .parse::<Address>()
+                .unwrap()]),
+            ..Default::default()
+        };
+        let (method, client_signer, _) = make_cosign_method(Some(overrides));
+
+        let tx = make_fee_payer_tx(60);
+        let encoded = sign_and_encode_0x78(tx, &client_signer);
+
+        let err = method
+            .cosign_fee_payer_transaction(
+                &encoded,
+                method.fee_payer_signer.as_ref().unwrap(),
+                KnownTempoNetwork::Moderato
+                    .default_currency()
+                    .parse::<Address>()
+                    .unwrap(),
+            )
+            .expect_err("cosign should reject non-allowlisted fee token");
+        assert!(
+            err.to_string()
+                .contains("is not allowed by fee payer policy"),
+            "got: {err}"
+        );
     }
 
     /// Sponsor MUST strip an attacker-injected wire access list: an honest
@@ -2823,8 +2916,9 @@ mod tests {
 
         let client_signer = PrivateKeySigner::random();
         let fee_payer_signer = PrivateKeySigner::random();
-        let fee_token: Address = "0x20c0000000000000000000000000000000000000"
-            .parse()
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
             .unwrap();
 
         // Honest tx with empty access list, signed by the client.

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -43,8 +43,8 @@ use crate::tempo::attribution;
 
 use super::transfers::{get_request_transfers, Transfer};
 use super::{
-    network::TempoNetwork as KnownTempoNetwork, proof, TempoChargeExt, CHAIN_ID, INTENT_CHARGE,
-    METHOD_NAME,
+    network::TempoNetwork as KnownTempoNetwork, proof, TempoChargeExt, CHAIN_ID,
+    DEFAULT_CURRENCY_TESTNET, INTENT_CHARGE, METHOD_NAME,
 };
 
 const MAX_FEE_PAYER_GAS_LIMIT: u64 = 2_000_000;
@@ -554,17 +554,16 @@ impl FeePayerPolicy {
 }
 
 fn default_fee_payer_allowed_fee_tokens(chain_id: u64) -> Vec<Address> {
-    let network = KnownTempoNetwork::from_chain_id(chain_id).unwrap_or(KnownTempoNetwork::Mainnet);
-    vec![network
-        .default_currency()
+    let token = KnownTempoNetwork::from_chain_id(chain_id)
+        .map(|network| network.default_currency())
+        .unwrap_or(DEFAULT_CURRENCY_TESTNET);
+    vec![token
         .parse()
         .expect("default Tempo fee token is a valid address")]
 }
 
 fn fee_token_allowed(allowed_fee_tokens: &[Address], fee_token: Address) -> bool {
-    allowed_fee_tokens
-        .iter()
-        .any(|allowed| *allowed == fee_token)
+    allowed_fee_tokens.contains(&fee_token)
 }
 
 impl<P> ChargeMethod<P>
@@ -3118,6 +3117,10 @@ mod tests {
                 .default_currency()
                 .parse::<Address>()
                 .unwrap()
+        ));
+        assert!(FeePayerPolicy::default_allows_fee_token(
+            31337,
+            DEFAULT_CURRENCY_TESTNET.parse::<Address>().unwrap()
         ));
     }
 

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -902,7 +902,9 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
                 .chain_id
                 .and_then(TempoNetwork::from_chain_id)
                 .map(|n| n.default_currency().to_string())
-                .unwrap_or_else(|| crate::protocol::methods::tempo::PATH_USD.to_string())
+                .unwrap_or_else(|| {
+                    crate::protocol::methods::tempo::DEFAULT_CURRENCY_MAINNET.to_string()
+                })
         };
 
         Ok(Self {
@@ -1069,6 +1071,10 @@ impl Mpp<crate::protocol::methods::stripe::method::ChargeMethod> {
 mod tests {
     use super::*;
     use crate::protocol::core::{ChallengeEcho, PaymentPayload};
+    #[cfg(feature = "tempo")]
+    use crate::protocol::methods::tempo::{
+        FeePayerPolicy, TempoChargeExt, CHAIN_ID, DEFAULT_CURRENCY_MAINNET,
+    };
     use crate::protocol::traits::ErrorCode;
     #[cfg(feature = "tempo")]
     use crate::server::{tempo, ChargeOptions, TempoConfig};
@@ -1353,16 +1359,39 @@ mod tests {
     fn test_mpp_create() {
         let mpp = create_test_mpp();
         assert_eq!(mpp.realm(), "MPP Payment");
-        // No chain_id set → unknown chain → defaults to pathUSD
-        assert_eq!(
-            mpp.currency(),
-            Some("0x20c0000000000000000000000000000000000000")
-        );
+        // No chain_id set follows the charge verifier fallback to mainnet.
+        assert_eq!(mpp.currency(), Some(DEFAULT_CURRENCY_MAINNET));
         assert_eq!(
             mpp.recipient(),
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2")
         );
         assert_eq!(mpp.decimals(), 6);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_default_fee_payer_charge_uses_allowlisted_currency() {
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let mpp = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .fee_payer(true)
+            .fee_payer_signer(fee_payer_signer)
+            .secret_key("test-secret"),
+        )
+        .unwrap();
+
+        let challenge = mpp.charge("1").unwrap();
+        let request: ChargeRequest = challenge.request.decode().unwrap();
+        assert!(mpp.fee_payer());
+        assert!(request.fee_payer());
+        assert_eq!(request.chain_id(), None);
+        assert_eq!(request.currency, DEFAULT_CURRENCY_MAINNET);
+        assert!(FeePayerPolicy::default_allows_fee_token(
+            request.chain_id().unwrap_or(CHAIN_ID),
+            request.currency_address().unwrap()
+        ));
     }
 
     #[cfg(feature = "tempo")]
@@ -1423,10 +1452,7 @@ mod tests {
 
         let request: ChargeRequest = challenge.request.decode().unwrap();
         assert_eq!(request.amount, "100000");
-        assert_eq!(
-            request.currency,
-            "0x20c0000000000000000000000000000000000000"
-        );
+        assert_eq!(request.currency, DEFAULT_CURRENCY_MAINNET);
         assert_eq!(
             request.recipient,
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string())

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -954,9 +954,7 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
                 .chain_id
                 .and_then(TempoNetwork::from_chain_id)
                 .map(|n| n.default_currency().to_string())
-                .unwrap_or_else(|| {
-                    crate::protocol::methods::tempo::DEFAULT_CURRENCY_MAINNET.to_string()
-                })
+                .unwrap_or_else(|| crate::protocol::methods::tempo::PATH_USD.to_string())
         };
 
         Ok(Self {
@@ -1127,6 +1125,7 @@ mod tests {
     #[cfg(feature = "tempo")]
     use crate::protocol::methods::tempo::{
         FeePayerPolicy, TempoChargeExt, CHAIN_ID, DEFAULT_CURRENCY_MAINNET,
+        DEFAULT_CURRENCY_TESTNET,
     };
     use crate::protocol::traits::ErrorCode;
     #[cfg(feature = "tempo")]
@@ -1414,8 +1413,8 @@ mod tests {
     fn test_mpp_create() {
         let mpp = create_test_mpp();
         assert_eq!(mpp.realm(), "MPP Payment");
-        // No chain_id set follows the charge verifier fallback to mainnet.
-        assert_eq!(mpp.currency(), Some(DEFAULT_CURRENCY_MAINNET));
+        // No chain_id set follows the existing local/dev fallback.
+        assert_eq!(mpp.currency(), Some(DEFAULT_CURRENCY_TESTNET));
         assert_eq!(
             mpp.recipient(),
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2")
@@ -1431,6 +1430,7 @@ mod tests {
             tempo(TempoConfig {
                 recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
             })
+            .chain_id(CHAIN_ID)
             .fee_payer(true)
             .fee_payer_signer(fee_payer_signer)
             .secret_key("test-secret"),
@@ -1441,10 +1441,37 @@ mod tests {
         let request: ChargeRequest = challenge.request.decode().unwrap();
         assert!(mpp.fee_payer());
         assert!(request.fee_payer());
-        assert_eq!(request.chain_id(), None);
+        assert_eq!(request.chain_id(), Some(CHAIN_ID));
         assert_eq!(request.currency, DEFAULT_CURRENCY_MAINNET);
         assert!(FeePayerPolicy::default_allows_fee_token(
             request.chain_id().unwrap_or(CHAIN_ID),
+            request.currency_address().unwrap()
+        ));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_unknown_chain_fee_payer_charge_uses_allowlisted_local_currency() {
+        let chain_id = 31337;
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let mpp = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .chain_id(chain_id)
+            .fee_payer(true)
+            .fee_payer_signer(fee_payer_signer)
+            .secret_key("test-secret"),
+        )
+        .unwrap();
+
+        let challenge = mpp.charge("1").unwrap();
+        let request: ChargeRequest = challenge.request.decode().unwrap();
+        assert!(request.fee_payer());
+        assert_eq!(request.chain_id(), Some(chain_id));
+        assert_eq!(request.currency, DEFAULT_CURRENCY_TESTNET);
+        assert!(FeePayerPolicy::default_allows_fee_token(
+            chain_id,
             request.currency_address().unwrap()
         ));
     }
@@ -1540,7 +1567,7 @@ mod tests {
 
         let request: ChargeRequest = challenge.request.decode().unwrap();
         assert_eq!(request.amount, "100000");
-        assert_eq!(request.currency, DEFAULT_CURRENCY_MAINNET);
+        assert_eq!(request.currency, DEFAULT_CURRENCY_TESTNET);
         assert_eq!(
             request.recipient,
             Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".to_string())

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -892,6 +892,9 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
         if let Some(signer) = builder.fee_payer_signer {
             method = method.with_fee_payer(signer);
         }
+        if let Some(allowed_fee_tokens) = builder.fee_payer_allowed_fee_tokens {
+            method = method.with_fee_payer_allowed_fee_tokens(allowed_fee_tokens);
+        }
 
         // Resolve currency from chain_id when not explicitly set
         let currency = if builder.currency_explicit {
@@ -1078,6 +1081,8 @@ mod tests {
     use crate::protocol::traits::ErrorCode;
     #[cfg(feature = "tempo")]
     use crate::server::{tempo, ChargeOptions, TempoConfig};
+    #[cfg(feature = "tempo")]
+    use alloy::primitives::Address;
     use std::{
         future::Future,
         sync::{Arc, Mutex},
@@ -1392,6 +1397,39 @@ mod tests {
             request.chain_id().unwrap_or(CHAIN_ID),
             request.currency_address().unwrap()
         ));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_fee_payer_custom_currency_can_override_allowed_fee_tokens() {
+        let custom_token: Address = "0x9999999999999999999999999999999999999999"
+            .parse()
+            .unwrap();
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let mpp = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .currency("0x9999999999999999999999999999999999999999")
+            .fee_payer(true)
+            .fee_payer_signer(fee_payer_signer)
+            .fee_payer_allowed_fee_tokens(vec![custom_token])
+            .secret_key("test-secret"),
+        )
+        .unwrap();
+
+        let challenge = mpp.charge("1").unwrap();
+        let request: ChargeRequest = challenge.request.decode().unwrap();
+        assert!(request.fee_payer());
+        assert_eq!(request.currency_address().unwrap(), custom_token);
+        assert!(!FeePayerPolicy::default_allows_fee_token(
+            request.chain_id().unwrap_or(CHAIN_ID),
+            custom_token
+        ));
+        assert_eq!(
+            mpp.method.fee_payer_allowed_fee_tokens(),
+            Some([custom_token].as_slice())
+        );
     }
 
     #[cfg(feature = "tempo")]

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -104,7 +104,7 @@ impl TempoBuilder {
 
 /// Create a Tempo payment method configuration with smart defaults.
 ///
-/// Only `currency` and `recipient` are required. Returns a [`TempoBuilder`]
+/// Only `recipient` is required. Returns a [`TempoBuilder`]
 /// that can be passed to [`Mpp::create()`](super::Mpp::create).
 ///
 /// # Defaults
@@ -114,8 +114,9 @@ impl TempoBuilder {
 ///   `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`,
 ///   `VERCEL_URL`, `WEBSITE_HOSTNAME` — falling back to `"MPP Payment"`
 /// - **secret_key**: reads `MPP_SECRET_KEY` env var; required if not explicitly set
-/// - **currency**: pathUSD (`0x20c0000000000000000000000000000000000000`)
-/// - **decimals**: `6` (for pathUSD / standard stablecoins)
+/// - **currency**: mainnet USDC, or pathUSD when `.chain_id(42431)` or a
+///   Moderato RPC URL is configured
+/// - **decimals**: `6` (for USDC / pathUSD / standard stablecoins)
 /// - **expires**: `now + 5 minutes`
 ///
 /// # Example
@@ -123,7 +124,7 @@ impl TempoBuilder {
 /// ```ignore
 /// use mpp::server::{Mpp, tempo, TempoConfig};
 ///
-/// // Minimal — currency defaults to pathUSD
+/// // Minimal — currency defaults to mainnet USDC
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     recipient: "0xabc...123",
 /// }))?;

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -1,5 +1,7 @@
 //! Tempo payment method configuration and builder.
 
+use alloy::primitives::Address;
+
 use super::mpp::detect_realm;
 
 pub use crate::protocol::methods::tempo::session_method::{
@@ -33,6 +35,7 @@ pub struct TempoBuilder {
     pub(crate) fee_payer: bool,
     pub(crate) chain_id: Option<u64>,
     pub(crate) fee_payer_signer: Option<alloy::signers::local::PrivateKeySigner>,
+    pub(crate) fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
 }
 
 impl TempoBuilder {
@@ -100,6 +103,17 @@ impl TempoBuilder {
         self.fee_payer_signer = Some(signer);
         self
     }
+
+    /// Replace the fee-sponsor token allowlist used when co-signing fee-payer
+    /// transactions.
+    ///
+    /// By default, sponsored transactions accept the known default currency for
+    /// the transaction chain ID. Use this when `.currency(...)` points at a
+    /// custom token that the fee payer should sponsor.
+    pub fn fee_payer_allowed_fee_tokens(mut self, allowed_fee_tokens: Vec<Address>) -> Self {
+        self.fee_payer_allowed_fee_tokens = Some(allowed_fee_tokens);
+        self
+    }
 }
 
 /// Create a Tempo payment method configuration with smart defaults.
@@ -153,6 +167,7 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         fee_payer: false,
         chain_id: None,
         fee_payer_signer: None,
+        fee_payer_allowed_fee_tokens: None,
     }
 }
 

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -143,9 +143,9 @@ impl TempoBuilder {
 ///   `HOST`, `HOSTNAME`, `RAILWAY_PUBLIC_DOMAIN`, `RENDER_EXTERNAL_HOSTNAME`,
 ///   `VERCEL_URL`, `WEBSITE_HOSTNAME` — falling back to `"MPP Payment"`
 /// - **secret_key**: reads `MPP_SECRET_KEY` env var; required if not explicitly set
-/// - **currency**: mainnet USDC, or pathUSD when `.chain_id(42431)` or a
-///   Moderato RPC URL is configured
-/// - **decimals**: `6` (for USDC / pathUSD / standard stablecoins)
+/// - **currency**: pathUSD by default, mainnet USDC with `.chain_id(4217)`,
+///   or pathUSD with `.chain_id(42431)` / a Moderato RPC URL
+/// - **decimals**: `6` (for pathUSD / USDC / standard stablecoins)
 /// - **expires**: `now + 5 minutes`
 ///
 /// # Example
@@ -153,7 +153,7 @@ impl TempoBuilder {
 /// ```ignore
 /// use mpp::server::{Mpp, tempo, TempoConfig};
 ///
-/// // Minimal — currency defaults to mainnet USDC
+/// // Minimal — currency defaults to pathUSD
 /// let mpp = Mpp::create(tempo(TempoConfig {
 ///     recipient: "0xabc...123",
 /// }))?;


### PR DESCRIPTION
## Summary
- Add a sponsor fee-token allowlist to FeePayerPolicy.
- Default sponsor fee tokens to Tempo mainnet USDC and Moderato pathUSD.
- Reject fee-payer cosigning when the chosen fee token is outside policy.
- Add conformance coverage for the non-allowlisted fee-token case.
