### PR TITLE
fix: bump tempo dependency pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,9 +85,9 @@ alloy-sol-type-parser = { version = "=1.6.0", optional = true }
 alloy-sol-types = { version = "=1.6.0", optional = true }
 
 # Tempo dependencies (optional)
-tempo-alloy = { version = "=1.8.0", optional = true }
-tempo-primitives = { version = "=1.8.0", optional = true }
-tempo-contracts = { version = "=1.8.0", optional = true }
+tempo-alloy = { version = "1.8.1", optional = true }
+tempo-primitives = { version = "1.8.1", optional = true }
+tempo-contracts = { version = "1.8.1", optional = true }
 
 # HTTP client dependencies (optional)
 reqwest = { version = "0.13", default-features = false, features = ["json"], optional = true }


### PR DESCRIPTION
Updates the `tempo-alloy`, `tempo-primitives`, and `tempo-contracts` dependency requirements from exact `=1.8.0` pins to `1.8.1`.

The exact pins prevented downstream workspaces from unifying on the latest Tempo crate release, which could leave two incompatible `tempo_primitives` sources in the same build graph. Using the current published Tempo crate version lets downstream consumers resolve a single compatible set while keeping the requirement explicit.