### PR TITLE
feat: add server body digest and route scope conformance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,24 @@ utils = ["hex", "rand"]
 middleware = ["client", "reqwest-middleware", "async-trait", "anyhow", "http-types"]
 
 # Tower middleware support (server-side)
-tower = ["dep:tower-layer", "dep:tower-service", "http-types", "dep:http-body", "server"]
+tower = [
+  "dep:tower-layer",
+  "dep:tower-service",
+  "http-types",
+  "dep:http-body",
+  "dep:http-body-util",
+  "dep:bytes",
+  "server",
+]
 
 # Axum middleware support (server-side convenience)
-axum = ["dep:axum-core", "server", "http-types"]
+axum = [
+  "dep:axum-core",
+  "server",
+  "http-types",
+  "dep:http-body-util",
+  "dep:bytes",
+]
 
 # WebSocket support
 ws = ["server", "client", "dep:tokio-tungstenite", "dep:futures-util"]
@@ -95,11 +109,13 @@ reqwest-middleware = { version = "0.5", optional = true }
 async-trait = { version = "0.1", optional = true }
 anyhow = { version = "1", optional = true }
 http-types = { package = "http", version = "1", optional = true }
+bytes = { version = "1", optional = true }
 
 # Tower middleware dependencies (optional)
 tower-layer = { version = "0.3", optional = true }
 tower-service = { version = "0.3", optional = true }
 http-body = { version = "1", optional = true }
+http-body-util = { version = "0.1", optional = true }
 
 # Axum dependencies (optional)
 axum-core = { version = "0.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tower = [
 # Axum middleware support (server-side convenience)
 axum = [
   "dep:axum-core",
+  "dep:axum",
   "server",
   "http-types",
   "dep:http-body-util",
@@ -119,6 +120,7 @@ http-body-util = { version = "0.1", optional = true }
 
 # Axum dependencies (optional)
 axum-core = { version = "0.5", optional = true }
+axum = { version = "0.8", default-features = false, features = ["matched-path"], optional = true }
 
 # WebSocket dependencies (optional)
 tokio-tungstenite = { version = "0.29", optional = true }
@@ -131,3 +133,4 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "rus
 hex = "0.4"
 tokio-tungstenite = "0.29"
 futures-util = "0.3"
+tower = { version = "0.5", features = ["util"] }

--- a/src/protocol/intents/charge.rs
+++ b/src/protocol/intents/charge.rs
@@ -28,6 +28,7 @@ use crate::evm::U256;
 ///     description: Some("API access".to_string()),
 ///     external_id: None,
 ///     method_details: None,
+///     mppx_scope: None,
 /// };
 ///
 /// assert_eq!(req.amount, "1000000");
@@ -63,6 +64,10 @@ pub struct ChargeRequest {
     /// Method-specific extension fields (interpreted by methods layer)
     #[serde(rename = "methodDetails", skip_serializing_if = "Option::is_none")]
     pub method_details: Option<serde_json::Value>,
+
+    /// Framework adapter route/resource/query scope.
+    #[serde(rename = "_mppx_scope", skip_serializing_if = "Option::is_none")]
+    pub mppx_scope: Option<serde_json::Value>,
 }
 
 impl ChargeRequest {

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -70,6 +70,7 @@
 //! #     amount: "1000".into(), currency: "0x".into(), recipient: None,
 //! #     description: None, external_id: None,
 //! #     decimals: None,
+//! #     mppx_scope: None,
 //! #     method_details: Some(serde_json::json!({
 //! #         "feePayer": true
 //! #     })),

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -168,10 +168,12 @@ pub trait ChargeConfig {
 }
 
 /// Options passed from a [`ChargeConfig`] to [`ChargeChallenger::challenge`].
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct ChallengeOptions {
     /// Human-readable description.
     pub description: Option<&'static str>,
+    /// Framework adapter route/resource/query scope.
+    pub mppx_scope: Option<serde_json::Value>,
 }
 
 /// Axum extractor that gates a handler behind payment verification.
@@ -298,6 +300,16 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         self.verify_payment(credential_str)
     }
 
+    /// Verify a credential string against route amount and framework scope.
+    fn verify_payment_for_amount_and_scope(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        _mppx_scope: Option<serde_json::Value>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        self.verify_payment_for_amount(credential_str, amount)
+    }
+
     /// Verify a credential string against route amount and actual request body bytes.
     fn verify_payment_for_amount_with_body(
         &self,
@@ -307,6 +319,18 @@ pub trait ChargeChallenger: Send + Sync + 'static {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
         let _ = body;
         self.verify_payment_for_amount(credential_str, amount)
+    }
+
+    /// Verify a credential string against route amount, framework scope, and request body bytes.
+    fn verify_payment_for_amount_scope_and_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        mppx_scope: Option<serde_json::Value>,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let _ = mppx_scope;
+        self.verify_payment_for_amount_with_body(credential_str, amount, body)
     }
 }
 
@@ -325,6 +349,7 @@ where
             amount,
             super::ChargeOptions {
                 description: options.description,
+                mppx_scope: options.mppx_scope.as_ref(),
                 ..Default::default()
             },
         )
@@ -341,6 +366,7 @@ where
             amount,
             super::ChargeOptions {
                 description: options.description,
+                mppx_scope: options.mppx_scope.as_ref(),
                 ..Default::default()
             },
             body,
@@ -416,6 +442,60 @@ where
         })
     }
 
