### PR TITLE
feat: Cache-Control private on receipt responses

### DIFF
--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -96,6 +96,27 @@ pub const PAYMENT_RECEIPT_HEADER: &str = "payment-receipt";
 /// Scheme identifier for the Payment authentication scheme
 pub const PAYMENT_SCHEME: &str = "Payment";
 
+/// Merge a `private` directive into an existing `Cache-Control` value.
+///
+/// Receipt responses MUST be `Cache-Control: private` (draft-httpauth-payment-00
+/// §11.10). Empty/none → `"private"`; already-private → unchanged; otherwise
+/// `, private` is appended, preserving other directives. Mirrors mppx.
+pub fn with_private_cache_control(value: Option<&str>) -> String {
+    match value {
+        Some(v) if !v.trim().is_empty() => {
+            let has_private = v
+                .split(',')
+                .any(|directive| directive.trim().eq_ignore_ascii_case("private"));
+            if has_private {
+                v.to_string()
+            } else {
+                format!("{v}, private")
+            }
+        }
+        _ => "private".to_string(),
+    }
+}
+
 /// Parse key="value" pairs from an auth-param string.
 ///
 /// This is a simple parser that handles:
@@ -526,6 +547,32 @@ mod tests {
     use super::*;
     use crate::protocol::core::types::{PayloadType, ReceiptStatus};
     use crate::protocol::core::PaymentPayload;
+
+    #[test]
+    fn test_with_private_cache_control() {
+        // No existing value → "private".
+        assert_eq!(with_private_cache_control(None), "private");
+        // Empty / whitespace-only existing value → "private".
+        assert_eq!(with_private_cache_control(Some("")), "private");
+        assert_eq!(with_private_cache_control(Some("   ")), "private");
+        // Other directives preserved, `private` appended.
+        assert_eq!(
+            with_private_cache_control(Some("no-store")),
+            "no-store, private"
+        );
+        assert_eq!(
+            with_private_cache_control(Some("public, max-age=60")),
+            "public, max-age=60, private"
+        );
+        // Already private → returned unchanged (no duplicate).
+        assert_eq!(with_private_cache_control(Some("private")), "private");
+        assert_eq!(
+            with_private_cache_control(Some("private, max-age=0")),
+            "private, max-age=0"
+        );
+        // Detection is case-insensitive and whitespace-tolerant.
+        assert_eq!(with_private_cache_control(Some("  PRIVATE ")), "  PRIVATE ");
+    }
 
     fn test_challenge() -> PaymentChallenge {
         PaymentChallenge {

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -81,8 +81,8 @@ pub use challenge::{
 pub use headers::{
     extract_payment_scheme, format_authorization, format_receipt, format_www_authenticate,
     format_www_authenticate_many, parse_authorization, parse_receipt, parse_www_authenticate,
-    parse_www_authenticate_all, AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME,
-    WWW_AUTHENTICATE_HEADER,
+    parse_www_authenticate_all, with_private_cache_control, AUTHORIZATION_HEADER,
+    PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
 };
 
 pub use types::{

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -77,8 +77,8 @@ use http_types::{header, HeaderValue, StatusCode};
 #[cfg(any(feature = "stripe", feature = "tempo"))]
 use crate::protocol::core::headers::parse_authorization;
 use crate::protocol::core::headers::{
-    extract_payment_scheme, format_receipt, format_www_authenticate, PAYMENT_RECEIPT_HEADER,
-    WWW_AUTHENTICATE_HEADER,
+    extract_payment_scheme, format_receipt, format_www_authenticate, with_private_cache_control,
+    PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
 };
 use crate::protocol::core::{PaymentChallenge, Receipt};
 
@@ -544,6 +544,19 @@ impl<T: IntoResponse> IntoResponse for WithReceipt<T> {
         if let Ok(header_val) = format_receipt(&self.receipt) {
             if let Ok(val) = HeaderValue::from_str(&header_val) {
                 resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
+
+                // Receipt responses MUST be Cache-Control: private (spec §11.10).
+                let existing_cc = resp
+                    .headers()
+                    .get_all(header::CACHE_CONTROL)
+                    .iter()
+                    .filter_map(|v| v.to_str().ok())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
+                if let Ok(cc) = HeaderValue::from_str(&cache_control) {
+                    resp.headers_mut().insert(header::CACHE_CONTROL, cc);
+                }
             }
         }
         resp
@@ -708,6 +721,11 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
         assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+        // Per spec, receipt responses must be Cache-Control: private.
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "private"
+        );
     }
 
     #[test]

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -29,7 +29,7 @@ use http_types::{header, HeaderValue, Request, Response, StatusCode};
 
 use crate::protocol::core::headers::{
     extract_payment_scheme, format_receipt, format_www_authenticate, parse_authorization,
-    PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
+    with_private_cache_control, PAYMENT_RECEIPT_HEADER, WWW_AUTHENTICATE_HEADER,
 };
 
 /// Trait for payment verification in middleware context.
@@ -209,6 +209,19 @@ where
 
             // Call the inner service.
             let mut resp = inner.call(req).await?;
+
+            // Receipt responses MUST be Cache-Control: private (spec §11.10).
+            let existing_cc = resp
+                .headers()
+                .get_all(header::CACHE_CONTROL)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .collect::<Vec<_>>()
+                .join(", ");
+            let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
+            if let Ok(val) = HeaderValue::from_str(&cache_control) {
+                resp.headers_mut().insert(header::CACHE_CONTROL, val);
+            }
 
             // Attach the receipt header.
             if let Ok(val) = HeaderValue::from_str(&receipt_header) {
@@ -482,6 +495,11 @@ mod tests {
         assert_eq!(
             resp.headers().get(PAYMENT_RECEIPT_HEADER).unwrap(),
             "mock-receipt-token"
+        );
+        // Per spec, receipt responses must be Cache-Control: private.
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "private"
         );
     }
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -30,7 +30,9 @@
 //! ```
 
 use crate::error::MppError;
-use crate::protocol::core::{PaymentChallenge, PaymentCredential, Receipt};
+use crate::protocol::core::{
+    with_private_cache_control, PaymentChallenge, PaymentCredential, Receipt,
+};
 
 /// Context passed to [`Transport::respond_challenge`].
 pub struct ChallengeContext<'a, I> {
@@ -155,6 +157,22 @@ impl Transport for HttpTransport {
             crate::protocol::core::format_receipt(ctx.receipt).unwrap_or_else(|_| String::new());
 
         let mut resp = ctx.response;
+
+        // Receipt responses MUST be Cache-Control: private (spec §11.10),
+        // merged across any existing directives.
+        let existing_cc = resp
+            .headers()
+            .get_all(http_types::header::CACHE_CONTROL)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
+        if let Ok(value) = http_types::HeaderValue::from_str(&cache_control) {
+            resp.headers_mut()
+                .insert(http_types::header::CACHE_CONTROL, value);
+        }
+
         if let Ok(value) = http_types::HeaderValue::from_str(&receipt_header) {
             resp.headers_mut()
                 .insert(crate::protocol::core::PAYMENT_RECEIPT_HEADER, value);
@@ -310,5 +328,68 @@ mod tests {
             .headers()
             .get(crate::protocol::core::PAYMENT_RECEIPT_HEADER)
             .is_some());
+        // Per spec, receipt responses must be Cache-Control: private.
+        assert_eq!(
+            resp.headers()
+                .get(http_types::header::CACHE_CONTROL)
+                .unwrap(),
+            "private"
+        );
+    }
+
+    #[test]
+    fn test_http_respond_receipt_merges_existing_cache_control() {
+        let transport = http();
+        let receipt = Receipt::success("tempo", "0xabc123");
+
+        let resp = http_types::Response::builder()
+            .status(http_types::StatusCode::OK)
+            .header(http_types::header::CACHE_CONTROL, "no-store")
+            .body("ok".to_string())
+            .unwrap();
+
+        let resp = transport.respond_receipt(ReceiptContext {
+            challenge_id: "ch-1",
+            receipt: &receipt,
+            response: resp,
+        });
+
+        // Existing directive preserved, `private` appended (not overwritten).
+        assert_eq!(
+            resp.headers()
+                .get(http_types::header::CACHE_CONTROL)
+                .unwrap(),
+            "no-store, private"
+        );
+    }
+
+    #[test]
+    fn test_http_respond_receipt_merges_multiple_cache_control_values() {
+        let transport = http();
+        let receipt = Receipt::success("tempo", "0xabc123");
+
+        // Two separate Cache-Control header lines (both valid HTTP).
+        let resp = http_types::Response::builder()
+            .status(http_types::StatusCode::OK)
+            .header(http_types::header::CACHE_CONTROL, "no-cache")
+            .header(http_types::header::CACHE_CONTROL, "max-age=60")
+            .body("ok".to_string())
+            .unwrap();
+
+        let resp = transport.respond_receipt(ReceiptContext {
+            challenge_id: "ch-1",
+            receipt: &receipt,
+            response: resp,
+        });
+
+        // Both existing directives preserved (not dropped) and `private` added,
+        // collapsed into a single normalized header value.
+        let values: Vec<_> = resp
+            .headers()
+            .get_all(http_types::header::CACHE_CONTROL)
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(values, vec!["no-cache, max-age=60, private"]);
     }
 }


### PR DESCRIPTION
Responses that include a `Payment-Receipt` header were missing a `Cache-Control` header, which could let a shared cache/CDN store one user's paid response and serve it to someone else.

This adds `Cache-Control: private` whenever a receipt is attached, across the three server surfaces (core transport, Tower, axum). Existing `Cache-Control` directives are preserved (merged, not overwritten). Required by the spec (draft-httpauth-payment-00 §11.10).