### PR TITLE
feat: add TIP-1034 session client primitives

### DIFF
--- a/.changelog/tip1034-session-client.md
+++ b/.changelog/tip1034-session-client.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added TIP-1034 Tempo session client primitives for descriptor-backed channels, precompile ABI helpers, voucher signing, and fee-sponsored session opens.

--- a/deny.toml
+++ b/deny.toml
@@ -6,6 +6,8 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436 paste! is unmaintained (transitive dep)
     "RUSTSEC-2024-0436",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained (transitive dep)
+    "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -5,7 +5,7 @@
 
 use std::num::NonZeroU64;
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, Signature, U256};
 use alloy::providers::Provider;
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
@@ -45,7 +45,7 @@ pub struct TempoTxOptions {
 pub fn build_tempo_tx(options: TempoTxOptions) -> TempoTransaction {
     TempoTransaction {
         chain_id: options.chain_id,
-        // Fee payer mode: fee_token is None (server chooses at co-sign time)
+        // Fee payer mode: fee_token is supplied by the server at co-sign time.
         fee_token: if options.fee_payer {
             None
         } else {
@@ -59,13 +59,10 @@ pub fn build_tempo_tx(options: TempoTxOptions) -> TempoTransaction {
         nonce: options.nonce,
         key_authorization: options.key_authorization,
         access_list: Default::default(),
-        // Fee payer mode: placeholder signature triggers skip_fee_token in signing hash
+        // Placeholder marks the transaction as fee-payer sponsored for the
+        // user's signing hash. The server replaces it during co-signing.
         fee_payer_signature: if options.fee_payer {
-            Some(alloy::primitives::Signature::new(
-                U256::ZERO,
-                U256::ZERO,
-                false,
-            ))
+            Some(Signature::new(U256::ZERO, U256::ZERO, false))
         } else {
             None
         },
@@ -347,6 +344,26 @@ mod tests {
 
         assert!(tx.calls.is_empty());
         assert_eq!(tx.chain_id, 42431);
+    }
+
+    #[test]
+    fn test_build_tempo_tx_fee_payer_sets_placeholder() {
+        let tx = build_tempo_tx(TempoTxOptions {
+            calls: vec![],
+            chain_id: 42431,
+            fee_token: Address::repeat_byte(0x33),
+            nonce: 0,
+            nonce_key: U256::MAX,
+            gas_limit: 100_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 100_000_000,
+            fee_payer: true,
+            valid_before: Some(9999999999),
+            key_authorization: None,
+        });
+
+        assert!(tx.fee_token.is_none());
+        assert!(tx.fee_payer_signature.is_some());
     }
 
     #[test]

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -20,11 +20,17 @@ use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
 use crate::protocol::intents::SessionRequest;
 use crate::protocol::methods::tempo::precompile_voucher::{
-    compute_precompile_channel_id, sign_precompile_voucher, PRECOMPILE_MAX_CUMULATIVE_AMOUNT,
+    compute_precompile_channel_id, compute_precompile_channel_id_with_escrow,
+    sign_precompile_voucher, sign_precompile_voucher_with_escrow, PRECOMPILE_MAX_CUMULATIVE_AMOUNT,
 };
-use crate::protocol::methods::tempo::session::{SessionCredentialPayload, TempoSessionExt};
+use crate::protocol::methods::tempo::session::{
+    ChannelDescriptor, SessionCredentialPayload, TempoSessionExt,
+};
 use crate::protocol::methods::tempo::voucher::{compute_channel_id, sign_voucher};
 use crate::protocol::methods::tempo::MODERATO_CHAIN_ID;
+
+#[cfg(feature = "tempo")]
+const FEE_PAYER_VALID_BEFORE_SECS: u64 = 25;
 
 /// Default escrow contract addresses per chain ID.
 pub fn default_escrow_contract(chain_id: u64) -> Option<Address> {
@@ -128,6 +134,7 @@ pub async fn create_voucher_payload(
 
     Ok(SessionCredentialPayload::Voucher {
         channel_id: channel_id.to_string(),
+        descriptor: None,
         cumulative_amount: cumulative_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&sig),
     })
@@ -146,6 +153,56 @@ pub async fn create_precompile_voucher_payload(
 
     Ok(SessionCredentialPayload::Voucher {
         channel_id: channel_id.to_string(),
+        descriptor: None,
+        cumulative_amount: cumulative_amount.to_string(),
+        signature: alloy::hex::encode_prefixed(&sig),
+    })
+}
+
+/// Voucher payload for TIP-1034 with the descriptor required for recovery.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_voucher_payload_with_descriptor(
+    signer: &impl Signer,
+    descriptor: ChannelDescriptor,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    create_precompile_voucher_payload_with_descriptor_and_escrow(
+        signer,
+        descriptor,
+        cumulative_amount,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+    .await
+}
+
+/// Voucher payload for TIP-1034 with an explicit escrow/precompile address.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_voucher_payload_with_descriptor_and_escrow(
+    signer: &impl Signer,
+    descriptor: ChannelDescriptor,
+    cumulative_amount: u128,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    let channel_id = compute_precompile_channel_id_from_descriptor_with_escrow(
+        &descriptor,
+        escrow_contract,
+        chain_id,
+    )?;
+    let sig = sign_precompile_voucher_with_escrow(
+        signer,
+        channel_id,
+        cumulative_amount,
+        escrow_contract,
+        chain_id,
+    )
+    .await?;
+
+    Ok(SessionCredentialPayload::Voucher {
+        channel_id: channel_id.to_string(),
+        descriptor: Some(descriptor),
         cumulative_amount: cumulative_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&sig),
     })
@@ -170,6 +227,7 @@ pub async fn create_close_payload(
 
     Ok(SessionCredentialPayload::Close {
         channel_id: channel_id.to_string(),
+        descriptor: None,
         cumulative_amount: cumulative_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&sig),
     })
@@ -187,6 +245,65 @@ pub async fn create_precompile_close_payload(
 
     Ok(SessionCredentialPayload::Close {
         channel_id: channel_id.to_string(),
+        descriptor: None,
+        cumulative_amount: cumulative_amount.to_string(),
+        signature: alloy::hex::encode_prefixed(&sig),
+    })
+}
+
+/// Close payload for TIP-1034 with the descriptor required for recovery.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_close_payload_with_descriptor(
+    signer: &impl Signer,
+    channel_id: B256,
+    descriptor: ChannelDescriptor,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    create_precompile_close_payload_with_descriptor_and_escrow(
+        signer,
+        channel_id,
+        descriptor,
+        cumulative_amount,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+    .await
+}
+
+/// Close payload for TIP-1034 with a descriptor and explicit escrow/precompile verifier.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_close_payload_with_descriptor_and_escrow(
+    signer: &impl Signer,
+    channel_id: B256,
+    descriptor: ChannelDescriptor,
+    cumulative_amount: u128,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> Result<SessionCredentialPayload, MppError> {
+    let expected_channel_id = compute_precompile_channel_id_from_descriptor_with_escrow(
+        &descriptor,
+        escrow_contract,
+        chain_id,
+    )?;
+    if expected_channel_id != channel_id {
+        return Err(MppError::InvalidConfig(
+            "TIP-1034 close descriptor does not match channel_id".to_string(),
+        ));
+    }
+
+    let sig = sign_precompile_voucher_with_escrow(
+        signer,
+        channel_id,
+        cumulative_amount,
+        escrow_contract,
+        chain_id,
+    )
+    .await?;
+
+    Ok(SessionCredentialPayload::Close {
+        channel_id: channel_id.to_string(),
+        descriptor: Some(descriptor),
         cumulative_amount: cumulative_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&sig),
     })
@@ -339,6 +456,7 @@ where
         payload_type: "transaction".to_string(),
         channel_id: channel_id.to_string(),
         transaction: signed_tx_hex,
+        descriptor: None,
         authorized_signer: Some(authorized_signer.to_string()),
         cumulative_amount: options.initial_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&voucher_sig),
@@ -361,6 +479,236 @@ pub fn compute_expiring_nonce_hash(unsigned_tx: &TempoTransaction, sender: Addre
     unsigned_tx.encode_for_signing(&mut buf);
     buf.extend_from_slice(sender.as_slice());
     keccak256(buf)
+}
+
+/// Compute `expiringNonceHash` for a fee-sponsored TIP-1034 channel open.
+///
+/// The sender signature is verified against the submitted transaction, but
+/// TIP-1034 derives channel identity from the fee-payer hash preimage that
+/// marks the transaction as sponsorable.
+#[cfg(feature = "tempo")]
+pub fn compute_fee_payer_expiring_nonce_hash(
+    unsigned_tx: &TempoTransaction,
+    sender: Address,
+) -> B256 {
+    let mut tx = unsigned_tx.clone();
+    tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
+        U256::ZERO,
+        U256::ZERO,
+        false,
+    ));
+    compute_expiring_nonce_hash(&tx, sender)
+}
+
+/// Build the wire descriptor for a TIP-1034 precompile channel.
+#[cfg(feature = "tempo")]
+#[allow(clippy::too_many_arguments)]
+pub fn build_channel_descriptor(
+    payer: Address,
+    payee: Address,
+    operator: Address,
+    token: Address,
+    salt: B256,
+    authorized_signer: Address,
+    expiring_nonce_hash: B256,
+) -> ChannelDescriptor {
+    ChannelDescriptor {
+        payer: payer.to_string(),
+        payee: payee.to_string(),
+        operator: operator.to_string(),
+        token: token.to_string(),
+        salt: salt.to_string(),
+        authorized_signer: authorized_signer.to_string(),
+        expiring_nonce_hash: expiring_nonce_hash.to_string(),
+    }
+}
+
+#[cfg(feature = "tempo")]
+fn parse_precompile_amount(value: u128, label: &str) -> Result<Uint<96, 2>, MppError> {
+    if value > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+        return Err(MppError::InvalidConfig(format!(
+            "{label} {value} exceeds precompile uint96 max"
+        )));
+    }
+    Ok(Uint::<96, 2>::from(value))
+}
+
+#[cfg(feature = "tempo")]
+fn precompile_open_tx_nonce_fields(fee_payer: bool, nonce: u64) -> (u64, U256, Option<u64>) {
+    if !fee_payer {
+        return (nonce, U256::ZERO, None);
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    (
+        0,
+        U256::MAX,
+        Some(now.saturating_add(FEE_PAYER_VALID_BEFORE_SECS)),
+    )
+}
+
+/// Convert a JSON wire descriptor into the generated precompile ABI tuple.
+#[cfg(feature = "tempo")]
+pub fn precompile_descriptor_from_wire(
+    descriptor: &ChannelDescriptor,
+) -> Result<ITIP20ChannelReserve::ChannelDescriptor, MppError> {
+    Ok(ITIP20ChannelReserve::ChannelDescriptor {
+        payer: descriptor.payer.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor payer: {e}"))
+        })?,
+        payee: descriptor.payee.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor payee: {e}"))
+        })?,
+        operator: descriptor.operator.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor operator: {e}"))
+        })?,
+        token: descriptor.token.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor token: {e}"))
+        })?,
+        salt: descriptor.salt.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor salt: {e}"))
+        })?,
+        authorizedSigner: descriptor.authorized_signer.parse().map_err(|e| {
+            MppError::InvalidConfig(format!("invalid TIP-1034 descriptor authorizedSigner: {e}"))
+        })?,
+        expiringNonceHash: descriptor.expiring_nonce_hash.parse().map_err(|e| {
+            MppError::InvalidConfig(format!(
+                "invalid TIP-1034 descriptor expiringNonceHash: {e}"
+            ))
+        })?,
+    })
+}
+
+/// Compute a TIP-1034 channel ID from a wire descriptor.
+#[cfg(feature = "tempo")]
+pub fn compute_precompile_channel_id_from_descriptor(
+    descriptor: &ChannelDescriptor,
+    chain_id: u64,
+) -> Result<B256, MppError> {
+    compute_precompile_channel_id_from_descriptor_with_escrow(
+        descriptor,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+}
+
+/// Compute a TIP-1034 channel ID from a wire descriptor and explicit escrow.
+#[cfg(feature = "tempo")]
+pub fn compute_precompile_channel_id_from_descriptor_with_escrow(
+    descriptor: &ChannelDescriptor,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> Result<B256, MppError> {
+    let descriptor = precompile_descriptor_from_wire(descriptor)?;
+    Ok(compute_precompile_channel_id_with_escrow(
+        descriptor.payer,
+        descriptor.payee,
+        descriptor.operator,
+        descriptor.token,
+        descriptor.salt,
+        descriptor.authorizedSigner,
+        descriptor.expiringNonceHash,
+        escrow_contract,
+        chain_id,
+    ))
+}
+
+/// ABI-encode `open(payee, operator, token, uint96 deposit, salt, authorizedSigner)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_open_call(
+    payee: Address,
+    operator: Address,
+    token: Address,
+    deposit: u128,
+    salt: B256,
+    authorized_signer: Address,
+) -> Result<Bytes, MppError> {
+    Ok(Bytes::from(
+        ITIP20ChannelReserve::openCall::new((
+            payee,
+            operator,
+            token,
+            parse_precompile_amount(deposit, "deposit")?,
+            salt,
+            authorized_signer,
+        ))
+        .abi_encode(),
+    ))
+}
+
+/// ABI-encode `topUp(descriptor, uint96 additionalDeposit)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_top_up_call(
+    descriptor: &ChannelDescriptor,
+    additional_deposit: u128,
+) -> Result<Bytes, MppError> {
+    Ok(Bytes::from(
+        ITIP20ChannelReserve::topUpCall::new((
+            precompile_descriptor_from_wire(descriptor)?,
+            parse_precompile_amount(additional_deposit, "additional_deposit")?,
+        ))
+        .abi_encode(),
+    ))
+}
+
+/// ABI-encode `getChannel(descriptor)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_get_channel_call(
+    descriptor: &ChannelDescriptor,
+) -> Result<Bytes, MppError> {
+    Ok(Bytes::from(
+        ITIP20ChannelReserve::getChannelCall::new((precompile_descriptor_from_wire(descriptor)?,))
+            .abi_encode(),
+    ))
+}
+
+/// ABI-encode `getChannelState(channelId)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_get_channel_state_call(channel_id: B256) -> Bytes {
+    Bytes::from(ITIP20ChannelReserve::getChannelStateCall::new((channel_id,)).abi_encode())
+}
+
+/// ABI-encode `requestClose(descriptor)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_request_close_call(
+    descriptor: &ChannelDescriptor,
+) -> Result<Bytes, MppError> {
+    Ok(Bytes::from(
+        ITIP20ChannelReserve::requestCloseCall::new(
+            (precompile_descriptor_from_wire(descriptor)?,),
+        )
+        .abi_encode(),
+    ))
+}
+
+/// ABI-encode `withdraw(descriptor)`.
+#[cfg(feature = "tempo")]
+pub fn encode_precompile_withdraw_call(descriptor: &ChannelDescriptor) -> Result<Bytes, MppError> {
+    Ok(Bytes::from(
+        ITIP20ChannelReserve::withdrawCall::new((precompile_descriptor_from_wire(descriptor)?,))
+            .abi_encode(),
+    ))
+}
+
+/// Build a descriptor-backed TIP-1034 top-up credential payload.
+#[cfg(feature = "tempo")]
+pub fn create_precompile_top_up_payload(
+    channel_id: B256,
+    descriptor: ChannelDescriptor,
+    transaction: String,
+    additional_deposit: u128,
+) -> SessionCredentialPayload {
+    SessionCredentialPayload::TopUp {
+        payload_type: "transaction".to_string(),
+        channel_id: channel_id.to_string(),
+        transaction,
+        descriptor: Some(descriptor),
+        additional_deposit: additional_deposit.to_string(),
+    }
 }
 
 /// Options for [`create_precompile_open_payload`]. Replaces `escrow_contract`