+    fn verify_payment_for_amount_and_scope(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        mppx_scope: Option<serde_json::Value>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.charge_with_options(
+            amount,
+            super::ChargeOptions {
+                mppx_scope: mppx_scope.as_ref(),
+                ..Default::default()
+            },
+        ) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request(
+                &mpp,
+                &credential,
+                &expected_request,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
+
     fn verify_payment_for_amount_with_body(
         &self,
         credential_str: &str,
@@ -433,6 +513,63 @@ where
         };
 
         let expected_challenge = match self.charge(amount) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        let body = body.to_vec();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request_and_body(
+                &mpp,
+                &credential,
+                &expected_request,
+                &body,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
+
+    fn verify_payment_for_amount_scope_and_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        mppx_scope: Option<serde_json::Value>,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.charge_with_options(
+            amount,
+            super::ChargeOptions {
+                mppx_scope: mppx_scope.as_ref(),
+                ..Default::default()
+            },
+        ) {
             Ok(challenge) => challenge,
             Err(e) => {
                 return Box::pin(std::future::ready(Err(format!(
@@ -481,6 +618,7 @@ where
             amount,
             super::StripeChargeOptions {
                 description: options.description,
+                mppx_scope: options.mppx_scope.as_ref(),
                 ..Default::default()
             },
         )
@@ -497,6 +635,7 @@ where
             amount,
             super::StripeChargeOptions {
                 description: options.description,
+                mppx_scope: options.mppx_scope.as_ref(),
                 ..Default::default()
             },
             body,
@@ -541,6 +680,60 @@ where
         };
 
         let expected_challenge = match self.stripe_charge(amount) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request(
+                &mpp,
+                &credential,
+                &expected_request,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
+
+    fn verify_payment_for_amount_and_scope(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        mppx_scope: Option<serde_json::Value>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.stripe_charge_with_options(
+            amount,
+            super::StripeChargeOptions {
+                mppx_scope: mppx_scope.as_ref(),
+                ..Default::default()
+            },
+        ) {
             Ok(challenge) => challenge,
             Err(e) => {
                 return Box::pin(std::future::ready(Err(format!(
@@ -621,6 +814,63 @@ where
             .map_err(|e| e.to_string())
         })
     }
+
+    fn verify_payment_for_amount_scope_and_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        mppx_scope: Option<serde_json::Value>,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.stripe_charge_with_options(
+            amount,
+            super::StripeChargeOptions {
+                mppx_scope: mppx_scope.as_ref(),
+                ..Default::default()
+            },
+        ) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        let body = body.to_vec();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request_and_body(
+                &mpp,
+                &credential,
+                &expected_request,
+                &body,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
 }
 
 impl<S, C> FromRequestParts<S> for MppCharge<C>
@@ -636,6 +886,7 @@ where
         state: &S,
     ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
         let challenger: Arc<dyn ChargeChallenger> = FromRef::from_ref(state);
+        let mppx_scope = mppx_scope_from_parts(parts);
         let auth_header = parts
             .headers
             .get(header::AUTHORIZATION)
@@ -646,6 +897,7 @@ where
         async move {
             let options = ChallengeOptions {
                 description: C::description(),
+                mppx_scope: mppx_scope.clone(),
             };
 
             let credential_str = match auth_header {
@@ -659,7 +911,7 @@ where
             };
 
             let receipt = match challenger
-                .verify_payment_for_amount(&credential_str, C::amount())
+                .verify_payment_for_amount_and_scope(&credential_str, C::amount(), mppx_scope)
                 .await
             {
                 Ok(r) => r,
@@ -695,6 +947,7 @@ where
     ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
         let challenger: Arc<dyn ChargeChallenger> = FromRef::from_ref(state);
         let (parts, body) = req.into_parts();
+        let mppx_scope = mppx_scope_from_parts(&parts);
         let auth_header = parts
             .headers
             .get(header::AUTHORIZATION)
@@ -712,6 +965,7 @@ where
                 .to_bytes();
             let options = ChallengeOptions {
                 description: C::description(),
+                mppx_scope: mppx_scope.clone(),
             };
 
             let credential_str = match auth_header {
@@ -725,7 +979,12 @@ where
             };
 
             let receipt = match challenger
-                .verify_payment_for_amount_with_body(&credential_str, C::amount(), &body)
+                .verify_payment_for_amount_scope_and_body(
+                    &credential_str,
+                    C::amount(),
+                    mppx_scope,
+                    &body,
+                )
                 .await
             {
                 Ok(r) => r,
@@ -745,6 +1004,28 @@ where
                 _config: std::marker::PhantomData,
             })
         }
+    }
+}
+
+fn mppx_scope_from_parts(parts: &http_types::request::Parts) -> Option<serde_json::Value> {
+    let mut scope = serde_json::Map::new();
+    let path = parts.uri.path();
+    if !path.is_empty() {
+        scope.insert("route".into(), serde_json::Value::String(path.to_string()));
+        scope.insert(
+            "resource".into(),
+            serde_json::Value::String(path.to_string()),
+        );
+    }
+    if let Some(query) = parts.uri.query() {
+        if !query.is_empty() {
+            scope.insert("query".into(), serde_json::Value::String(query.to_string()));
+        }
+    }
+    if scope.is_empty() {
+        None
+    } else {
+        Some(serde_json::Value::Object(scope))
     }
 }
 
@@ -1037,8 +1318,16 @@ mod tests {
         challenger: impl ChargeChallenger,
         auth_header: Option<&str>,
     ) -> Result<MppCharge<C>, MppChargeRejection> {
+        run_extractor_with_uri::<C>(challenger, auth_header, "/test").await
+    }
+
+    async fn run_extractor_with_uri<C: ChargeConfig>(
+        challenger: impl ChargeChallenger,
+        auth_header: Option<&str>,
+        uri: &str,
+    ) -> Result<MppCharge<C>, MppChargeRejection> {
         let state: Arc<dyn ChargeChallenger> = Arc::new(challenger);
-        let mut builder = http_types::Request::builder().uri("/test");
+        let mut builder = http_types::Request::builder().uri(uri);
         if let Some(auth) = auth_header {
             builder = builder.header(header::AUTHORIZATION, auth);
         }
@@ -1348,6 +1637,7 @@ mod tests {
                         amount,
                         crate::server::ChargeOptions {
                             description: options.description,
+                            mppx_scope: options.mppx_scope.as_ref(),
                             ..Default::default()
                         },
                     )
@@ -1392,12 +1682,65 @@ mod tests {
                         .map_err(|e| e.to_string())
                 })
             }
+
+            fn verify_payment_for_amount_and_scope(
+                &self,
+                credential_str: &str,
+                amount: &str,
+                mppx_scope: Option<serde_json::Value>,
+            ) -> std::pin::Pin<Box<dyn Future<Output = Result<Receipt, String>> + Send>>
+            {
+                let credential = match parse_authorization(credential_str) {
+                    Ok(c) => c,
+                    Err(e) => return Box::pin(std::future::ready(Err(e.to_string()))),
+                };
+                let expected = match self
+                    .mpp
+                    .charge_with_options(
+                        amount,
+                        crate::server::ChargeOptions {
+                            mppx_scope: mppx_scope.as_ref(),
+                            ..Default::default()
+                        },
+                    )
+                    .and_then(|c| c.request.decode())
+                {
+                    Ok(req) => req,
+                    Err(e) => return Box::pin(std::future::ready(Err(e.to_string()))),
+                };
+                let mpp = self.mpp.clone();
+                Box::pin(async move {
+                    mpp.verify_credential_with_expected_request(&credential, &expected)
+                        .await
+                        .map_err(|e| e.to_string())
+                })
+            }
         }
 
         // Mint an `Authorization: Payment …` string for the given route amount.
+        fn scope_for_uri(uri: &str) -> serde_json::Value {
+            let req = http_types::Request::builder().uri(uri).body(()).unwrap();
+            let (parts, _body) = req.into_parts();
+            mppx_scope_from_parts(&parts).unwrap()
+        }
+
         fn mint_credential(challenger: &RealBindingChallenger, amount: &str) -> String {
+            mint_scoped_credential(challenger, amount, "/test")
+        }
+
+        fn mint_scoped_credential(
+            challenger: &RealBindingChallenger,
+            amount: &str,
+            uri: &str,
+        ) -> String {
             let challenge = challenger
-                .challenge(amount, ChallengeOptions::default())
+                .challenge(
+                    amount,
+                    ChallengeOptions {
+                        mppx_scope: Some(scope_for_uri(uri)),
+                        ..Default::default()
+                    },
+                )
                 .unwrap();
             let credential =
                 PaymentCredential::new(challenge.to_echo(), PaymentPayload::hash("0xdeadbeef"));
@@ -1442,6 +1785,20 @@ mod tests {
                 .await
                 .expect_err("premium credential must not satisfy the cheap route");
             assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+        }
+
+        #[tokio::test]
+        async fn test_extractor_rejects_cross_resource_credential_replay() {
+            let challenger = RealBindingChallenger::new();
+            let auth =
+                mint_scoped_credential(&challenger, OneCent::amount(), "/paid/one?view=full");
+
+            let err =
+                run_extractor_with_uri::<OneCent>(challenger, Some(&auth), "/paid/two?view=full")
+                    .await
+                    .expect_err("same-price cross-resource replay must be rejected");
+            assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+            assert_eq!(err.into_response().status(), StatusCode::PAYMENT_REQUIRED);
         }
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -70,8 +70,10 @@
 
 use std::sync::Arc;
 
-use axum_core::extract::{FromRef, FromRequestParts};
+use axum_core::extract::{FromRef, FromRequest, FromRequestParts, Request};
 use axum_core::response::IntoResponse;
+use bytes::Bytes;
+use http_body_util::BodyExt;
 use http_types::{header, HeaderValue, StatusCode};
 
 #[cfg(any(feature = "stripe", feature = "tempo"))]
@@ -166,7 +168,7 @@ pub trait ChargeConfig {
 }
 
 /// Options passed from a [`ChargeConfig`] to [`ChargeChallenger::challenge`].
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct ChallengeOptions {
     /// Human-readable description.
     pub description: Option<&'static str>,
@@ -213,6 +215,20 @@ pub struct MppCharge<C: ChargeConfig> {
     _config: std::marker::PhantomData<C>,
 }
 
+/// Axum extractor that gates a handler behind body-bound payment verification.
+///
+/// This extractor consumes the request body, binds issued challenges to the
+/// body digest, verifies submitted credentials against the same bytes, and
+/// exposes the preserved bytes to the handler.
+#[derive(Debug)]
+pub struct MppChargeWithBody<C: ChargeConfig> {
+    /// The verified payment receipt.
+    pub receipt: Receipt,
+    /// The request body bytes that were bound to the challenge digest.
+    pub body: Bytes,
+    _config: std::marker::PhantomData<C>,
+}
+
 /// Rejection type for [`MppCharge`] extractors.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -252,6 +268,17 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         options: ChallengeOptions,
     ) -> Result<PaymentChallenge, String>;
 
+    /// Generate a charge challenge bound to the actual request body bytes.
+    fn challenge_with_body(
+        &self,
+        amount: &str,
+        options: ChallengeOptions,
+        body: &[u8],
+    ) -> Result<PaymentChallenge, String> {
+        let _ = body;
+        self.challenge(amount, options)
+    }
+
     /// Verify a credential string and return a receipt.
     fn verify_payment(
         &self,
@@ -269,6 +296,17 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         _amount: &str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
         self.verify_payment(credential_str)
+    }
+
+    /// Verify a credential string against route amount and actual request body bytes.
+    fn verify_payment_for_amount_with_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let _ = body;
+        self.verify_payment_for_amount(credential_str, amount)
     }
 }
 
@@ -289,6 +327,23 @@ where
                 description: options.description,
                 ..Default::default()
             },
+        )
+        .map_err(|e| e.to_string())
+    }
+
+    fn challenge_with_body(
+        &self,
+        amount: &str,
+        options: ChallengeOptions,
+        body: &[u8],
+    ) -> Result<PaymentChallenge, String> {
+        self.charge_with_options_and_body(
+            amount,
+            super::ChargeOptions {
+                description: options.description,
+                ..Default::default()
+            },
+            body,
         )
         .map_err(|e| e.to_string())
     }
@@ -360,6 +415,56 @@ where
             .map_err(|e| e.to_string())
         })
     }
+
+    fn verify_payment_for_amount_with_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.charge(amount) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        let body = body.to_vec();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request_and_body(
+                &mpp,
+                &credential,
+                &expected_request,
+                &body,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
 }
 
 #[cfg(feature = "stripe")]
@@ -378,6 +483,23 @@ where
                 description: options.description,
                 ..Default::default()
             },
