### PR TITLE
feat: simulate sponsored txs before broadcast

### DIFF
--- a/.changelog/sponsor-pre-broadcast-simulation.md
+++ b/.changelog/sponsor-pre-broadcast-simulation.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Sponsored (fee-payer) charges now dry-run the co-signed transaction via `tempo_simulateV1` before broadcasting. If the transaction would revert on-chain, the sponsor rejects it instead of paying gas for a failing transaction. The check fails closed: if the simulation RPC is unavailable, the charge is rejected.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ tokio-tungstenite = { version = "0.29", optional = true }
 futures-util = { version = "0.3", optional = true }
 
 [dev-dependencies]
+alloy-json-rpc = "2.0.5"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.8", features = ["ws"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -37,6 +37,7 @@ use tempo_alloy::contracts::precompiles::{
 };
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
+use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
 use tokio::sync::OnceCell;
 
 use crate::protocol::core::{PaymentCredential, Receipt};
@@ -1016,11 +1017,8 @@ where
         Ok(receipt.transaction_hash())
     }
 
-    /// Turn a co-signed `0x76` tx into a `tempo_simulateV1` request.
-    ///
-    /// The `AASigned -> request` conversion drops `from`, so we recover the
-    /// signer and set it back; the node needs it to model the sender. Split out
-    /// from the RPC call so tests can check the request shape.
+    /// Decode a co-signed `0x76` tx and build the equivalent
+    /// `tempo_simulateV1` request.
     fn build_simulate_payload(
         final_tx_bytes: &[u8],
     ) -> Result<SimulatePayload<TempoTransactionRequest>, VerificationError> {
@@ -1032,8 +1030,32 @@ where
             VerificationError::new(format!("Failed to recover sender for simulation: {e}"))
         })?;
 
+        // Extract the access key while the signature is still available; the
+        // `into()` conversion below discards it.
+        let keychain = match signed.signature() {
+            TempoSignature::Keychain(keychain_sig) => {
+                let key_id = keychain_sig.key_id(&signed.signature_hash()).map_err(|e| {
+                    VerificationError::new(format!(
+                        "Failed to recover keychain access key for simulation: {e}"
+                    ))
+                })?;
+                let key_type = keychain_sig.signature.signature_type();
+                let key_data = match &keychain_sig.signature {
+                    PrimitiveSignature::WebAuthn(webauthn) => Some(webauthn.webauthn_data.clone()),
+                    _ => None,
+                };
+                Some((key_id, key_type, key_data))
+            }
+            TempoSignature::Primitive(_) => None,
+        };
+
         let mut req: TempoTransactionRequest = signed.into();
         req.inner.from = Some(sender);