@@ -429,33 +777,53 @@ where
         input: Bytes::from(open_data),
     }];
 
-    let nonce = provider
-        .get_transaction_count(payer)
-        .await
-        .mpp_http("failed to get nonce")?;
+    let nonce = if options.fee_payer {
+        0
+    } else {
+        provider
+            .get_transaction_count(payer)
+            .await
+            .mpp_http("failed to get nonce")?
+    };
 
     let gas_price = provider
         .get_gas_price()
         .await
         .mpp_http("failed to get gas price")?;
 
+    let (nonce, nonce_key, valid_before) =
+        precompile_open_tx_nonce_fields(options.fee_payer, nonce);
+
     let unsigned_tx = build_tempo_tx(TempoTxOptions {
         calls,
         chain_id: options.chain_id,
         fee_token: options.currency,
         nonce,
-        nonce_key: U256::ZERO,
+        nonce_key,
         gas_limit: 2_000_000,
         max_fee_per_gas: gas_price,
         max_priority_fee_per_gas: gas_price,
         fee_payer: options.fee_payer,
-        valid_before: None,
+        valid_before,
         key_authorization: signing_mode.key_authorization().cloned(),
     });
 
     // Derive id from the unsigned tx before signing; expiringNonceHash binds
     // the signing-payload bytes.