+        )
+        .map_err(|e| e.to_string())
+    }
+
+    fn challenge_with_body(
+        &self,
+        amount: &str,
+        options: ChallengeOptions,
+        body: &[u8],
+    ) -> Result<PaymentChallenge, String> {
+        self.stripe_charge_with_options_and_body(
+            amount,
+            super::StripeChargeOptions {
+                description: options.description,
+                ..Default::default()
+            },
+            body,
         )
         .map_err(|e| e.to_string())
     }
@@ -449,6 +571,56 @@ where
             .map_err(|e| e.to_string())
         })
     }
+
+    fn verify_payment_for_amount_with_body(
+        &self,
+        credential_str: &str,
+        amount: &str,
+        body: &[u8],
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        let credential = match parse_authorization(credential_str) {
+            Ok(c) => c,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Invalid credential: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_challenge = match self.stripe_charge(amount) {
+            Ok(challenge) => challenge,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to generate expected challenge: {}",
+                    e
+                ))))
+            }
+        };
+
+        let expected_request = match expected_challenge.request.decode() {
+            Ok(request) => request,
+            Err(e) => {
+                return Box::pin(std::future::ready(Err(format!(
+                    "Failed to decode expected request: {}",
+                    e
+                ))))
+            }
+        };
+
+        let mpp = self.clone();
+        let body = body.to_vec();
+        Box::pin(async move {
+            super::Mpp::verify_credential_with_expected_request_and_body(
+                &mpp,
+                &credential,
+                &expected_request,
+                &body,
+            )
+            .await
+            .map_err(|e| e.to_string())
+        })
+    }
 }
 
 impl<S, C> FromRequestParts<S> for MppCharge<C>
@@ -503,6 +675,73 @@ where
 
             Ok(MppCharge {
                 receipt,
+                _config: std::marker::PhantomData,
+            })
+        }
+    }
+}
+
+impl<S, C> FromRequest<S> for MppChargeWithBody<C>
+where
+    Arc<dyn ChargeChallenger>: FromRef<S>,
+    C: ChargeConfig,
+    S: Send + Sync,
+{
+    type Rejection = MppChargeRejection;
+
+    fn from_request(
+        req: Request,
+        state: &S,
+    ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
+        let challenger: Arc<dyn ChargeChallenger> = FromRef::from_ref(state);
+        let (parts, body) = req.into_parts();
+        let auth_header = parts
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(extract_payment_scheme)
+            .map(|s| s.to_string());
+
+        async move {
+            let body = body
+                .collect()
+                .await
+                .map_err(|e| {
+                    MppChargeRejection::InternalError(format!("Failed to read request body: {e}"))
+                })?
+                .to_bytes();
+            let options = ChallengeOptions {
+                description: C::description(),
+            };
+
+            let credential_str = match auth_header {
+                Some(c) => c,
+                None => {
+                    let challenge = challenger
+                        .challenge_with_body(C::amount(), options, &body)
+                        .map_err(MppChargeRejection::InternalError)?;
+                    return Err(MppChargeRejection::Challenge(PaymentRequired(challenge)));
+                }
+            };
+
+            let receipt = match challenger
+                .verify_payment_for_amount_with_body(&credential_str, C::amount(), &body)
+                .await
+            {
+                Ok(r) => r,
+                Err(_) => {
+                    let challenge = challenger
+                        .challenge_with_body(C::amount(), options, &body)
+                        .map_err(MppChargeRejection::InternalError)?;
+                    return Err(MppChargeRejection::VerificationFailed(PaymentRequired(
+                        challenge,
+                    )));
+                }
+            };
+
+            Ok(MppChargeWithBody {
+                receipt,
+                body,
                 _config: std::marker::PhantomData,
             })
         }
@@ -603,6 +842,66 @@ mod tests {
                     Err("payment rejected".into())
                 }
             })
+        }
+    }
+
+    struct BodyAwareChallenger {
+        seen_challenge_body: Arc<std::sync::Mutex<Option<Vec<u8>>>>,
+        seen_verify_body: Arc<std::sync::Mutex<Option<Vec<u8>>>>,
+    }
+
+    impl ChargeChallenger for BodyAwareChallenger {
+        fn challenge(
+            &self,
+            amount: &str,
+            _options: ChallengeOptions,
+        ) -> Result<PaymentChallenge, String> {
+            Ok(PaymentChallenge::new(
+                "mock-id",
+                "mock-realm",
+                "tempo",
+                "charge",
+                Base64UrlJson::from_value(&serde_json::json!({"amount": amount})).unwrap(),
+            ))
+        }
+
+        fn challenge_with_body(
+            &self,
+            amount: &str,
+            options: ChallengeOptions,
+            body: &[u8],
+        ) -> Result<PaymentChallenge, String> {
+            *self.seen_challenge_body.lock().unwrap() = Some(body.to_vec());
+            let mut challenge = self.challenge(amount, options)?;
+            challenge.digest = Some(crate::body_digest::compute(body));
+            Ok(challenge)
+        }
+
+        fn verify_payment(
+            &self,
+            _credential_str: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        {
+            Box::pin(std::future::ready(Err(
+                "legacy verifier should not be called".into(),
+            )))
+        }
+
+        fn verify_payment_for_amount_with_body(
+            &self,
+            _credential_str: &str,
+            _amount: &str,
+            body: &[u8],
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        {
+            *self.seen_verify_body.lock().unwrap() = Some(body.to_vec());
+            Box::pin(std::future::ready(Ok(Receipt {
+                status: crate::protocol::core::ReceiptStatus::Success,
+                method: crate::protocol::core::MethodName::new("tempo"),
+                timestamp: "2025-01-01T00:00:00Z".into(),
+                reference: "0xbody-aware".into(),
+                external_id: None,
+            })))
         }
     }
 
@@ -748,6 +1047,20 @@ mod tests {
         MppCharge::<C>::from_request_parts(&mut parts, &state).await
     }
 
+    async fn run_body_extractor<C: ChargeConfig>(
+        challenger: impl ChargeChallenger,
+        auth_header: Option<&str>,
+        body: &'static str,
+    ) -> Result<MppChargeWithBody<C>, MppChargeRejection> {
+        let state: Arc<dyn ChargeChallenger> = Arc::new(challenger);
+        let mut builder = Request::builder().uri("/test");
+        if let Some(auth) = auth_header {
+            builder = builder.header(header::AUTHORIZATION, auth);
+        }
+        let req = builder.body(axum_core::body::Body::from(body)).unwrap();
+        MppChargeWithBody::<C>::from_request(req, &state).await
+    }
+
     #[tokio::test]
     async fn test_extractor_no_auth_returns_challenge() {
         let result = run_extractor::<OneCent>(MockChallenger { accept: true }, None).await;
@@ -849,6 +1162,58 @@ mod tests {
         assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+    }
+
+    #[tokio::test]
+    async fn test_body_extractor_challenge_binds_request_body() {
+        let seen_challenge_body = Arc::new(std::sync::Mutex::new(None));
+        let seen_verify_body = Arc::new(std::sync::Mutex::new(None));
+        let result = run_body_extractor::<OneCent>(
+            BodyAwareChallenger {
+                seen_challenge_body: seen_challenge_body.clone(),
+                seen_verify_body,
+            },
+            None,
+            r#"{"query":"paid"}"#,
+        )
+        .await;
+
+        let err = result.unwrap_err();
+        let challenge = match err {
+            MppChargeRejection::Challenge(PaymentRequired(challenge)) => challenge,
+            other => panic!("expected challenge rejection, got {other:?}"),
+        };
+        assert_eq!(
+            challenge.digest.as_deref(),
+            Some(crate::body_digest::compute(br#"{"query":"paid"}"#).as_str())
+        );
+        assert_eq!(
+            seen_challenge_body.lock().unwrap().as_deref(),
+            Some(br#"{"query":"paid"}"#.as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_body_extractor_verifies_and_preserves_request_body() {
+        let seen_challenge_body = Arc::new(std::sync::Mutex::new(None));
+        let seen_verify_body = Arc::new(std::sync::Mutex::new(None));
+        let result = run_body_extractor::<OneCent>(
+            BodyAwareChallenger {
+                seen_challenge_body,
+                seen_verify_body: seen_verify_body.clone(),
+            },
+            Some("Payment eyJmYWtlIjp0cnVlfQ"),
+            r#"{"query":"paid"}"#,
+        )
+        .await;
+
+        let charge = result.unwrap();
+        assert_eq!(charge.receipt.reference, "0xbody-aware");
+        assert_eq!(charge.body.as_ref(), br#"{"query":"paid"}"#);
+        assert_eq!(
+            seen_verify_body.lock().unwrap().as_deref(),
+            Some(br#"{"query":"paid"}"#.as_slice())
+        );
     }
 
     #[tokio::test]

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -305,8 +305,15 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         &self,
         credential_str: &str,
         amount: &str,
-        _mppx_scope: Option<serde_json::Value>,
+        mppx_scope: Option<serde_json::Value>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+        if mppx_scope.is_some() {
+            let _ = credential_str;
+            let _ = amount;
+            return Box::pin(std::future::ready(Err(
+                "framework scope verification is not implemented for this ChargeChallenger".into(),
+            )));
+        }
         self.verify_payment_for_amount(credential_str, amount)
     }
 
@@ -329,7 +336,14 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         mppx_scope: Option<serde_json::Value>,
         body: &[u8],
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
-        let _ = mppx_scope;
+        if mppx_scope.is_some() {
+            let _ = credential_str;
+            let _ = amount;
+            let _ = body;
+            return Box::pin(std::future::ready(Err(
+                "framework scope verification is not implemented for this ChargeChallenger".into(),
+            )));
+        }
         self.verify_payment_for_amount_with_body(credential_str, amount, body)
     }
 }
@@ -1131,6 +1145,16 @@ mod tests {
                 }
             })
         }
+
+        fn verify_payment_for_amount_and_scope(
+            &self,
+            credential_str: &str,
+            amount: &str,
+            _mppx_scope: Option<serde_json::Value>,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        {
+            self.verify_payment_for_amount(credential_str, amount)
+        }
     }
 
     struct BodyAwareChallenger {
@@ -1190,6 +1214,17 @@ mod tests {
                 reference: "0xbody-aware".into(),
                 external_id: None,
             })))
+        }
+
+        fn verify_payment_for_amount_scope_and_body(
+            &self,
+            credential_str: &str,
+            amount: &str,
+            _mppx_scope: Option<serde_json::Value>,
+            body: &[u8],
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        {
+            self.verify_payment_for_amount_with_body(credential_str, amount, body)
         }
     }
 
