### PR TITLE
feat: Tower retryable 402 challenges

### DIFF
--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -173,37 +173,32 @@ where
             let credential = match auth_header {
                 Some(c) => c,
                 None => {
-                    // No credential — return 402 with challenge.
-                    let challenge = match verifier.challenge() {
-                        Ok(c) => c,
-                        Err(e) => {
-                            return Ok(error_response(
-                                StatusCode::INTERNAL_SERVER_ERROR,
-                                &format!("Failed to generate challenge: {}", e),
-                            ));
-                        }
-                    };
-                    let mut resp = Response::new(ResBody::default());
-                    *resp.status_mut() = StatusCode::PAYMENT_REQUIRED;
-                    resp.headers_mut().insert(
-                        WWW_AUTHENTICATE_HEADER,
-                        HeaderValue::from_str(&challenge)
-                            .unwrap_or_else(|_| HeaderValue::from_static("Payment")),
-                    );
-                    resp.headers_mut()
-                        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
-                    return Ok(resp);
+                    // No credential — return a fresh, retryable 402 challenge.
+                    return Ok(match verifier.challenge() {
+                        Ok(challenge) => challenge_response(&challenge),
+                        Err(e) => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            &format!("Failed to generate challenge: {}", e),
+                        ),
+                    });
                 }
             };
 
             // Verify the credential.
             let receipt_header = match verifier.verify(&credential).await {
                 Ok(r) => r,
-                Err(e) => {
-                    return Ok(error_response(
-                        StatusCode::PAYMENT_REQUIRED,
-                        &format!("Payment verification failed: {}", e),
-                    ));
+                Err(_e) => {
+                    // Verification failed — per the Payment auth spec, return a
+                    // fresh, retryable 402 carrying a new `WWW-Authenticate`
+                    // challenge (not a dead-end bare 402) so the client can pay
+                    // again. Mirrors the no-credential path above.
+                    return Ok(match verifier.challenge() {
+                        Ok(challenge) => challenge_response(&challenge),
+                        Err(e) => error_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            &format!("Failed to generate challenge: {}", e),
+                        ),
+                    });
                 }
             };
 
@@ -224,6 +219,24 @@ where
 fn error_response<B: Default>(status: StatusCode, _message: &str) -> Response<B> {
     let mut resp = Response::new(B::default());
     *resp.status_mut() = status;
+    resp
+}
+
+/// Build a retryable `402 Payment Required` response carrying a fresh
+/// `WWW-Authenticate: Payment` challenge and `Cache-Control: no-store`.
+///
+/// Used for both the no-credential and failed-verification paths so that a
+/// client always receives a usable challenge it can pay against, per the
+/// Payment authentication scheme.
+fn challenge_response<B: Default>(challenge: &str) -> Response<B> {
+    let mut resp = Response::new(B::default());
+    *resp.status_mut() = StatusCode::PAYMENT_REQUIRED;
+    resp.headers_mut().insert(
+        WWW_AUTHENTICATE_HEADER,
+        HeaderValue::from_str(challenge).unwrap_or_else(|_| HeaderValue::from_static("Payment")),
+    );
+    resp.headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
     resp
 }
 
@@ -485,9 +498,14 @@ mod tests {
         );
     }
 
-    /// Test: invalid auth → 402 error.
+    /// Test: invalid auth → retryable 402 with a fresh challenge.
+    ///
+    /// A failed credential must yield a 402 that carries a new
+    /// `WWW-Authenticate: Payment` challenge and `Cache-Control: no-store`,
+    /// so the client can pay again. A bare 402 (no challenge) is a dead end
+    /// the Payment auth scheme — and this SDK's own client — reject.
     #[tokio::test]
-    async fn test_service_invalid_auth_returns_402() {
+    async fn test_service_invalid_auth_returns_retryable_402() {
         use tower_service::Service;
 
         let layer = PaymentLayer::new(MockVerifier {
@@ -523,6 +541,16 @@ mod tests {
 
         let resp = svc.call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        // Must carry a fresh challenge so the client can retry.
+        assert_eq!(
+            resp.headers().get(WWW_AUTHENTICATE_HEADER).unwrap(),
+            "Payment id=\"challenge\""
+        );
+        // 402 responses must not be cached.
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-store"
+        );
     }
 
     // ==================== Real ChargeVerifier tests ====================


### PR DESCRIPTION
Tower returned a bare 402 on verification failure (no `WWW-Authenticate`, no `Cache-Control`). Now returns a retryable 402 with a fresh challenge + `Cache-Control: no-store`, per spec (draft-httpauth-payment-00 §4.4.2, §11.10).