-    let expiring_nonce_hash = compute_expiring_nonce_hash(&unsigned_tx, payer);
+    let expiring_nonce_hash = if options.fee_payer {
+        compute_fee_payer_expiring_nonce_hash(&unsigned_tx, payer)
+    } else {
+        compute_expiring_nonce_hash(&unsigned_tx, payer)
+    };
+    let descriptor = build_channel_descriptor(
+        payer,
+        options.payee,
+        options.operator,
+        options.currency,
+        salt,
+        authorized_signer,
+        expiring_nonce_hash,
+    );
     let channel_id = compute_precompile_channel_id(
         payer,
         options.payee,
@@ -467,9 +835,17 @@ where
         options.chain_id,
     );
 
-    let tx_bytes =
+    let tx_bytes = if options.fee_payer {
+        crate::client::tempo::signing::sign_and_encode_fee_payer_request_async(
+            unsigned_tx,
+            signer,
+            signing_mode,
+        )
+        .await?
+    } else {
         crate::client::tempo::signing::sign_and_encode_async(unsigned_tx, signer, signing_mode)
-            .await?;
+            .await?
+    };
     let signed_tx_hex = alloy::hex::encode_prefixed(&tx_bytes);
 
     let voucher_sig =
@@ -489,6 +865,7 @@ where
         payload_type: "transaction".to_string(),
         channel_id: channel_id.to_string(),
         transaction: signed_tx_hex,