@@ -1446,6 +1481,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extractor_fails_closed_when_challenger_does_not_verify_scope() {
+        struct LegacyChallenger;
+
+        impl ChargeChallenger for LegacyChallenger {
+            fn challenge(
+                &self,
+                amount: &str,
+                _options: ChallengeOptions,
+            ) -> Result<PaymentChallenge, String> {
+                Ok(PaymentChallenge::new(
+                    "mock-id",
+                    "mock-realm",
+                    "tempo",
+                    "charge",
+                    Base64UrlJson::from_value(&serde_json::json!({"amount": amount})).unwrap(),
+                ))
+            }
+
+            fn verify_payment(
+                &self,
+                _credential_str: &str,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+            {
+                Box::pin(std::future::ready(Ok(Receipt {
+                    status: crate::protocol::core::ReceiptStatus::Success,
+                    method: crate::protocol::core::MethodName::new("tempo"),
+                    timestamp: "2025-01-01T00:00:00Z".into(),
+                    reference: "0xlegacy".into(),
+                    external_id: None,
+                })))
+            }
+        }
+
+        let result =
+            run_extractor::<OneCent>(LegacyChallenger, Some("Payment eyJmYWtlIjp0cnVlfQ")).await;
+
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+    }
+
+    #[tokio::test]
     async fn test_extractor_invalid_payment_returns_challenge_for_retry() {
         let result = run_extractor::<OneCent>(
             MockChallenger { accept: false },
@@ -1625,6 +1701,16 @@ mod tests {
                     reference: "0xroute-aware".into(),
                     external_id: None,
                 })))
+            }
+
+            fn verify_payment_for_amount_and_scope(
+                &self,
+                credential_str: &str,
+                amount: &str,
+                _mppx_scope: Option<serde_json::Value>,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+            {
+                self.verify_payment_for_amount(credential_str, amount)
             }
         }
 

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -1010,8 +1010,15 @@ where
 fn mppx_scope_from_parts(parts: &http_types::request::Parts) -> Option<serde_json::Value> {
     let mut scope = serde_json::Map::new();
     let path = parts.uri.path();
+    let route = parts
+        .extensions
+        .get::<::axum::extract::MatchedPath>()
+        .map(|matched| matched.as_str())
+        .unwrap_or(path);
+    if !route.is_empty() {
+        scope.insert("route".into(), serde_json::Value::String(route.to_string()));
+    }
     if !path.is_empty() {
-        scope.insert("route".into(), serde_json::Value::String(path.to_string()));
         scope.insert(
             "resource".into(),
             serde_json::Value::String(path.to_string()),
@@ -1334,6 +1341,74 @@ mod tests {
         let req = builder.body(()).unwrap();
         let (mut parts, _body) = req.into_parts();
         MppCharge::<C>::from_request_parts(&mut parts, &state).await
+    }
+
+    #[tokio::test]
+    async fn test_extractor_binds_axum_matched_route_scope() {
+        use axum::routing::get;
+        use tower::ServiceExt;
+
+        #[derive(Clone)]
+        struct ScopeCaptureChallenger {
+            seen_scope: Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+        }
+
+        impl ChargeChallenger for ScopeCaptureChallenger {
+            fn challenge(
+                &self,
+                amount: &str,
+                options: ChallengeOptions,
+            ) -> Result<PaymentChallenge, String> {
+                *self.seen_scope.lock().unwrap() = options.mppx_scope;
+                Ok(PaymentChallenge::new(
+                    "mock-id",
+                    "mock-realm",
+                    "tempo",
+                    "charge",
+                    Base64UrlJson::from_value(&serde_json::json!({"amount": amount})).unwrap(),
+                ))
+            }
+
+            fn verify_payment(
+                &self,
+                _credential_str: &str,
+            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+            {
+                Box::pin(std::future::ready(Err("unused".into())))
+            }
+        }
+
+        async fn paid(_charge: MppCharge<OneCent>) -> &'static str {
+            "paid"
+        }
+
+        let seen_scope = Arc::new(std::sync::Mutex::new(None));
+        let state: Arc<dyn ChargeChallenger> = Arc::new(ScopeCaptureChallenger {
+            seen_scope: seen_scope.clone(),
+        });
+        let app = axum::Router::new()
+            .route("/paid/{id}", get(paid))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                http_types::Request::builder()
+                    .uri("/paid/one?view=full")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::PAYMENT_REQUIRED);
+        assert_eq!(
+            seen_scope.lock().unwrap().as_ref(),
+            Some(&serde_json::json!({
+                "route": "/paid/{id}",
+                "resource": "/paid/one",
+                "query": "view=full",
+            }))
+        );
     }
 
     async fn run_body_extractor<C: ChargeConfig>(

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -25,6 +25,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use bytes::Bytes;
+use http_body_util::BodyExt;
 use http_types::{header, HeaderValue, Request, Response, StatusCode};
 
 use crate::protocol::core::headers::{
@@ -40,6 +42,12 @@ pub trait PaymentVerifier: Send + Sync + 'static {
     /// Generate a `WWW-Authenticate: Payment ...` challenge header value.
     fn challenge(&self) -> Result<String, String>;
 
+    /// Generate a body-bound `WWW-Authenticate: Payment ...` challenge header value.
+    fn challenge_with_body(&self, body: &[u8]) -> Result<String, String> {
+        let _ = body;
+        self.challenge()
+    }
+
     /// Verify a credential string and return a `Payment-Receipt` header value.
     ///
     /// The `credential` is the raw `Authorization` header value
@@ -48,6 +56,16 @@ pub trait PaymentVerifier: Send + Sync + 'static {
         &self,
         credential: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>;
+
+    /// Verify a credential string against the actual request body bytes.
+    fn verify_with_body(
+        &self,
+        credential: &str,
+        body: &[u8],
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+        let _ = body;
+        self.verify(credential)
+    }
 }
 
 // ==================== FnVerifier ====================
@@ -56,10 +74,18 @@ pub trait PaymentVerifier: Send + Sync + 'static {
 #[allow(clippy::type_complexity)]
 pub struct FnVerifier {
     challenge_fn: Box<dyn Fn() -> Result<String, String> + Send + Sync>,
+    challenge_with_body_fn: Option<Box<dyn Fn(&[u8]) -> Result<String, String> + Send + Sync>>,
     verify_fn: Box<
         dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
             + Send
             + Sync,
+    >,
+    verify_with_body_fn: Option<
+        Box<
+            dyn Fn(String, Vec<u8>) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
+                + Send
+                + Sync,
+        >,
     >,
 }
 
@@ -68,11 +94,29 @@ impl PaymentVerifier for FnVerifier {
         (self.challenge_fn)()
     }
 
+    fn challenge_with_body(&self, body: &[u8]) -> Result<String, String> {
+        match &self.challenge_with_body_fn {
+            Some(f) => f(body),
+            None => self.challenge(),
+        }
+    }
+
     fn verify(
         &self,
         credential: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
         (self.verify_fn)(credential.to_string())
+    }
+
+    fn verify_with_body(
+        &self,
+        credential: &str,
+        body: &[u8],
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+        match &self.verify_with_body_fn {
+            Some(f) => f(credential.to_string(), body.to_vec()),
+            None => self.verify(credential),
+        }
     }
 }
 
@@ -109,7 +153,9 @@ impl PaymentLayer<FnVerifier> {
     ) -> Self {
         Self::new(FnVerifier {
             challenge_fn: Box::new(challenge_fn),
+            challenge_with_body_fn: None,
             verify_fn: Box::new(verify_fn),
+            verify_with_body_fn: None,
         })
     }
 }
@@ -220,6 +266,136 @@ where
     }
 }
 