+        if let Some((key_id, key_type, key_data)) = keychain {
+            req.key_id = Some(key_id);
+            req.key_type = Some(key_type);
+            req.key_data = key_data;
+        }
 
         Ok(SimulatePayload {
             block_state_calls: vec![SimBlock {
@@ -3398,6 +3420,102 @@ mod tests {
                 fee_token,
             )
             .expect("cosign should succeed")
+    }
+
+    /// Co-signed `0x76` tx whose client signature is a keychain (access-key)
+    /// signature. Returns `(cosigned bytes, wallet, access key)`.
+    fn make_keychain_cosigned_fee_payer_tx() -> (Vec<u8>, Address, Address) {
+        use super::super::FeePayerEnvelope78;
+        use alloy::signers::SignerSync;
+        use tempo_primitives::transaction::{
+            KeychainSignature, PrimitiveSignature, TempoSignature,
+        };
+
+        let wallet = Address::repeat_byte(0xab);
+        let access_key_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
+            .unwrap();
+
+        let tx = make_fee_payer_tx(60);
+        let sig_hash = tx.signature_hash();
+        // V1 keychain signs sig_hash directly; inner signer is the access key.
+        let inner = access_key_signer.sign_hash_sync(&sig_hash).unwrap();
+        let keychain_sig = KeychainSignature::new_v1(wallet, PrimitiveSignature::Secp256k1(inner));
+        let signature = TempoSignature::Keychain(keychain_sig);
+        let envelope =
+            FeePayerEnvelope78::from_signing_tx(tx, wallet, signature).encoded_envelope();
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+        let cosigned = method
+            .cosign_fee_payer_transaction(
+                &envelope,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect("cosign should succeed");
+
+        (cosigned, wallet, access_key_signer.address())
+    }
+
+    /// A keychain tx must be simulated as the access key, not the wallet alone:
+    /// the request sets `from` to the wallet *and* carries the access key as
+    /// `keyId`/`keyType` so the node applies keychain auth/revocation checks.
+    #[test]
+    fn test_build_simulate_payload_preserves_keychain_access_key() {
+        let (cosigned, wallet, access_key) = make_keychain_cosigned_fee_payer_tx();
+
+        let payload =
+            ChargeMethod::<alloy::providers::RootProvider<tempo_alloy::TempoNetwork>>::build_simulate_payload(
+                &cosigned,
+            )
+            .expect("payload must build");
+
+        let call = &payload.block_state_calls[0].calls[0];
+
+        assert_eq!(call.inner.from, Some(wallet), "from must be the wallet");
+        assert_eq!(
+            call.key_id,
+            Some(access_key),
+            "keyId must be the access key, not the wallet"
+        );
+        assert_eq!(
+            call.key_type,
+            Some(tempo_primitives::SignatureType::Secp256k1)
+        );
+        // Otherwise the assertions above would be vacuous.
+        assert_ne!(wallet, access_key);
+
+        // Confirm the keychain fields serialize onto the wire.
+        let p = serde_json::to_value(&payload).unwrap();
+        let wire_call = &p["blockStateCalls"][0]["calls"][0];
+        assert_eq!(
+            wire_call["keyId"].as_str().unwrap().to_lowercase(),
+            format!("{:#x}", access_key),
+        );
+        assert!(wire_call["keyType"].is_string() || wire_call["keyType"].is_number());
+    }
+
+    /// A plain EOA tx must not carry keychain fields.
+    #[test]
+    fn test_build_simulate_payload_omits_keychain_for_primitive_sig() {
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        let payload =
+            ChargeMethod::<alloy::providers::RootProvider<tempo_alloy::TempoNetwork>>::build_simulate_payload(
+                &cosigned,
+            )
+            .expect("payload must build");
+
+        let call = &payload.block_state_calls[0].calls[0];
+        assert!(call.key_id.is_none(), "plain EOA tx must not set keyId");
+        assert!(call.key_type.is_none(), "plain EOA tx must not set keyType");
+        assert!(call.key_data.is_none(), "plain EOA tx must not set keyData");
     }
 
     /// The outbound `tempo_simulateV1` request must carry the full sponsor /

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1030,24 +1030,26 @@ where
             VerificationError::new(format!("Failed to recover sender for simulation: {e}"))
         })?;
 
-        // Extract the access key while the signature is still available; the
-        // `into()` conversion below discards it. `keyId`/`keyType`/`keyData`
-        // are used by the node's gas model for keychain txs.
-        let keychain = match signed.signature() {
-            TempoSignature::Keychain(keychain_sig) => {
-                let key_id = keychain_sig.key_id(&signed.signature_hash()).map_err(|e| {
-                    VerificationError::new(format!(
-                        "Failed to recover keychain access key for simulation: {e}"
-                    ))
-                })?;
-                let key_type = keychain_sig.signature.signature_type();
-                let key_data = match &keychain_sig.signature {
-                    PrimitiveSignature::WebAuthn(webauthn) => Some(webauthn.webauthn_data.clone()),
-                    _ => None,
-                };
-                Some((key_id, key_type, key_data))
-            }
-            TempoSignature::Primitive(_) => None,
+        // Extract auth metadata before `into()` discards the signature: the
+        // node sizes signature gas from `keyType`/`keyData` (primitive
+        // p256/webauthn included) and selects the keychain key via `keyId`.
+        let (key_id, key_type, key_data) = {
+            let (key_id, primitive_sig) = match signed.signature() {
+                TempoSignature::Keychain(keychain_sig) => {
+                    let key_id = keychain_sig.key_id(&signed.signature_hash()).map_err(|e| {
+                        VerificationError::new(format!(
+                            "Failed to recover keychain access key for simulation: {e}"
+                        ))
+                    })?;
+                    (Some(key_id), &keychain_sig.signature)
+                }
+                TempoSignature::Primitive(primitive_sig) => (None, primitive_sig),
+            };
+            let key_data = match primitive_sig {
+                PrimitiveSignature::WebAuthn(webauthn) => Some(webauthn.webauthn_data.clone()),
+                _ => None,
+            };
+            (key_id, primitive_sig.signature_type(), key_data)
         };
 
         let mut req: TempoTransactionRequest = signed.into();
@@ -1065,10 +1067,10 @@ where
         req.inner.value = Some(tail.value);
         req.inner.input = tail.input.into();
 
-        if let Some((key_id, key_type, key_data)) = keychain {
+        req.key_type = Some(key_type);
+        req.key_data = key_data;
+        if let Some(key_id) = key_id {
             req.key_id = Some(key_id);
-            req.key_type = Some(key_type);
-            req.key_data = key_data;
         }
 
         Ok(SimulatePayload {
@@ -3514,7 +3516,8 @@ mod tests {
         assert!(wire_call["keyType"].is_string() || wire_call["keyType"].is_number());
     }
 
-    /// A plain EOA tx must not carry keychain fields.
+    /// A plain EOA tx carries no `keyId` but still advertises its `keyType`
+    /// so the node sizes signature gas correctly.
     #[test]
     fn test_build_simulate_payload_omits_keychain_for_primitive_sig() {
         let cosigned = make_cosigned_fee_payer_tx();
@@ -3527,8 +3530,15 @@ mod tests {
 
         let call = &payload.block_state_calls[0].calls[0];
         assert!(call.key_id.is_none(), "plain EOA tx must not set keyId");
-        assert!(call.key_type.is_none(), "plain EOA tx must not set keyType");
-        assert!(call.key_data.is_none(), "plain EOA tx must not set keyData");
+        assert_eq!(
+            call.key_type,
+            Some(tempo_primitives::SignatureType::Secp256k1),
+            "primitive tx must advertise its keyType for gas sizing"
+        );
+        assert!(
+            call.key_data.is_none(),
+            "secp256k1 tx has no WebAuthn auth data"
+        );
     }
 
     /// The `tempo_simulateV1` request must carry the full sponsor/cosign ABI:

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -23,15 +23,19 @@
 //! assert!(receipt.is_success());
 //! ```
 
+use alloy::consensus::transaction::SignerRecoverable;
+use alloy::eips::Decodable2718;
 use alloy::network::ReceiptResponse;
 use alloy::primitives::{keccak256, Address, Bytes, TxKind, B256, U256};
 use alloy::providers::Provider;
+use alloy::rpc::types::simulate::{SimBlock, SimCallResult, SimulatePayload};
 use alloy::sol_types::SolCall;
 use std::future::Future;
 use std::sync::Arc;
 use tempo_alloy::contracts::precompiles::{
     IAccountKeychain, IStablecoinDEX, ACCOUNT_KEYCHAIN_ADDRESS, ITIP20, STABLECOIN_DEX_ADDRESS,
 };
+use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
 use tokio::sync::OnceCell;
 
@@ -566,6 +570,19 @@ fn fee_token_allowed(allowed_fee_tokens: &[Address], fee_token: Address) -> bool
     allowed_fee_tokens.contains(&fee_token)
 }
 
+/// `tempo_simulateV1` response; we only read the per-call status.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TempoSimulateResponse {
+    #[serde(default)]
+    blocks: Vec<TempoSimulateBlock>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct TempoSimulateBlock {
+    #[serde(default)]
+    calls: Vec<SimCallResult>,
+}
+
 impl<P> ChargeMethod<P>
 where
     P: Provider<TempoNetwork> + Clone + Send + Sync + 'static,
@@ -932,6 +949,13 @@ where
             charge.fee_payer(),
         )?;
 
+        // The sponsor pays the gas here, so simulate first and bail if the tx
+        // would revert. Static validation above only checks call shape, not
+        // execution. Fails closed: no simulation, no broadcast.
+        if charge.fee_payer() {
+            self.simulate_before_broadcast(&final_tx_bytes).await?;
+        }
+
         // Pre-broadcast dedup of the final tx bytes. Separate namespace from
         // the post-broadcast hash dedup in verify_hash.
         if let Some(store) = &self.store {
@@ -992,6 +1016,82 @@ where
         Ok(receipt.transaction_hash())
     }
 
+    /// Turn a co-signed `0x76` tx into a `tempo_simulateV1` request.
+    ///
+    /// The `AASigned -> request` conversion drops `from`, so we recover the
+    /// signer and set it back; the node needs it to model the sender. Split out
+    /// from the RPC call so tests can check the request shape.
+    fn build_simulate_payload(
+        final_tx_bytes: &[u8],
+    ) -> Result<SimulatePayload<TempoTransactionRequest>, VerificationError> {
+        let signed =
+            tempo_primitives::AASigned::decode_2718(&mut &final_tx_bytes[..]).map_err(|e| {
+                VerificationError::new(format!("Failed to decode co-signed tx for simulation: {e}"))
+            })?;
+        let sender = signed.recover_signer().map_err(|e| {
+            VerificationError::new(format!("Failed to recover sender for simulation: {e}"))
+        })?;
+
+        let mut req: TempoTransactionRequest = signed.into();
+        req.inner.from = Some(sender);
+
+        Ok(SimulatePayload {
+            block_state_calls: vec![SimBlock {
+                block_overrides: None,
+                state_overrides: None,
+                calls: vec![req],
+            }],
+            // We only care about execution outcome, not mempool admission.
+            validation: false,
+            trace_transfers: false,
+            return_full_transactions: false,
+        })
+    }
+
+    /// Simulate a co-signed `0x76` tx and error if it would revert. Fails
+    /// closed: an RPC error is treated as a failed check, not a pass.
+    async fn simulate_before_broadcast(
+        &self,
+        final_tx_bytes: &[u8],
+    ) -> Result<(), VerificationError> {
+        let payload = Self::build_simulate_payload(final_tx_bytes)?;
+
+        // tempo_simulateV1(payload, block?) — omit block to use the latest state.
+        let response: TempoSimulateResponse = self
+            .provider
+            .raw_request("tempo_simulateV1".into(), (payload,))
+            .await
+            .map_err(|e| {
+                VerificationError::network_error(format!("Pre-broadcast simulation failed: {e}"))
+            })?;
+
+        let call: &SimCallResult = response
+            .blocks
+            .first()
+            .and_then(|block| block.calls.first())
+            .ok_or_else(|| {
+                VerificationError::new("Pre-broadcast simulation returned no call results")
+            })?;
+
+        if !call.status {
+            let detail = match &call.error {
+                Some(err) => format!("{} (code {})", err.message, err.code),
+                None if !call.return_data.is_empty() => {
+                    format!(
+                        "revert data {}",
+                        alloy::hex::encode_prefixed(&call.return_data)
+                    )
+                }
+                None => "no revert reason returned".to_string(),
+            };
+            return Err(VerificationError::transaction_failed(format!(
+                "Sponsored transaction would revert in pre-broadcast simulation: {detail}"
+            )));
+        }
+
+        Ok(())
+    }
+
     /// Co-sign a fee payer transaction.
     ///
     /// Accepts a `0x78` fee payer envelope, recovers the sender via
@@ -1004,7 +1104,6 @@ where
         fee_token: Address,
     ) -> Result<Vec<u8>, VerificationError> {
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
-        use alloy::consensus::transaction::SignerRecoverable;
         use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
         use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
@@ -1845,7 +1944,6 @@ mod tests {
     #[test]
     fn test_fee_payer_round_trip_0x78_envelope() {
         use super::super::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
-        use alloy::eips::Decodable2718;
         use alloy::signers::SignerSync;
 
         let client_signer = alloy::signers::local::PrivateKeySigner::random();
@@ -3204,7 +3302,6 @@ mod tests {
     #[test]
     fn test_cosign_strips_tampered_access_list() {
         use alloy::eips::eip2930::{AccessList, AccessListItem};
-        use alloy::eips::Decodable2718;
         use alloy::primitives::B256;
         use alloy::signers::local::PrivateKeySigner;
         use alloy::signers::SignerSync;
@@ -3268,5 +3365,184 @@ mod tests {
             "broadcast tx must have empty access list"
         );
         assert_eq!(signed.tx().fee_token, Some(fee_token));
+    }
+
+    /// Build a co-signed `0x76` transaction the same way `broadcast_transaction`
+    /// does, for exercising `simulate_before_broadcast` against a mocked node.
+    fn make_cosigned_fee_payer_tx() -> Vec<u8> {
+        use super::super::FeePayerEnvelope78;
+        use alloy::signers::SignerSync;
+
+        let client_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_payer_signer = alloy::signers::local::PrivateKeySigner::random();
+        let fee_token = KnownTempoNetwork::Mainnet
+            .default_currency()
+            .parse::<Address>()
+            .unwrap();
+
+        let tx = make_fee_payer_tx(60);
+        let sig_hash = tx.signature_hash();
+        let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
+        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+        let envelope = FeePayerEnvelope78::from_signing_tx(tx, client_signer.address(), signature)
+            .encoded_envelope();
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider).with_fee_payer(fee_payer_signer);
+        method
+            .cosign_fee_payer_transaction(
+                &envelope,
+                method.fee_payer_signer.as_ref().unwrap(),
+                fee_token,
+            )
+            .expect("cosign should succeed")
+    }
+
+    /// The outbound `tempo_simulateV1` request must carry the full sponsor /
+    /// cosign ABI: the cosigned call's `from` (recovered sender), `feeToken`,
+    /// `feePayerSignature`, the payment `calls`, the expiring `nonceKey`, the
+    /// validity window, and `validation: false`. This is the request-shape
+    /// half of the conformance fixture (the response-handling half lives in the
+    /// revert/success/fail-closed tests).
+    #[test]
+    fn test_build_simulate_payload_request_abi() {
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        // The from we expect is the client sender recovered from the cosigned tx.
+        let expected_from = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice())
+            .unwrap()
+            .recover_signer()
+            .unwrap();
+
+        let payload =
+            ChargeMethod::<alloy::providers::RootProvider<tempo_alloy::TempoNetwork>>::build_simulate_payload(
+                &cosigned,
+            )
+            .expect("payload must build");
+
+        // Serialize exactly as it goes over the wire (single-element param array).
+        let params = serde_json::to_value((payload,)).unwrap();
+        let arr = params.as_array().expect("params serialize to a JSON array");
+        assert_eq!(
+            arr.len(),
+            1,
+            "tempo_simulateV1 takes a single payload param"
+        );
+
+        let p = &arr[0];
+        assert_eq!(p["validation"], serde_json::json!(false));
+
+        let call = &p["blockStateCalls"][0]["calls"][0];
+        assert_eq!(
+            call["from"].as_str().unwrap().to_lowercase(),
+            format!("{:#x}", expected_from),
+            "request must set the recovered sender as `from`"
+        );
+        // Fee-sponsor fields the node needs to model gas affordability/execution.
+        assert!(call["feeToken"].is_string(), "feeToken must be present");
+        assert!(
+            call["feePayerSignature"].is_string() || call["feePayerSignature"].is_object(),
+            "feePayerSignature must be present: {call}"
+        );
+        assert!(call["nonceKey"].is_string(), "nonceKey must be present");
+        assert!(
+            call["validBefore"].is_string(),
+            "validBefore must be present"
+        );
+        let calls = call["calls"].as_array().expect("payment calls present");
+        assert_eq!(calls.len(), 1, "expected the single payment call");
+    }
+
+    /// A reverting simulation must block the broadcast so the sponsor never
+    /// pays gas for a failing transaction.
+    #[tokio::test]
+    async fn test_simulate_before_broadcast_rejects_revert() {
+        use alloy::providers::mock::Asserter;
+
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!({
+            "blocks": [{
+                "calls": [{
+                    "returnData": "0x",
+                    "gasUsed": "0x5208",
+                    "status": "0x0",
+                    "error": { "code": 3, "message": "execution reverted" }
+                }]
+            }]
+        }));
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_mocked_client(asserter);
+        let method = ChargeMethod::new(provider);
+
+        let err = method
+            .simulate_before_broadcast(&cosigned)
+            .await
+            .expect_err("reverting simulation must be rejected");
+        assert!(
+            err.to_string().contains("would revert"),
+            "unexpected error: {err}"
+        );
+        assert!(err.to_string().contains("execution reverted"));
+    }
+
+    /// A successful simulation must allow the broadcast to proceed.
+    #[tokio::test]
+    async fn test_simulate_before_broadcast_accepts_success() {
+        use alloy::providers::mock::Asserter;
+
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        let asserter = Asserter::new();
+        asserter.push_success(&serde_json::json!({
+            "blocks": [{
+                "calls": [{
+                    "returnData": "0x",
+                    "gasUsed": "0x5208",
+                    "status": "0x1"
+                }]
+            }]
+        }));
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_mocked_client(asserter);
+        let method = ChargeMethod::new(provider);
+
+        method
+            .simulate_before_broadcast(&cosigned)
+            .await
+            .expect("successful simulation must pass");
+    }
+
+    /// If the simulation RPC itself errors, fail closed: the sponsor must not
+    /// broadcast a transaction it could not simulate.
+    #[tokio::test]
+    async fn test_simulate_before_broadcast_fails_closed_on_rpc_error() {
+        use alloy::providers::mock::Asserter;
+
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("tempo_simulateV1 unavailable");
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_mocked_client(asserter);
+        let method = ChargeMethod::new(provider);
+
+        let err = method
+            .simulate_before_broadcast(&cosigned)
+            .await
+            .expect_err("RPC failure must fail closed");
+        assert!(
+            err.to_string().contains("Pre-broadcast simulation failed"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1086,22 +1086,39 @@ where
         })
     }
 
-    /// Simulate a co-signed `0x76` tx and error if it would revert. Fails
-    /// closed: an RPC error is treated as a failed check, not a pass.
+    /// Simulate a co-signed `0x76` tx and error if it would revert. Generally
+    /// fails closed: an RPC error is treated as a failed check, not a pass.
+    /// Exception: nodes without `tempo_simulateV1` (JSON-RPC -32601) skip the
+    /// check rather than reject every sponsored payment.
     async fn simulate_before_broadcast(
         &self,
         final_tx_bytes: &[u8],
     ) -> Result<(), VerificationError> {
+        // Standard JSON-RPC "method not found" code.
+        const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
+
         let payload = Self::build_simulate_payload(final_tx_bytes)?;
 
         // tempo_simulateV1(payload, block?) — omit block to use the latest state.
-        let response: TempoSimulateResponse = self
+        let response: TempoSimulateResponse = match self
             .provider
             .raw_request("tempo_simulateV1".into(), (payload,))
             .await
-            .map_err(|e| {
-                VerificationError::network_error(format!("Pre-broadcast simulation failed: {e}"))
-            })?;
+        {
+            Ok(response) => response,
+            Err(e) => {
+                // Node doesn't support pre-simulation: skip the check rather
+                // than failing the payment.
+                if e.as_error_resp()
+                    .is_some_and(|err| err.code == JSONRPC_METHOD_NOT_FOUND)
+                {
+                    return Ok(());
+                }
+                return Err(VerificationError::network_error(format!(
+                    "Pre-broadcast simulation failed: {e}"
+                )));
+            }
+        };
 
         let call: &SimCallResult = response
             .blocks
@@ -3761,5 +3778,32 @@ mod tests {
             err.to_string().contains("Pre-broadcast simulation failed"),
             "unexpected error: {err}"
         );
+    }
+
+    /// A node that doesn't implement `tempo_simulateV1` (JSON-RPC "method not
+    /// found", -32601) has nothing to simulate against, so the check is skipped
+    /// and the broadcast proceeds rather than rejecting the payment.
+    #[tokio::test]
+    async fn test_simulate_before_broadcast_skips_when_method_not_found() {
+        use alloy::providers::mock::Asserter;
+
+        let cosigned = make_cosigned_fee_payer_tx();
+
+        let asserter = Asserter::new();
+        asserter.push_failure(alloy_json_rpc::ErrorPayload {
+            code: -32601,
+            message: "the method tempo_simulateV1 does not exist/is not available".into(),
+            data: None,
+        });
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_mocked_client(asserter);
+        let method = ChargeMethod::new(provider);
+
+        method
+            .simulate_before_broadcast(&cosigned)
+            .await
+            .expect("method-not-found must skip the check, not fail");
     }
 }

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1031,7 +1031,8 @@ where
         })?;
 
         // Extract the access key while the signature is still available; the
-        // `into()` conversion below discards it.
+        // `into()` conversion below discards it. `keyId`/`keyType`/`keyData`
+        // are used by the node's gas model for keychain txs.
         let keychain = match signed.signature() {
             TempoSignature::Keychain(keychain_sig) => {
                 let key_id = keychain_sig.key_id(&signed.signature_hash()).map_err(|e| {
@@ -1051,6 +1052,19 @@ where
 
         let mut req: TempoTransactionRequest = signed.into();
         req.inner.from = Some(sender);
+
+        // `From<AASigned>` leaves `inner.to` unset, which the node reads as a
+        // contract CREATE and rejects alongside the AA batch. The node rebuilds
+        // the batch as `calls ++ [inner.to call]`, so fold the last sub-call
+        // into `inner.to/value/input`: same resulting batch (order and
+        // fee-payer signature preserved) with a real call target.
+        let tail = req.calls.pop().ok_or_else(|| {
+            VerificationError::new("Cannot simulate Tempo AA transaction with no calls")
+        })?;
+        req.inner.to = Some(tail.to);
+        req.inner.value = Some(tail.value);
+        req.inner.input = tail.input.into();
+
         if let Some((key_id, key_type, key_data)) = keychain {
             req.key_id = Some(key_id);
             req.key_type = Some(key_type);
@@ -3463,11 +3477,10 @@ mod tests {
         (cosigned, wallet, access_key_signer.address())
     }
 
-    /// A keychain tx must be simulated as the access key, not the wallet alone:
-    /// the request sets `from` to the wallet *and* carries the access key as
-    /// `keyId`/`keyType` so the node applies keychain auth/revocation checks.
+    /// A keychain tx's request sets `from` to the wallet and carries the access
+    /// key as `keyId`/`keyType`, serialized onto the wire.
     #[test]
-    fn test_build_simulate_payload_preserves_keychain_access_key() {
+    fn test_build_simulate_payload_includes_keychain_fields() {
         let (cosigned, wallet, access_key) = make_keychain_cosigned_fee_payer_tx();
 
         let payload =
@@ -3518,27 +3531,36 @@ mod tests {
         assert!(call.key_data.is_none(), "plain EOA tx must not set keyData");
     }
 
-    /// The outbound `tempo_simulateV1` request must carry the full sponsor /
-    /// cosign ABI: the cosigned call's `from` (recovered sender), `feeToken`,
-    /// `feePayerSignature`, the payment `calls`, the expiring `nonceKey`, the
-    /// validity window, and `validation: false`. This is the request-shape
-    /// half of the conformance fixture (the response-handling half lives in the
-    /// revert/success/fail-closed tests).
+    /// The `tempo_simulateV1` request must carry the full sponsor/cosign ABI:
+    /// `from` (recovered sender), `feeToken`, `feePayerSignature`, `nonceKey`,
+    /// the validity window, and `validation: false`. The single payment call is
+    /// folded into `to`/`input` (not left in `calls`) so the node does not read
+    /// the empty `to` as a CREATE.
     #[test]
     fn test_build_simulate_payload_request_abi() {
         let cosigned = make_cosigned_fee_payer_tx();
 
         // The from we expect is the client sender recovered from the cosigned tx.
-        let expected_from = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice())
-            .unwrap()
-            .recover_signer()
-            .unwrap();
+        let signed = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
+        let expected_from = signed.recover_signer().unwrap();
+        let expected_calls = signed.tx().calls.clone();
 
         let payload =
             ChargeMethod::<alloy::providers::RootProvider<tempo_alloy::TempoNetwork>>::build_simulate_payload(
                 &cosigned,
             )
             .expect("payload must build");
+
+        // `build_aa()` must reproduce the original call list exactly, so the
+        // fee-payer signature still recovers.
+        let rebuilt = payload.block_state_calls[0].calls[0]
+            .clone()
+            .build_aa()
+            .expect("request must rebuild into an AA tx");
+        assert_eq!(
+            rebuilt.calls, expected_calls,
+            "rebuilt batch must match the signed tx's calls"
+        );
 
         // Serialize exactly as it goes over the wire (single-element param array).
         let params = serde_json::to_value((payload,)).unwrap();
@@ -3558,6 +3580,19 @@ mod tests {
             format!("{:#x}", expected_from),
             "request must set the recovered sender as `from`"
         );
+        // The single payment call must be folded into `to` (so the node does
+        // not treat the empty `to` as a CREATE) — not left in `calls`.
+        assert!(
+            call["to"].is_string(),
+            "payment call must be folded into `to`: {call}"
+        );
+        assert!(
+            call["calls"]
+                .as_array()
+                .map(|c| c.is_empty())
+                .unwrap_or(true),
+            "single-call request must leave `calls` empty: {call}"
+        );
         // Fee-sponsor fields the node needs to model gas affordability/execution.
         assert!(call["feeToken"].is_string(), "feeToken must be present");
         assert!(
@@ -3569,8 +3604,62 @@ mod tests {
             call["validBefore"].is_string(),
             "validBefore must be present"
         );
-        let calls = call["calls"].as_array().expect("payment calls present");
-        assert_eq!(calls.len(), 1, "expected the single payment call");
+    }
+
+    /// A multi-call AA batch must round-trip with its order preserved: the
+    /// last call is folded into `to`, the rest stay in `calls`, and the node's
+    /// `calls ++ [inner.to call]` reconstruction reproduces the original order.
+    #[test]
+    fn test_build_simulate_payload_preserves_multi_call_order() {
+        use alloy::eips::Encodable2718;
+        use alloy::signers::SignerSync;
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+
+        // Three distinct calls so a reordering bug (e.g. moving the first call)
+        // would be observable.
+        let calls = vec![
+            tempo_primitives::transaction::Call {
+                to: TxKind::Call(Address::repeat_byte(0x11)),
+                value: U256::ZERO,
+                input: Bytes::from(vec![0xaa]),
+            },
+            tempo_primitives::transaction::Call {
+                to: TxKind::Call(Address::repeat_byte(0x22)),
+                value: U256::from(7u64),
+                input: Bytes::from(vec![0xbb, 0xbb]),
+            },
+            tempo_primitives::transaction::Call {
+                to: TxKind::Call(Address::repeat_byte(0x33)),
+                value: U256::ZERO,
+                input: Bytes::from(vec![0xcc, 0xcc, 0xcc]),
+            },
+        ];
+
+        let mut tx = make_fee_payer_tx(60);
+        tx.calls = calls.clone();
+        let signature: tempo_primitives::transaction::TempoSignature =
+            signer.sign_hash_sync(&tx.signature_hash()).unwrap().into();
+        let signed_bytes = tx.into_signed(signature).encoded_2718();
+
+        let payload =
+            ChargeMethod::<alloy::providers::RootProvider<tempo_alloy::TempoNetwork>>::build_simulate_payload(
+                &signed_bytes,
+            )
+            .expect("payload must build");
+
+        let req = &payload.block_state_calls[0].calls[0];
+        // N-1 calls stay in `calls`, the last is folded into `to`.
+        assert_eq!(req.calls, calls[..2], "first N-1 calls stay in `calls`");
+        assert_eq!(req.inner.to, Some(calls[2].to), "last call folds into `to`");
+        assert_eq!(req.inner.value, Some(calls[2].value));
+
+        // The node reconstructs `calls ++ [inner.to call]`; verify it matches.
+        let rebuilt = req.clone().build_aa().expect("must rebuild");
+        assert_eq!(
+            rebuilt.calls, calls,
+            "reconstructed batch must preserve the original order"
+        );
     }
 
     /// A reverting simulation must block the broadcast so the sponsor never

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1957,3 +1957,162 @@ async fn test_proof_credential_replay_rejected() {
     handle.abort();
     let _ = handle.await;
 }
+
+/// Authorize `access_key` for `wallet`'s account on-chain with a single pathUSD
+/// spending limit, in its own transaction (so the limit is live in committed
+/// state for any later charge). The wallet signs and pays its own gas.
+async fn wallet_authorize_access_key(
+    rpc: &str,
+    wallet: &PrivateKeySigner,
+    access_key: Address,
+    path_usd_limit: U256,
+) {
+    use tempo_alloy::contracts::precompiles::{IAccountKeychain, ACCOUNT_KEYCHAIN_ADDRESS};
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let config = IAccountKeychain::KeyRestrictions {
+        expiry: now + 3_600, // 1 hour from now
+        enforceLimits: true,
+        limits: vec![IAccountKeychain::TokenLimit {
+            token: PATH_USD,
+            amount: path_usd_limit,
+            period: 0,
+        }],
+        allowAnyCalls: true, // only the spending limit should bite
+        allowedCalls: vec![],
+    };
+    let calldata = IAccountKeychain::authorizeKey_1Call {
+        keyId: access_key,
+        signatureType: IAccountKeychain::SignatureType::Secp256k1,
+        config,
+    }
+    .abi_encode();
+
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+    let nonce = provider
+        .get_transaction_count(wallet.address())
+        .await
+        .expect("nonce");
+    let chain_id = provider.get_chain_id().await.expect("chain id");
+    let gas_price = provider.get_gas_price().await.expect("gas price");
+
+    let tx = TempoTransaction {
+        chain_id,
+        nonce,
+        gas_limit: 5_000_000,
+        max_fee_per_gas: gas_price,
+        max_priority_fee_per_gas: gas_price,
+        fee_token: Some(PATH_USD),
+        calls: vec![Call {
+            to: TxKind::Call(ACCOUNT_KEYCHAIN_ADDRESS),
+            value: U256::ZERO,
+            input: Bytes::from(calldata),
+        }],
+        ..Default::default()
+    };
+    let sig = wallet.sign_hash_sync(&tx.signature_hash()).unwrap();
+    let signed = tx.into_signed(sig.into());
+    let raw = format!("0x{}", hex::encode(signed.encoded_2718()));
+    let tx_hash: B256 = provider
+        .raw_request("eth_sendRawTransaction".into(), (raw,))
+        .await
+        .expect("authorizeKey send failed");
+
+    let receipt = wait_for_receipt(&provider, tx_hash)
+        .await
+        .expect("authorizeKey receipt");
+    assert!(receipt.status(), "authorizeKey tx reverted: {tx_hash:#x}");
+}
+
+/// A valid keychain (access-key) sponsored charge passes the pre-broadcast
+/// simulation gate and settles on-chain, with the sponsor as the fee payer.
+#[tokio::test]
+async fn test_keychain_sponsored_charge_passes_simulation_and_settles() {
+    use mpp::client::tempo::signing::{KeychainVersion, TempoSigningMode};
+
+    let rpc = rpc_url();
+    let chain_id = get_chain_id(&rpc).await;
+
+    let sponsor_signer = PrivateKeySigner::random();
+    let wallet_signer = PrivateKeySigner::random();
+    let access_key_signer = PrivateKeySigner::random();
+
+    // Sponsor pays gas; wallet holds the funds the access key spends.
+    fund_account(&rpc, sponsor_signer.address()).await;
+    fund_account(&rpc, wallet_signer.address()).await;
+
+    // Provision the access key on-chain with a generous pathUSD limit so the
+    // 0.01 charge is well within bounds.
+    wallet_authorize_access_key(
+        &rpc,
+        &wallet_signer,
+        access_key_signer.address(),
+        U256::from(1_000_000u64),
+    )
+    .await;
+
+    let sponsor_addr = sponsor_signer.address();
+    let mpp = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &format!("{}", sponsor_addr),
+        })
+        .rpc_url(&rpc)
+        .chain_id(chain_id)
+        .fee_payer(true)
+        .fee_payer_signer(sponsor_signer)
+        .secret_key("keychain-sim-test"),
+    )
+    .expect("failed to create Mpp");
+
+    let (url, handle) = start_server(Arc::new(mpp) as Arc<dyn ChargeChallenger>).await;
+
+    // Access key acts for the wallet; key already on-chain (no key_authorization).
+    let provider = TempoProvider::new(access_key_signer, &rpc)
+        .expect("failed to create TempoProvider")
+        .with_signing_mode(TempoSigningMode::Keychain {
+            wallet: wallet_signer.address(),
+            key_authorization: None,
+            version: KeychainVersion::V2,
+        });
+
+    let resp = Client::new()
+        .get(format!("{url}/paid"))
+        .send_with_payment(&provider)
+        .await
+        .expect("keychain fee-payer payment failed");
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "valid keychain sponsored charge must pass simulation and settle"
+    );
+
+    let receipt_hdr = resp
+        .headers()
+        .get("payment-receipt")
+        .expect("missing Payment-Receipt header")
+        .to_str()
+        .unwrap();
+    let receipt = mpp::parse_receipt(receipt_hdr).expect("failed to parse receipt");
+    assert_eq!(receipt.status, mpp::ReceiptStatus::Success);
+
+    // The sponsor, not the wallet, is the on-chain fee payer.
+    let provider_http =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc.parse().unwrap());
+    let tx_hash: B256 = receipt.reference.parse().expect("receipt ref is a tx hash");
+    let chain_receipt = wait_for_receipt(&provider_http, tx_hash)
+        .await
+        .expect("on-chain receipt");
+    assert_eq!(
+        chain_receipt.fee_payer, sponsor_addr,
+        "sponsor must be the on-chain fee payer for the keychain charge"
+    );
+
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
Sponsors now dry-run fee-payer transactions via `tempo_simulateV1` before broadcasting, rejecting reverts so they don't pay gas for failing txs.

Part of OSS-314