+        descriptor: Some(descriptor),
         authorized_signer: Some(authorized_signer.to_string()),
         cumulative_amount: options.initial_amount.to_string(),
         signature: alloy::hex::encode_prefixed(&voucher_sig),
@@ -691,6 +1068,33 @@ mod tests {
     }
 
     #[cfg(feature = "tempo")]
+    #[test]
+    fn test_precompile_open_tx_nonce_fields_for_fee_payer() {
+        let before = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let (nonce, nonce_key, valid_before) = precompile_open_tx_nonce_fields(true, 7);
+
+        assert_eq!(nonce, 0);
+        assert_eq!(nonce_key, U256::MAX);
+        let valid_before = valid_before.expect("fee payer open sets valid_before");
+        assert!(valid_before >= before);
+        assert!(valid_before <= before + FEE_PAYER_VALID_BEFORE_SECS + 1);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_precompile_open_tx_nonce_fields_for_direct_payer() {
+        let (nonce, nonce_key, valid_before) = precompile_open_tx_nonce_fields(false, 7);
+
+        assert_eq!(nonce, 7);
+        assert_eq!(nonce_key, U256::ZERO);
+        assert!(valid_before.is_none());
+    }
+
+    #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn test_create_precompile_open_payload_rejects_uint96_overflow() {
         use crate::protocol::methods::tempo::precompile_voucher::PRECOMPILE_MAX_CUMULATIVE_AMOUNT;
@@ -864,6 +1268,7 @@ mod tests {
 
         let payload = SessionCredentialPayload::Voucher {
             channel_id: "0xabc".to_string(),
+            descriptor: None,
             cumulative_amount: "5000".to_string(),
             signature: "0xdef".to_string(),
         };
@@ -894,10 +1299,12 @@ mod tests {
         match payload {
             SessionCredentialPayload::Voucher {
                 channel_id: cid,
+                descriptor,
                 cumulative_amount,
                 signature,
             } => {
                 assert!(cid.starts_with("0x"));
+                assert!(descriptor.is_none());
                 assert_eq!(cumulative_amount, "1000");
                 assert!(signature.starts_with("0x"));
             }
@@ -923,15 +1330,46 @@ mod tests {
         match payload {
             SessionCredentialPayload::Close {
                 channel_id: cid,
+                descriptor,
                 cumulative_amount,
                 signature,
             } => {
                 assert!(cid.starts_with("0x"));
+                assert!(descriptor.is_none());
                 assert_eq!(cumulative_amount, "2000");
                 assert!(signature.starts_with("0x"));
             }
             _ => panic!("Expected Close variant"),
         }
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn test_create_precompile_close_payload_rejects_descriptor_mismatch() {
+        use alloy::signers::local::PrivateKeySigner;
+
+        let signer = PrivateKeySigner::random();
+        let descriptor = build_channel_descriptor(
+            Address::repeat_byte(0x11),
+            Address::repeat_byte(0x22),
+            Address::ZERO,
+            Address::repeat_byte(0x33),
+            B256::repeat_byte(0x44),
+            Address::repeat_byte(0x55),
+            B256::repeat_byte(0x66),
+        );
+
+        let err = create_precompile_close_payload_with_descriptor(
+            &signer,
+            B256::repeat_byte(0x77),
+            descriptor,
+            2000,
+            42431,
+        )
+        .await
+        .expect_err("descriptor/channel mismatch should fail");
+
+        assert!(err.to_string().contains("does not match channel_id"));
     }
 
     #[test]
@@ -1116,6 +1554,7 @@ mod tests {
 
         let payload = SessionCredentialPayload::Voucher {
             channel_id: "0xabc".to_string(),
+            descriptor: None,
             cumulative_amount: "5000".to_string(),
             signature: "0xdef".to_string(),
         };

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -1458,6 +1458,7 @@ mod tests {
                 signature,
                 cumulative_amount,
                 channel_id: cid,
+                ..
             } => {
                 assert_eq!(cumulative_amount, "1500");
                 assert_eq!(cid, channel_id.to_string());

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -191,6 +191,53 @@ pub async fn sign_and_encode_async(
     Ok(signed_tx.encoded_2718())
 }
 
+/// Sign a fee-sponsored Tempo transaction and encode the client-submitted 0x76.
+///
+/// Session fee-payer requests submit a type-0x76 transaction with a `0x00`
+/// fee-payer marker. The marker lets the server recover the payer against the
+/// same preimage the payer signed, then replace it with the sponsor signature.
+pub async fn sign_and_encode_fee_payer_request_async(
+    mut tx: tempo_primitives::transaction::TempoTransaction,
+    signer: &impl alloy::signers::Signer,
+    mode: &TempoSigningMode,
+) -> Result<Vec<u8>, MppError> {
+    if tx.fee_payer_signature.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer request requires fee_payer_signature placeholder; build tx with TempoTxOptions { fee_payer: true }"
+                .to_string(),
+        ));
+    }
+    if tx.fee_token.is_some() {
+        return Err(MppError::InvalidConfig(
+            "fee payer request must not include fee_token (server chooses)".to_string(),
+        ));
+    }
+    if tx.nonce_key != U256::MAX {
+        return Err(MppError::InvalidConfig(
+            "fee payer request must use expiring nonce key (U256::MAX)".to_string(),
+        ));
+    }
+    if tx.valid_before.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer request must include valid_before".to_string(),
+        ));
+    }
+
+    tx.access_list = AccessList::default();
+
+    let sig_hash = tx.signature_hash();
+    let hash_to_sign = effective_signing_hash(sig_hash, mode);
+    let inner_signature = signer
+        .sign_hash(&hash_to_sign)
+        .await
+        .mpp_http("failed to sign transaction")?;
+
+    let signed_tx = tx.into_signed(build_tempo_signature(inner_signature, mode));
+    let mut out = Vec::new();
+    signed_tx.encode_for_fee_payer_service(&mut out);
+    Ok(out)
+}
+
 /// Async version of [`sign_and_encode_fee_payer_envelope`].
 pub async fn sign_and_encode_fee_payer_envelope_async(
     mut tx: tempo_primitives::transaction::TempoTransaction,
@@ -438,6 +485,41 @@ mod tests {
 
         // V1 and V2 should produce different signatures
         assert_ne!(v1_bytes, v2_bytes, "fee payer V1 and V2 should differ");
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_encode_fee_payer_request_rejects_missing_placeholder() {
+        let signer = test_signer();
+        let mut tx = test_tx();
+        tx.fee_token = None;
+        tx.nonce_key = alloy::primitives::U256::MAX;
+        tx.valid_before = NonZeroU64::new(9999999999);
+
+        let err = sign_and_encode_fee_payer_request_async(tx, &signer, &TempoSigningMode::Direct)
+            .await
+            .expect_err("missing placeholder should fail");
+
+        assert!(err.to_string().contains("fee_payer_signature"));
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_encode_fee_payer_request_produces_tempo_tx() {
+        let signer = test_signer();
+        let mut tx = test_tx();
+        tx.fee_token = None;
+        tx.nonce_key = alloy::primitives::U256::MAX;
+        tx.valid_before = NonZeroU64::new(9999999999);
+        tx.fee_payer_signature = Some(alloy::primitives::Signature::new(
+            alloy::primitives::U256::ZERO,
+            alloy::primitives::U256::ZERO,
+            false,
+        ));
+
+        let bytes = sign_and_encode_fee_payer_request_async(tx, &signer, &TempoSigningMode::Direct)
+            .await
+            .unwrap();
+
+        assert_eq!(bytes[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
     }
 
     #[test]

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -129,7 +129,9 @@ pub use session_receipt as stream_receipt;
 pub type StreamReceipt = SessionReceipt;
 #[cfg(feature = "tempo")]
 pub use precompile_voucher::{
-    compute_precompile_channel_id, sign_precompile_voucher, PRECOMPILE_DOMAIN_NAME,
+    compute_precompile_channel_id, compute_precompile_channel_id_with_escrow,
+    precompile_voucher_signing_hash, precompile_voucher_signing_hash_with_escrow,
+    sign_precompile_voucher, sign_precompile_voucher_with_escrow, PRECOMPILE_DOMAIN_NAME,
     PRECOMPILE_DOMAIN_VERSION, PRECOMPILE_MAX_CUMULATIVE_AMOUNT,
 };
 pub use transaction::{

--- a/src/protocol/methods/tempo/precompile_voucher.rs
+++ b/src/protocol/methods/tempo/precompile_voucher.rs
@@ -34,7 +34,7 @@ pub fn compute_precompile_channel_id(
     expiring_nonce_hash: B256,
     chain_id: u64,
 ) -> B256 {
-    let encoded = (
+    compute_precompile_channel_id_with_escrow(
         payer,
         payee,
         operator,
@@ -43,6 +43,33 @@ pub fn compute_precompile_channel_id(
         authorized_signer,
         expiring_nonce_hash,
         TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+}
+
+/// Compute a TIP-1034 channel id with an explicit escrow/precompile address.
+#[cfg(feature = "tempo")]
+#[allow(clippy::too_many_arguments)]
+pub fn compute_precompile_channel_id_with_escrow(
+    payer: Address,
+    payee: Address,
+    operator: Address,
+    token: Address,
+    salt: B256,
+    authorized_signer: Address,
+    expiring_nonce_hash: B256,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> B256 {
+    let encoded = (
+        payer,
+        payee,
+        operator,
+        token,
+        salt,
+        authorized_signer,
+        expiring_nonce_hash,
+        escrow_contract,
         U256::from(chain_id),
     )
         .abi_encode();
@@ -53,7 +80,7 @@ pub fn compute_precompile_channel_id(
 alloy::sol! {
     /// EIP-712 voucher struct. `uint96` (legacy escrow uses `uint128`).
     #[derive(Debug)]
-    struct PrecompileVoucher {
+    struct Voucher {
         bytes32 channelId;
         uint96 cumulativeAmount;
     }
@@ -62,6 +89,51 @@ alloy::sol! {
 /// Maximum cumulative amount the precompile accepts (2^96 − 1).
 #[cfg(feature = "tempo")]
 pub const PRECOMPILE_MAX_CUMULATIVE_AMOUNT: u128 = (1u128 << 96) - 1;
+
+/// Compute the TIP-1034 EIP-712 voucher signing hash.
+#[cfg(feature = "tempo")]
+pub fn precompile_voucher_signing_hash(
+    channel_id: B256,
+    cumulative_amount: u128,
+    chain_id: u64,
+) -> Result<B256> {
+    precompile_voucher_signing_hash_with_escrow(
+        channel_id,
+        cumulative_amount,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+}
+
+/// Compute the TIP-1034 EIP-712 voucher signing hash with an explicit
+/// escrow/precompile verifier.
+#[cfg(feature = "tempo")]
+pub fn precompile_voucher_signing_hash_with_escrow(
+    channel_id: B256,
+    cumulative_amount: u128,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> Result<B256> {
+    if cumulative_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+        return Err(MppError::InvalidConfig(format!(
+            "cumulative_amount {cumulative_amount} exceeds precompile uint96 max"
+        )));
+    }
+
+    let domain = eip712_domain! {
+        name: PRECOMPILE_DOMAIN_NAME,
+        version: PRECOMPILE_DOMAIN_VERSION,
+        chain_id: chain_id,
+        verifying_contract: escrow_contract,
+    };
+
+    let voucher = Voucher {
+        channelId: channel_id,
+        cumulativeAmount: Uint::<96, 2>::from(cumulative_amount),
+    };
+
+    Ok(voucher.eip712_signing_hash(&domain))
+}
 
 /// Sign a TIP-1034 voucher (EIP-712). Returns 65-byte ECDSA signature.
 /// Rejects `cumulative_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT` with
@@ -73,25 +145,31 @@ pub async fn sign_precompile_voucher(
     cumulative_amount: u128,
     chain_id: u64,
 ) -> Result<Bytes> {
-    if cumulative_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
-        return Err(MppError::InvalidConfig(format!(
-            "cumulative_amount {cumulative_amount} exceeds precompile uint96 max"
-        )));
-    }
+    sign_precompile_voucher_with_escrow(
+        signer,
+        channel_id,
+        cumulative_amount,
+        TIP20_CHANNEL_RESERVE_ADDRESS,
+        chain_id,
+    )
+    .await
+}
 
-    let domain = eip712_domain! {
-        name: PRECOMPILE_DOMAIN_NAME,
-        version: PRECOMPILE_DOMAIN_VERSION,
-        chain_id: chain_id,
-        verifying_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
-    };
-
-    let voucher = PrecompileVoucher {
-        channelId: channel_id,
-        cumulativeAmount: Uint::<96, 2>::from(cumulative_amount),
-    };
-
-    let signing_hash = voucher.eip712_signing_hash(&domain);
+/// Sign a TIP-1034 voucher with an explicit escrow/precompile verifier.
+#[cfg(feature = "tempo")]
+pub async fn sign_precompile_voucher_with_escrow(
+    signer: &impl Signer,
+    channel_id: B256,
+    cumulative_amount: u128,
+    escrow_contract: Address,
+    chain_id: u64,
+) -> Result<Bytes> {
+    let signing_hash = precompile_voucher_signing_hash_with_escrow(
+        channel_id,
+        cumulative_amount,
+        escrow_contract,
+        chain_id,
+    )?;
     let signature = signer.sign_hash(&signing_hash).await.map_err(|e| {
         MppError::InvalidSignature(Some(format!("failed to sign precompile voucher: {e}")))
     })?;
@@ -202,6 +280,41 @@ mod tests {
     }
 
     #[cfg(feature = "tempo")]
+    #[test]
+    fn compute_precompile_channel_id_matches_mppx_golden() {
+        let channel_id = compute_precompile_channel_id_with_escrow(
+            "0x3d6885f89100445ca9869d1b0a49c97cfdbafeee"
+                .parse()
+                .unwrap(),
+            "0xda2390fEE8d9744b39A8A855675649e95617aCd8"
+                .parse()
+                .unwrap(),
+            Address::ZERO,
+            "0x20C0000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+            "0xfb05173ba9285aef8a91f275930f68ad3565a491edb810c07baa60b643fdd378"
+                .parse()
+                .unwrap(),
+            "0xFE9d3D9cBb5f6FBe495b03f7Ec90d4Adc22126f5"
+                .parse()
+                .unwrap(),
+            "0x4e40183cda8c676032af4f7b038178505d877ae1c36b374239fe20ac3485c3ab"
+                .parse()
+                .unwrap(),
+            TIP20_CHANNEL_RESERVE_ADDRESS,
+            42431,
+        );
+
+        assert_eq!(
+            channel_id,
+            "0xb3946b996bd166db3b61fba0f6af2918b6687bc054e2f4bae979edffc7bd0b4d"
+                .parse::<B256>()
+                .unwrap()
+        );
+    }
+
+    #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn sign_precompile_voucher_roundtrips_via_eip712() {
         use alloy::primitives::{Bytes, B256};
@@ -225,7 +338,7 @@ mod tests {
             chain_id: chain_id,
             verifying_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
         };
-        let voucher = PrecompileVoucher {
+        let voucher = Voucher {
             channelId: channel_id,
             cumulativeAmount: alloy::primitives::Uint::<96, 2>::from(cumulative),
         };
@@ -233,6 +346,36 @@ mod tests {
         let parsed = alloy::signers::Signature::try_from(sig.as_ref()).unwrap();
         let recovered = parsed.recover_address_from_prehash(&hash).unwrap();
         assert_eq!(recovered, signer.address());
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn precompile_voucher_signing_hash_matches_tip1034_golden() {
+        let channel_id: B256 = "0x57e629663a75a0a49f8dc65c9f62ee38ab5dfa9124d7316d160766e4ecbc1227"
+            .parse()
+            .unwrap();
+        let hash = precompile_voucher_signing_hash(channel_id, 50, 42431).unwrap();
+        let expected: B256 = "0x41a23f1573d302acae1dcec60d237f78d2514768faf670ef27458931c38b5db3"
+            .parse()
+            .unwrap();
+        assert_eq!(hash, expected);
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn precompile_voucher_signing_hash_binds_explicit_escrow() {
+        let channel_id = B256::repeat_byte(0x42);
+        let canonical =
+            precompile_voucher_signing_hash(channel_id, 50, 42431).expect("canonical hash");
+        let custom = precompile_voucher_signing_hash_with_escrow(
+            channel_id,
+            50,
+            Address::repeat_byte(0x11),
+            42431,
+        )
+        .expect("custom hash");
+
+        assert_ne!(canonical, custom);
     }
 
     #[cfg(feature = "tempo")]

--- a/src/protocol/methods/tempo/session.rs
+++ b/src/protocol/methods/tempo/session.rs
@@ -6,6 +6,44 @@ use crate::error::{MppError, Result};
 use crate::protocol::intents::SessionRequest;
 use serde::{Deserialize, Serialize};
 
+/// Legacy contract-backed Tempo session protocol marker.
+pub const SESSION_PROTOCOL_LEGACY: &str = "v1";
+
+/// TIP-1034 precompile-backed Tempo session protocol marker.
+pub const SESSION_PROTOCOL_TIP1034: &str = "v2";
+
+/// Full TIP-1034 channel descriptor used to derive and verify a channel ID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelDescriptor {
+    pub payer: String,
+    pub payee: String,
+    pub operator: String,
+    pub token: String,
+    pub salt: String,
+    pub authorized_signer: String,
+    pub expiring_nonce_hash: String,
+}
+
+/// Server-provided reusable TIP-1034 channel state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSnapshot {
+    pub accepted_cumulative: String,
+    pub chain_id: u64,
+    pub channel_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub close_requested_at: Option<String>,
+    pub deposit: String,
+    pub descriptor: ChannelDescriptor,
+    pub escrow: String,
+    pub required_cumulative: String,
+    pub settled: String,
+    pub spent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub units: Option<u64>,
+}
+
 /// Custom deserializer that only accepts the literal string "transaction".
 fn deserialize_transaction_literal<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
 where
@@ -36,6 +74,9 @@ where
 ///     min_voucher_delta: Some("1000".to_string()),
 ///     chain_id: Some(42431),
 ///     fee_payer: Some(true),
+///     operator: None,
+///     session_protocol: None,
+///     session_snapshot: None,
 /// };
 /// assert_eq!(details.escrow_contract, "0x1234567890abcdef1234567890abcdef12345678");
 /// ```
@@ -55,6 +96,15 @@ pub struct TempoSessionMethodDetails {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_payer: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_protocol: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_snapshot: Option<SessionSnapshot>,
 }
 
 /// Session credential payload, discriminated on the `action` field.
@@ -84,6 +134,8 @@ pub enum SessionCredentialPayload {
         #[serde(rename = "channelId")]
         channel_id: String,
         transaction: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        descriptor: Option<ChannelDescriptor>,
         #[serde(rename = "authorizedSigner", skip_serializing_if = "Option::is_none")]
         authorized_signer: Option<String>,
         #[serde(rename = "cumulativeAmount")]
@@ -97,6 +149,8 @@ pub enum SessionCredentialPayload {
         #[serde(rename = "channelId")]
         channel_id: String,
         transaction: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        descriptor: Option<ChannelDescriptor>,
         #[serde(rename = "additionalDeposit")]
         additional_deposit: String,
     },
@@ -104,6 +158,8 @@ pub enum SessionCredentialPayload {
     Voucher {
         #[serde(rename = "channelId")]
         channel_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        descriptor: Option<ChannelDescriptor>,
         #[serde(rename = "cumulativeAmount")]
         cumulative_amount: String,
         signature: String,
@@ -112,6 +168,8 @@ pub enum SessionCredentialPayload {
     Close {
         #[serde(rename = "channelId")]
         channel_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        descriptor: Option<ChannelDescriptor>,
         #[serde(rename = "cumulativeAmount")]
         cumulative_amount: String,
         signature: String,
@@ -156,6 +214,18 @@ pub trait TempoSessionExt {
 
     /// Check if fee sponsorship is enabled.
     fn fee_payer(&self) -> bool;
+
+    /// Get the TIP-1034 operator address from methodDetails, if present.
+    fn operator(&self) -> Option<String>;
+
+    /// Get the session protocol version marker from methodDetails, if present.
+    fn session_protocol(&self) -> Option<String>;
+
+    /// Whether methodDetails explicitly requests the TIP-1034 session protocol.
+    fn is_tip1034_session(&self) -> bool;
+
+    /// Get the reusable TIP-1034 session snapshot from methodDetails, if present.
+    fn session_snapshot(&self) -> Option<SessionSnapshot>;
 
     /// Parse the method_details as Tempo session-specific details.
     fn tempo_session_details(&self) -> Result<TempoSessionMethodDetails>;
@@ -209,6 +279,33 @@ impl TempoSessionExt for SessionRequest {
             .unwrap_or(false)
     }
 
+    fn operator(&self) -> Option<String> {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("operator"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    }
+
+    fn session_protocol(&self) -> Option<String> {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("sessionProtocol"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    }
+
+    fn is_tip1034_session(&self) -> bool {
+        self.session_protocol().as_deref() == Some(SESSION_PROTOCOL_TIP1034)
+    }
+
+    fn session_snapshot(&self) -> Option<SessionSnapshot> {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("sessionSnapshot"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
     fn tempo_session_details(&self) -> Result<TempoSessionMethodDetails> {
         match &self.method_details {
             Some(value) => serde_json::from_value(value.clone()).map_err(|e| {
@@ -245,7 +342,9 @@ mod tests {
                 "channelId": "0xchannel123",
                 "minVoucherDelta": "500",
                 "chainId": 42431,
-                "feePayer": true
+                "feePayer": true,
+                "operator": "0x1111111111111111111111111111111111111111",
+                "sessionProtocol": SESSION_PROTOCOL_TIP1034
             })),
             ..Default::default()
         }
@@ -261,6 +360,9 @@ mod tests {
             min_voucher_delta: Some("1000".to_string()),
             chain_id: Some(42431),
             fee_payer: Some(true),
+            operator: Some("0x1111111111111111111111111111111111111111".to_string()),
+            session_protocol: Some(SESSION_PROTOCOL_TIP1034.to_string()),
+            session_snapshot: None,
         };
 
         let json = serde_json::to_string(&details).unwrap();
@@ -276,6 +378,14 @@ mod tests {
         assert_eq!(parsed.min_voucher_delta.as_deref(), Some("1000"));
         assert_eq!(parsed.chain_id, Some(42431));
         assert_eq!(parsed.fee_payer, Some(true));
+        assert_eq!(
+            parsed.operator.as_deref(),
+            Some("0x1111111111111111111111111111111111111111")
+        );
+        assert_eq!(
+            parsed.session_protocol.as_deref(),
+            Some(SESSION_PROTOCOL_TIP1034)
+        );
     }
 
     #[test]
@@ -286,6 +396,9 @@ mod tests {
             min_voucher_delta: None,
             chain_id: None,
             fee_payer: None,
+            operator: None,
+            session_protocol: None,
+            session_snapshot: None,
         };
 
         let json = serde_json::to_string(&details).unwrap();
@@ -294,6 +407,9 @@ mod tests {
         assert!(!json.contains("minVoucherDelta"));
         assert!(!json.contains("chainId"));
         assert!(!json.contains("feePayer"));
+        assert!(!json.contains("operator"));
+        assert!(!json.contains("sessionProtocol"));
+        assert!(!json.contains("sessionSnapshot"));
     }
 
     // ==================== SessionCredentialPayload Tests ====================
@@ -304,6 +420,7 @@ mod tests {
             payload_type: "transaction".to_string(),
             channel_id: "0xchannel123".to_string(),
             transaction: "0xtx456".to_string(),
+            descriptor: None,
             authorized_signer: Some("0xsigner789".to_string()),
             cumulative_amount: "10000".to_string(),
             signature: "0xsig".to_string(),
@@ -340,6 +457,7 @@ mod tests {
             payload_type: "transaction".to_string(),
             channel_id: "0xchannel123".to_string(),
             transaction: "0xtx456".to_string(),
+            descriptor: None,
             authorized_signer: None,
             cumulative_amount: "10000".to_string(),
             signature: "0xsig".to_string(),
@@ -365,6 +483,7 @@ mod tests {
             payload_type: "transaction".to_string(),
             channel_id: "0xchannel123".to_string(),
             transaction: "0xtx789".to_string(),
+            descriptor: None,
             additional_deposit: "5000".to_string(),
         };
 
@@ -395,6 +514,7 @@ mod tests {
     fn test_voucher_payload_serialization() {
         let payload = SessionCredentialPayload::Voucher {
             channel_id: "0xchannel123".to_string(),
+            descriptor: None,
             cumulative_amount: "15000".to_string(),
             signature: "0xvouchersig".to_string(),
         };
@@ -411,10 +531,12 @@ mod tests {
         match parsed {
             SessionCredentialPayload::Voucher {
                 channel_id,
+                descriptor,
                 cumulative_amount,
                 signature,
             } => {
                 assert_eq!(channel_id, "0xchannel123");
+                assert!(descriptor.is_none());
                 assert_eq!(cumulative_amount, "15000");
                 assert_eq!(signature, "0xvouchersig");
             }
@@ -426,6 +548,7 @@ mod tests {
     fn test_close_payload_serialization() {
         let payload = SessionCredentialPayload::Close {
             channel_id: "0xchannel123".to_string(),
+            descriptor: None,
             cumulative_amount: "20000".to_string(),
             signature: "0xclosesig".to_string(),
         };
@@ -440,10 +563,12 @@ mod tests {
         match parsed {
             SessionCredentialPayload::Close {
                 channel_id,
+                descriptor,
                 cumulative_amount,
                 signature,
             } => {
                 assert_eq!(channel_id, "0xchannel123");
+                assert!(descriptor.is_none());
                 assert_eq!(cumulative_amount, "20000");
                 assert_eq!(signature, "0xclosesig");
             }

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -313,6 +313,9 @@ where
                 channel_id: None,
                 min_voucher_delta: None,
                 fee_payer: None,
+                operator: None,
+                session_protocol: None,
+                session_snapshot: None,
             }),
         }
     }
@@ -748,6 +751,7 @@ where
                 channel_id,
                 cumulative_amount,
                 signature,
+                ..
             } => (channel_id, cumulative_amount, signature),
             _ => unreachable!(),
         };
@@ -865,6 +869,7 @@ where
                 channel_id,
                 cumulative_amount,
                 signature,
+                ..
             } => (channel_id, cumulative_amount, signature),
             _ => unreachable!(),
         };
@@ -1231,6 +1236,9 @@ where
             min_voucher_delta: Some(self.config.min_voucher_delta.to_string()),
             channel_id: None,
             fee_payer: None,
+            operator: None,
+            session_protocol: None,
+            session_snapshot: None,
         };
         serde_json::to_value(details).ok()
     }
@@ -2800,6 +2808,7 @@ mod tests {
             "0x3333333333333333333333333333333333333333",
             SessionCredentialPayload::Voucher {
                 channel_id,
+                descriptor: None,
                 cumulative_amount: "1000".to_string(),
                 signature: format!("0x{}", "aa".repeat(65)),
             },
@@ -2837,6 +2846,7 @@ mod tests {
             "0x3333333333333333333333333333333333333333", // matches stored token
             SessionCredentialPayload::Voucher {
                 channel_id,
+                descriptor: None,
                 cumulative_amount: "1000".to_string(),
                 signature: format!("0x{}", "aa".repeat(65)),
             },
@@ -2875,6 +2885,7 @@ mod tests {
             "0x9999999999999999999999999999999999999999",       // wrong token
             SessionCredentialPayload::Voucher {
                 channel_id,
+                descriptor: None,
                 cumulative_amount: "1000".to_string(),
                 signature: format!("0x{}", "aa".repeat(65)),
             },
@@ -2911,6 +2922,7 @@ mod tests {
             "0x3333333333333333333333333333333333333333",
             SessionCredentialPayload::Close {
                 channel_id,
+                descriptor: None,
                 cumulative_amount: "1000".to_string(),
                 signature: format!("0x{}", "aa".repeat(65)),
             },
@@ -2948,6 +2960,7 @@ mod tests {
             SessionCredentialPayload::TopUp {
                 payload_type: "transaction".to_string(),
                 channel_id,
+                descriptor: None,
                 additional_deposit: "5000".to_string(),
                 transaction: format!("0x{}", "bb".repeat(32)),
             },


### PR DESCRIPTION
## Summary

- add TIP-1034 session protocol wire types and method detail fields
- add descriptor-backed precompile ABI, channel ID, and voucher signing helpers
- add fee-payer signing support for descriptor-backed session opens