+// ==================== PaymentBodyLayer ====================
+
+/// Tower [`Layer`](tower_layer::Layer) that binds payment verification to request body bytes.
+///
+/// The request body is buffered, used for body-digest challenge/verification,
+/// and then replayed to the inner service as `http_body_util::Full<Bytes>`.
+#[derive(Clone)]
+pub struct PaymentBodyLayer<V> {
+    verifier: Arc<V>,
+}
+
+impl<V: PaymentVerifier> PaymentBodyLayer<V> {
+    /// Create a body-aware payment layer with a custom [`PaymentVerifier`].
+    pub fn new(verifier: V) -> Self {
+        Self {
+            verifier: Arc::new(verifier),
+        }
+    }
+}
+
+impl<S, V: PaymentVerifier> tower_layer::Layer<S> for PaymentBodyLayer<V> {
+    type Service = PaymentBodyService<S, V>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PaymentBodyService {
+            inner,
+            verifier: Arc::clone(&self.verifier),
+        }
+    }
+}
+
+/// Tower [`Service`](tower_service::Service) for body-bound payment verification.
+#[derive(Clone)]
+pub struct PaymentBodyService<S, V> {
+    inner: S,
+    verifier: Arc<V>,
+}
+
+impl<S, V, ReqBody, ResBody> tower_service::Service<Request<ReqBody>> for PaymentBodyService<S, V>
+where
+    S: tower_service::Service<Request<http_body_util::Full<Bytes>>, Response = Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    S::Error: Send,
+    V: PaymentVerifier,
+    ReqBody: http_body::Body<Data = Bytes> + Send + 'static,
+    ReqBody::Error: std::fmt::Display + Send + Sync + 'static,
+    ResBody: Default + Send + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response<ResBody>, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let verifier = Arc::clone(&self.verifier);
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move {
+            let (parts, body) = req.into_parts();
+            let body = match body.collect().await {
+                Ok(collected) => collected.to_bytes(),
+                Err(e) => {
+                    return Ok(error_response(
+                        StatusCode::BAD_REQUEST,
+                        &format!("Failed to read request body: {e}"),
+                    ));
+                }
+            };
+
+            let auth_header = parts
+                .headers
+                .get(header::AUTHORIZATION)
+                .and_then(|v| v.to_str().ok())
+                .and_then(extract_payment_scheme)
+                .map(|s| s.to_string());
+
+            let credential = match auth_header {
+                Some(c) => c,
+                None => {
+                    let challenge = match verifier.challenge_with_body(&body) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            return Ok(error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                &format!("Failed to generate challenge: {e}"),
+                            ));
+                        }
+                    };
+                    let mut resp = Response::new(ResBody::default());
+                    *resp.status_mut() = StatusCode::PAYMENT_REQUIRED;
+                    resp.headers_mut().insert(
+                        WWW_AUTHENTICATE_HEADER,
+                        HeaderValue::from_str(&challenge)
+                            .unwrap_or_else(|_| HeaderValue::from_static("Payment")),
+                    );
+                    resp.headers_mut()
+                        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+                    return Ok(resp);
+                }
+            };
+
+            let receipt_header = match verifier.verify_with_body(&credential, &body).await {
+                Ok(r) => r,
+                Err(e) => {
+                    return Ok(error_response(
+                        StatusCode::PAYMENT_REQUIRED,
+                        &format!("Payment verification failed: {e}"),
+                    ));
+                }
+            };
+
+            let req = Request::from_parts(parts, http_body_util::Full::new(body));
+            let mut resp = inner.call(req).await?;
+
+            if let Ok(val) = HeaderValue::from_str(&receipt_header) {
+                resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
+            }
+
+            Ok(resp)
+        })
+    }
+}
+
 /// Build a minimal error response.
 fn error_response<B: Default>(status: StatusCode, _message: &str) -> Response<B> {
     let mut resp = Response::new(B::default());
@@ -236,9 +412,17 @@ fn error_response<B: Default>(status: StatusCode, _message: &str) -> Response<B>
 struct ChargeVerifier {
     /// Builds a fresh `WWW-Authenticate` header value per request.
     challenge_fn: Box<dyn Fn() -> Result<String, String> + Send + Sync>,
+    /// Builds a fresh body-bound `WWW-Authenticate` header value per request.
+    challenge_with_body_fn: Box<dyn Fn(&[u8]) -> Result<String, String> + Send + Sync>,
     /// Shared mpp instance for verification (type-erased).
     verify_fn: Box<
         dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
+            + Send
+            + Sync,
+    >,
+    /// Shared mpp instance for body-bound verification (type-erased).
+    verify_with_body_fn: Box<
+        dyn Fn(String, Vec<u8>) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
             + Send
             + Sync,
     >,
@@ -249,11 +433,23 @@ impl PaymentVerifier for ChargeVerifier {
         (self.challenge_fn)()
     }
 
+    fn challenge_with_body(&self, body: &[u8]) -> Result<String, String> {
+        (self.challenge_with_body_fn)(body)
+    }
+
     fn verify(
         &self,
         credential: &str,
     ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
         (self.verify_fn)(credential.to_string())
+    }
+
+    fn verify_with_body(
+        &self,
+        credential: &str,
+        body: &[u8],
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+        (self.verify_with_body_fn)(credential.to_string(), body.to_vec())
     }
 }
 
@@ -296,7 +492,18 @@ impl PaymentLayer<ChargeVerifier> {
                 .map_err(|e| format!("Failed to format challenge: {e}"))
         });
 
+        let mpp_for_body_challenge = mpp.clone();
+        let charge_amount_for_body = amount.to_string();
+        let challenge_with_body_fn = Box::new(move |body: &[u8]| {
+            let challenge = mpp_for_body_challenge
+                .charge_with_body(&charge_amount_for_body, body)
+                .map_err(|e| format!("Failed to generate challenge: {e}"))?;
+            format_www_authenticate(&challenge)
+                .map_err(|e| format!("Failed to format challenge: {e}"))
+        });
+
         let mpp_for_verify = mpp.clone();
+        let expected_request_for_body = expected_request.clone();
         let verify_fn = Box::new(move |credential_str: String| -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
             let mpp = mpp_for_verify.clone();
             let expected_request = expected_request.clone();
@@ -313,16 +520,63 @@ impl PaymentLayer<ChargeVerifier> {
             })
         });
 
+        let mpp_for_body_verify = mpp.clone();
+        let verify_with_body_fn = Box::new(
+            move |credential_str: String,
+                  body: Vec<u8>|
+                  -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+                let mpp = mpp_for_body_verify.clone();
+                let expected_request = expected_request_for_body.clone();
+                Box::pin(async move {
+                    let credential = parse_authorization(&credential_str)
+                        .map_err(|e| format!("Invalid credential: {e}"))?;
+
+                    let receipt = mpp
+                        .verify_credential_with_expected_request_and_body(
+                            &credential,
+                            &expected_request,
+                            &body,
+                        )
+                        .await
+                        .map_err(|e| e.to_string())?;
+
+                    format_receipt(&receipt).map_err(|e| format!("Failed to format receipt: {e}"))
+                })
+            },
+        );
+
         Ok(Self::new(ChargeVerifier {
             challenge_fn,
+            challenge_with_body_fn,
             verify_fn,
+            verify_with_body_fn,
         }))
+    }
+}
+
+impl PaymentBodyLayer<ChargeVerifier> {
+    /// Create a body-aware payment layer that charges a dollar amount per request.
+    ///
+    /// This buffers the request body, binds issued challenges to its digest,
+    /// verifies credentials against the same bytes, and replays the body to
+    /// the inner service.
+    #[cfg(feature = "tempo")]
+    pub fn charge<M, S>(mpp: &super::Mpp<M, S>, amount: &str) -> crate::error::Result<Self>
+    where
+        M: crate::protocol::traits::ChargeMethod + Clone + Send + Sync + 'static,
+        S: Clone + Send + Sync + 'static,
+    {
+        let layer = PaymentLayer::charge(mpp, amount)?;
+        Ok(Self {
+            verifier: layer.verifier,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tower_layer::Layer;
 
     #[derive(Clone)]
     struct MockVerifier {
@@ -385,7 +639,9 @@ mod tests {
     fn test_fn_verifier_challenge() {
         let v = FnVerifier {
             challenge_fn: Box::new(|| Ok("Payment test".to_string())),
+            challenge_with_body_fn: None,
             verify_fn: Box::new(|_| Box::pin(async { Ok("receipt".to_string()) })),
+            verify_with_body_fn: None,
         };
         assert_eq!(v.challenge().unwrap(), "Payment test");
     }
@@ -523,6 +779,121 @@ mod tests {
 
         let resp = svc.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+    }
+
+    #[derive(Clone)]
+    struct BodyAwareVerifier {
+        challenge_body: Arc<std::sync::Mutex<Option<Vec<u8>>>>,
+        verify_body: Arc<std::sync::Mutex<Option<Vec<u8>>>>,
+    }
+
+    impl PaymentVerifier for BodyAwareVerifier {
+        fn challenge(&self) -> Result<String, String> {
+            Ok("Payment id=\"legacy\"".to_string())
+        }
+
+        fn challenge_with_body(&self, body: &[u8]) -> Result<String, String> {
+            *self.challenge_body.lock().unwrap() = Some(body.to_vec());
+            Ok("Payment id=\"body-bound\"".to_string())
+        }
+
+        fn verify(
+            &self,
+            _credential: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+            Box::pin(async { Err("legacy verifier should not be called".to_string()) })
+        }
+
+        fn verify_with_body(
+            &self,
+            _credential: &str,
+            body: &[u8],
+        ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
+            *self.verify_body.lock().unwrap() = Some(body.to_vec());
+            Box::pin(async { Ok("mock-receipt-token".to_string()) })
+        }
+    }
+
+    #[derive(Clone)]
+    struct BodyEchoService;
+
+    impl tower_service::Service<Request<http_body_util::Full<Bytes>>> for BodyEchoService {
+        type Response = Response<Vec<u8>>;
+        type Error = std::convert::Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Response<Vec<u8>>, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, req: Request<http_body_util::Full<Bytes>>) -> Self::Future {
+            Box::pin(async move {
+                let body = req.into_body().collect().await.unwrap().to_bytes();
+                Ok(Response::new(body.to_vec()))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_body_service_no_auth_binds_challenge_to_body() {
+        use tower_service::Service;
+
+        let challenge_body = Arc::new(std::sync::Mutex::new(None));
+        let layer = PaymentBodyLayer::new(BodyAwareVerifier {
+            challenge_body: challenge_body.clone(),
+            verify_body: Arc::new(std::sync::Mutex::new(None)),
+        });
+        let mut svc = layer.layer(BodyEchoService);
+
+        let req = Request::builder()
+            .uri("/premium")
+            .body(http_body_util::Full::new(Bytes::from_static(
+                br#"{"query":"paid"}"#,
+            )))
+            .unwrap();
+
+        let resp = svc.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert_eq!(
+            resp.headers().get(WWW_AUTHENTICATE_HEADER).unwrap(),
+            "Payment id=\"body-bound\""
+        );
+        assert_eq!(
+            challenge_body.lock().unwrap().as_deref(),
+            Some(br#"{"query":"paid"}"#.as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_body_service_valid_auth_verifies_and_replays_body() {
+        use tower_service::Service;
+
+        let verify_body = Arc::new(std::sync::Mutex::new(None));
+        let layer = PaymentBodyLayer::new(BodyAwareVerifier {
+            challenge_body: Arc::new(std::sync::Mutex::new(None)),
+            verify_body: verify_body.clone(),
+        });
+        let mut svc = layer.layer(BodyEchoService);
+
+        let req = Request::builder()
+            .uri("/premium")
+            .header(header::AUTHORIZATION, "Payment eyJmYWtlIjp0cnVlfQ")
+            .body(http_body_util::Full::new(Bytes::from_static(
+                br#"{"query":"paid"}"#,
+            )))
+            .unwrap();
+
+        let resp = svc.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.body(), br#"{"query":"paid"}"#);
+        assert_eq!(
+            resp.headers().get(PAYMENT_RECEIPT_HEADER).unwrap(),
+            "mock-receipt-token"
+        );
+        assert_eq!(
+            verify_body.lock().unwrap().as_deref(),
+            Some(br#"{"query":"paid"}"#.as_slice())
+        );
     }
 
     // ==================== Real ChargeVerifier tests ====================

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -102,4 +102,6 @@ pub struct ChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Enable fee sponsorship.
     pub fee_payer: bool,
+    /// Actual request body bytes to bind into the challenge digest.
+    pub request_body: Option<&'a [u8]>,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -102,4 +102,6 @@ pub struct ChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Enable fee sponsorship.
     pub fee_payer: bool,
+    /// Framework adapter route/resource/query scope.
+    pub mppx_scope: Option<&'a serde_json::Value>,
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -102,6 +102,4 @@ pub struct ChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Enable fee sponsorship.
     pub fee_payer: bool,
-    /// Actual request body bytes to bind into the challenge digest.
-    pub request_body: Option<&'a [u8]>,
 }

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -494,6 +494,7 @@ where
             recipient: Some(recipient.to_string()),
             description: options.description.map(|s| s.to_string()),
             external_id: options.external_id.map(|s| s.to_string()),
+            mppx_scope: options.mppx_scope.cloned(),
             ..Default::default()
         };
         {
@@ -673,6 +674,13 @@ where
         if request.recipient != expected.recipient {
             return Err(VerificationError::with_code(
                 "Recipient mismatch: credential was issued for a different recipient",
+                crate::protocol::traits::ErrorCode::CredentialMismatch,
+            ));
+        }
+
+        if request.mppx_scope != expected.mppx_scope {
+            return Err(VerificationError::with_code(
+                "Framework scope mismatch: credential was issued for a different route",
                 crate::protocol::traits::ErrorCode::CredentialMismatch,
             ));
         }
@@ -1139,6 +1147,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
                     "failed to serialize methodDetails: {e}"
                 ))
             })?),
+            mppx_scope: options.mppx_scope.cloned(),
             ..Default::default()
         };
 

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -680,7 +680,7 @@ where
         #[cfg(feature = "tempo")]
         if credential.challenge.method.as_str() == crate::protocol::methods::tempo::METHOD_NAME {
             let req_transfers =
-                crate::protocol::methods::tempo::transfers::get_request_transfers(&request)
+                crate::protocol::methods::tempo::transfers::get_request_transfers(request)
                     .map_err(|e| {
                         VerificationError::with_code(
                             format!("Invalid Tempo request in credential: {e}"),

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -502,13 +502,27 @@ where
                 request.method_details = Some(serde_json::Value::Object(details));
             }
         }
-        let challenge = crate::protocol::methods::tempo::charge_challenge_with_options(
+        let mut challenge = crate::protocol::methods::tempo::charge_challenge_with_options(
             &self.secret_key,
             &self.realm,
             &request,
             options.expires,
             options.description,
         )?;
+        if let Some(body) = options.request_body {
+            let digest = crate::body_digest::compute(body);
+            challenge.id = crate::protocol::core::compute_challenge_id(
+                &self.secret_key,
+                &challenge.realm,
+                challenge.method.as_str(),
+                challenge.intent.as_str(),
+                challenge.request.raw(),
+                challenge.expires.as_deref(),
+                Some(&digest),
+                challenge.opaque.as_ref().map(|o| o.raw()),
+            );
+            challenge.digest = Some(digest);
+        }
         Ok(self.apply_pinned_opaque(challenge))
     }
 
@@ -568,6 +582,24 @@ where
         self.verify(credential, &request).await
     }
 
+    /// Verify a payment credential against the actual request body bytes.
+    ///
+    /// Use this when the echoed challenge contains a body digest. The digest is
+    /// recomputed over `body` before method-specific payment verification runs.
+    pub async fn verify_credential_with_body(
+        &self,
+        credential: &PaymentCredential,
+        body: &[u8],
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request: ChargeRequest = credential
+            .challenge
+            .request
+            .decode()
+            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
+        self.verify_with_body(credential, &request, Some(body))
+            .await
+    }
+
     /// Verify a payment credential, ensuring the charge request matches the server's expected values.
     ///
     /// This prevents cross-route credential replay attacks where a credential
@@ -584,6 +616,36 @@ where
             .decode()
             .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
 
+        self.verify_expected_request_matches(credential, &request, expected)?;
+
+        self.verify(credential, &request).await
+    }
+
+    /// Verify a payment credential against expected route values and actual body bytes.
+    pub async fn verify_credential_with_expected_request_and_body(
+        &self,
+        credential: &PaymentCredential,
+        expected: &ChargeRequest,
+        body: &[u8],
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request: ChargeRequest = credential
+            .challenge
+            .request
+            .decode()
+            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
+
+        self.verify_expected_request_matches(credential, &request, expected)?;
+
+        self.verify_with_body(credential, &request, Some(body))
+            .await
+    }
+
+    fn verify_expected_request_matches(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+        expected: &ChargeRequest,
+    ) -> std::result::Result<(), VerificationError> {
         if request.amount != expected.amount {
             return Err(VerificationError::with_code(
                 format!(
@@ -638,7 +700,7 @@ where
             }
         }
 
-        self.verify(credential, &request).await
+        Ok(())
     }
 
     /// Verify a charge credential with an explicit request.
@@ -647,8 +709,18 @@ where
         credential: &PaymentCredential,
         request: &ChargeRequest,
     ) -> std::result::Result<Receipt, VerificationError> {
+        self.verify_with_body(credential, request, None).await
+    }
+
+    async fn verify_with_body(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+        body: Option<&[u8]>,
+    ) -> std::result::Result<Receipt, VerificationError> {
         // Tier 1: HMAC provenance + expiry
         self.verify_hmac_and_expiry(credential)?;
+        self.verify_body_digest(credential, body)?;
         // Tier 2: Pinned field safety net
         self.verify_pinned_fields(credential, request)?;
         let receipt = self.method.verify(credential, request).await?;
@@ -663,6 +735,30 @@ where
             })
             .await;
         Ok(receipt)
+    }
+
+    fn verify_body_digest(
+        &self,
+        credential: &PaymentCredential,
+        body: Option<&[u8]>,
+    ) -> std::result::Result<(), VerificationError> {
+        match (credential.challenge.digest.as_deref(), body) {
+            (Some(_), None) => Err(VerificationError::with_code(
+                "body digest present but request body was not provided",
+                crate::protocol::traits::ErrorCode::CredentialMismatch,
+            )),
+            (None, Some(_)) => Err(VerificationError::with_code(
+                "missing body digest",
+                crate::protocol::traits::ErrorCode::CredentialMismatch,
+            )),
+            (Some(digest), Some(body)) if !crate::body_digest::verify(digest, body) => {
+                Err(VerificationError::with_code(
+                    "body digest mismatch",
+                    crate::protocol::traits::ErrorCode::CredentialMismatch,
+                ))
+            }
+            _ => Ok(()),
+        }
     }
 }
 
@@ -1029,6 +1125,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
                 })?
         };
 
+        let digest = options.request_body.map(crate::body_digest::compute);
         let id = crate::protocol::core::compute_challenge_id(
             &self.secret_key,
             &self.realm,
@@ -1036,7 +1133,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
             crate::protocol::methods::stripe::INTENT_CHARGE,
             encoded_request.raw(),
             Some(&expires),
-            None,
+            digest.as_deref(),
             None,
         );
 
@@ -1048,7 +1145,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
             request: encoded_request,
             expires: Some(expires),
             description: options.description.map(|s| s.to_string()),
-            digest: None,
+            digest,
             opaque: None,
         }))
     }
@@ -1230,6 +1327,37 @@ mod tests {
         }
     }
 
+    fn test_credential_with_body_digest(secret_key: &str, body: &[u8]) -> PaymentCredential {
+        let request = test_request();
+        let encoded = Base64UrlJson::from_typed(&request).unwrap();
+        let expires = (time::OffsetDateTime::now_utc() + time::Duration::minutes(5))
+            .format(&time::format_description::well_known::Rfc3339)
+            .unwrap();
+        let digest = crate::body_digest::compute(body);
+        let id = crate::protocol::core::compute_challenge_id(
+            secret_key,
+            "api.example.com",
+            "mock",
+            "charge",
+            encoded.raw(),
+            Some(&expires),
+            Some(&digest),
+            None,
+        );
+
+        let echo = ChallengeEcho {
+            id,
+            realm: "api.example.com".into(),
+            method: "mock".into(),
+            intent: "charge".into(),
+            request: encoded,
+            expires: Some(expires),
+            digest: Some(digest),
+            opaque: None,
+        };
+        PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
+    }
+
     #[test]
     fn test_mpp_creation() {
         let payment = Mpp::new(MockMethod, "api.example.com", "secret");
@@ -1387,6 +1515,67 @@ mod tests {
         assert_eq!(seen.recipient, request.recipient);
     }
 
+    #[tokio::test]
+    async fn test_verify_credential_with_body_digest_accepts_matching_body() {
+        let payment = Mpp::new(MockMethod, "api.example.com", "secret");
+        let body = br#"{"query":"paid"}"#;
+        let credential = test_credential_with_body_digest("secret", body);
+
+        let receipt = payment
+            .verify_credential_with_body(&credential, body)
+            .await
+            .unwrap();
+
+        assert!(receipt.is_success());
+    }
+
+    #[tokio::test]
+    async fn test_verify_credential_with_body_digest_rejects_mismatch() {
+        let payment = Mpp::new(MockMethod, "api.example.com", "secret");
+        let credential = test_credential_with_body_digest("secret", br#"{"query":"paid"}"#);
+
+        let err = payment
+            .verify_credential_with_body(&credential, br#"{"query":"tampered"}"#)
+            .await
+            .unwrap_err();
+
+        assert!(err.message.contains("body digest mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_credential_rejects_digest_without_body() {
+        let payment = Mpp::new(MockMethod, "api.example.com", "secret");
+        let credential = test_credential_with_body_digest("secret", br#"{"query":"paid"}"#);
+
+        let err = payment.verify_credential(&credential).await.unwrap_err();
+
+        assert!(err.message.contains("request body was not provided"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_credential_with_body_rejects_missing_digest() {
+        let payment = Mpp::new(MockMethod, "api.example.com", "secret");
+        let mut credential = test_credential_with_body_digest("secret", br#"{"query":"paid"}"#);
+        credential.challenge.digest = None;
+        credential.challenge.id = crate::protocol::core::compute_challenge_id(
+            "secret",
+            "api.example.com",
+            "mock",
+            "charge",
+            credential.challenge.request.raw(),
+            credential.challenge.expires.as_deref(),
+            None,
+            None,
+        );
+
+        let err = payment
+            .verify_credential_with_body(&credential, br#"{"query":"paid"}"#)
+            .await
+            .unwrap_err();
+
+        assert!(err.message.contains("missing body digest"));
+    }
+
     #[cfg(feature = "tempo")]
     fn create_test_mpp() -> Mpp<crate::server::TempoChargeMethod<crate::server::TempoProvider>> {
         Mpp::create(
@@ -1525,6 +1714,26 @@ mod tests {
         let request: ChargeRequest = challenge.request.decode().unwrap();
         assert_eq!(request.amount, "5500000");
         assert_eq!(challenge.description, Some("API access fee".to_string()));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_charge_with_options_binds_request_body_digest() {
+        let mpp = create_test_mpp();
+        let body = br#"{"query":"paid"}"#;
+        let challenge = mpp
+            .charge_with_options(
+                "0.10",
+                ChargeOptions {
+                    request_body: Some(body),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let digest = crate::body_digest::compute(body);
+        assert_eq!(challenge.digest.as_deref(), Some(digest.as_str()));
+        assert!(challenge.verify("test-secret"));
     }
 
     // ── Real HMAC challenge verification tests ─────────────────────────

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -471,6 +471,12 @@ where
         self.charge_with_options(amount, super::ChargeOptions::default())
     }
 
+    /// Generate a charge challenge and bind it to the actual request body bytes.
+    #[cfg(feature = "tempo")]
+    pub fn charge_with_body(&self, amount: &str, body: &[u8]) -> Result<PaymentChallenge> {
+        self.charge_with_options_and_body(amount, super::ChargeOptions::default(), body)
+    }
+
     /// Generate a charge challenge with a dollar amount and additional options.
     ///
     /// Requires currency and recipient to be bound (via [`Mpp::create()`]).
@@ -502,28 +508,26 @@ where
                 request.method_details = Some(serde_json::Value::Object(details));
             }
         }
-        let mut challenge = crate::protocol::methods::tempo::charge_challenge_with_options(
+        let challenge = crate::protocol::methods::tempo::charge_challenge_with_options(
             &self.secret_key,
             &self.realm,
             &request,
             options.expires,
             options.description,
         )?;
-        if let Some(body) = options.request_body {
-            let digest = crate::body_digest::compute(body);
-            challenge.id = crate::protocol::core::compute_challenge_id(
-                &self.secret_key,
-                &challenge.realm,
-                challenge.method.as_str(),
-                challenge.intent.as_str(),
-                challenge.request.raw(),
-                challenge.expires.as_deref(),
-                Some(&digest),
-                challenge.opaque.as_ref().map(|o| o.raw()),
-            );
-            challenge.digest = Some(digest);
-        }
         Ok(self.apply_pinned_opaque(challenge))
+    }
+
+    /// Generate a charge challenge with options and bind it to the actual request body bytes.
+    #[cfg(feature = "tempo")]
+    pub fn charge_with_options_and_body(
+        &self,
+        amount: &str,
+        options: super::ChargeOptions<'_>,
+        body: &[u8],
+    ) -> Result<PaymentChallenge> {
+        let challenge = self.charge_with_options(amount, options)?;
+        Ok(self.with_body_digest(challenge, body))
     }
 
     /// Generate a charge challenge with explicit parameters (base units).
@@ -759,6 +763,23 @@ where
             }
             _ => Ok(()),
         }
+    }
+
+    #[cfg(any(feature = "tempo", feature = "stripe"))]
+    fn with_body_digest(&self, mut challenge: PaymentChallenge, body: &[u8]) -> PaymentChallenge {
+        let digest = crate::body_digest::compute(body);
+        challenge.id = crate::protocol::core::compute_challenge_id(
+            &self.secret_key,
+            &challenge.realm,
+            challenge.method.as_str(),
+            challenge.intent.as_str(),
+            challenge.request.raw(),
+            challenge.expires.as_deref(),
+            Some(&digest),
+            challenge.opaque.as_ref().map(|o| o.raw()),
+        );
+        challenge.digest = Some(digest);
+        challenge
     }
 }
 
@@ -1077,6 +1098,15 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
         self.stripe_charge_with_options(amount, super::StripeChargeOptions::default())
     }
 
+    /// Generate a Stripe charge challenge and bind it to the actual request body bytes.
+    pub fn stripe_charge_with_body(&self, amount: &str, body: &[u8]) -> Result<PaymentChallenge> {
+        self.stripe_charge_with_options_and_body(
+            amount,
+            super::StripeChargeOptions::default(),
+            body,
+        )
+    }
+
     /// Generate a Stripe charge challenge with additional options.
     ///
     /// Accepts [`StripeChargeOptions`](super::StripeChargeOptions) for description,
@@ -1125,7 +1155,6 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
                 })?
         };
 
-        let digest = options.request_body.map(crate::body_digest::compute);
         let id = crate::protocol::core::compute_challenge_id(
             &self.secret_key,
             &self.realm,
@@ -1133,7 +1162,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
             crate::protocol::methods::stripe::INTENT_CHARGE,
             encoded_request.raw(),
             Some(&expires),
-            digest.as_deref(),
+            None,
             None,
         );
 
@@ -1145,9 +1174,20 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
             request: encoded_request,
             expires: Some(expires),
             description: options.description.map(|s| s.to_string()),
-            digest,
+            digest: None,
             opaque: None,
         }))
+    }
+
+    /// Generate a Stripe charge challenge with options and bind it to the actual request body bytes.
+    pub fn stripe_charge_with_options_and_body(
+        &self,
+        amount: &str,
+        options: super::StripeChargeOptions<'_>,
+        body: &[u8],
+    ) -> Result<PaymentChallenge> {
+        let challenge = self.stripe_charge_with_options(amount, options)?;
+        Ok(self.with_body_digest(challenge, body))
     }
 }
 
@@ -1722,12 +1762,12 @@ mod tests {
         let mpp = create_test_mpp();
         let body = br#"{"query":"paid"}"#;
         let challenge = mpp
-            .charge_with_options(
+            .charge_with_options_and_body(
                 "0.10",
                 ChargeOptions {
-                    request_body: Some(body),
                     ..Default::default()
                 },
+                body,
             )
             .unwrap();
 

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -1833,6 +1833,35 @@ mod tests {
 
     #[cfg(feature = "tempo")]
     #[tokio::test]
+    async fn test_hmac_verify_expected_request_with_body_digest_happy_path() {
+        let mpp = create_hmac_test_mpp();
+        let body = br#"{"query":"paid"}"#;
+        let challenge = mpp.charge_with_body("0.10", body).unwrap();
+        let expected_request: ChargeRequest = challenge.request.decode().unwrap();
+        let credential =
+            PaymentCredential::new(challenge.to_echo(), PaymentPayload::hash("0xdeadbeef"));
+
+        let receipt = mpp
+            .verify_credential_with_expected_request_and_body(&credential, &expected_request, body)
+            .await
+            .unwrap();
+
+        assert!(receipt.is_success());
+        assert_eq!(receipt.reference, "0xtxhash");
+
+        let err = mpp
+            .verify_credential_with_expected_request_and_body(
+                &credential,
+                &expected_request,
+                br#"{"query":"tampered"}"#,
+            )
+            .await
+            .unwrap_err();
+        assert!(err.message.contains("body digest mismatch"));
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
     async fn test_hmac_tampered_request_rejected() {
         let mpp = create_hmac_test_mpp();
         let challenge = mpp.charge("0.10").unwrap();
@@ -3211,5 +3240,51 @@ mod tests {
         let request: serde_json::Value = challenge.request.decode_value().expect("decode request");
         assert!(request["methodDetails"].is_object());
         assert!(challenge.description.is_none());
+    }
+
+    #[cfg(feature = "stripe")]
+    #[test]
+    fn test_stripe_charge_with_body_binds_request_body_digest() {
+        let mpp = test_stripe_mpp();
+        let body = br#"{"query":"paid"}"#;
+        let challenge = mpp.stripe_charge_with_body("0.10", body).unwrap();
+
+        let digest = crate::body_digest::compute(body);
+        assert_eq!(challenge.digest.as_deref(), Some(digest.as_str()));
+        assert!(challenge.verify("test-hmac-secret"));
+
+        let mut tampered = challenge.clone();
+        tampered.digest = Some(crate::body_digest::compute(br#"{"query":"tampered"}"#));
+        assert!(!tampered.verify("test-hmac-secret"));
+    }
+
+    #[cfg(feature = "stripe")]
+    #[test]
+    fn test_stripe_charge_with_options_and_body_preserves_options() {
+        use crate::server::StripeChargeOptions;
+
+        let mpp = test_stripe_mpp();
+        let body = br#"{"query":"paid"}"#;
+        let challenge = mpp
+            .stripe_charge_with_options_and_body(
+                "0.50",
+                StripeChargeOptions {
+                    description: Some("body-bound stripe charge"),
+                    external_id: Some("order-42"),
+                    ..Default::default()
+                },
+                body,
+            )
+            .unwrap();
+
+        let digest = crate::body_digest::compute(body);
+        assert_eq!(challenge.digest.as_deref(), Some(digest.as_str()));
+        assert_eq!(
+            challenge.description.as_deref(),
+            Some("body-bound stripe charge")
+        );
+        assert!(challenge.verify("test-hmac-secret"));
+        let request: serde_json::Value = challenge.request.decode_value().expect("decode request");
+        assert_eq!(request["externalId"], "order-42");
     }
 }

--- a/src/server/stripe.rs
+++ b/src/server/stripe.rs
@@ -32,6 +32,8 @@ pub struct StripeChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Optional metadata key-value pairs.
     pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    /// Framework adapter route/resource/query scope.
+    pub mppx_scope: Option<&'a serde_json::Value>,
 }
 
 /// Builder returned by [`stripe()`] for configuring a Stripe payment method.

--- a/src/server/stripe.rs
+++ b/src/server/stripe.rs
@@ -32,6 +32,8 @@ pub struct StripeChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Optional metadata key-value pairs.
     pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    /// Actual request body bytes to bind into the challenge digest.
+    pub request_body: Option<&'a [u8]>,
 }
 
 /// Builder returned by [`stripe()`] for configuring a Stripe payment method.

--- a/src/server/stripe.rs
+++ b/src/server/stripe.rs
@@ -32,8 +32,6 @@ pub struct StripeChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Optional metadata key-value pairs.
     pub metadata: Option<&'a std::collections::HashMap<String, String>>,
-    /// Actual request body bytes to bind into the challenge digest.
-    pub request_body: Option<&'a [u8]>,
 }
 
 /// Builder returned by [`stripe()`] for configuring a Stripe payment method.


### PR DESCRIPTION
## Summary
- bind server-side challenges to request body digests in tower/axum flows
- bind challenges to framework route/resource/query scope to reject same-price cross-resource replay
- fail closed for custom Axum challengers that do not implement scope-aware verification

## Testing
- `cargo test --features axum test_extractor_ --lib`
- `cargo test --features axum test_body_extractor --lib`