### PR TITLE
feat: RFC 9457 problem+json on payment challenges

### DIFF
--- a/.changelog/problem-details-on-challenge.md
+++ b/.changelog/problem-details-on-challenge.md
@@ -1,0 +1,24 @@
+---
+mpp: major
+---
+
+Payment challenge/re-challenge `402` responses now carry an RFC 9457
+`application/problem+json` body whose `type` reflects the specific failure
+(`malformed-credential`, `verification-failed`, `payment-expired`, etc.), per
+draft-httpauth-payment-00 §5.3.1. Bare challenges use a `payment-required`
+problem.
+
+Breaking changes for custom server integrations:
+
+- `ChallengeContext.error` is now `Option<&MppError>` (was `Option<&str>`), so
+  `Transport` implementations carry the typed error to the response layer.
+- `PaymentRequired` is now a struct `{ challenge, error: Option<MppError> }` with
+  `PaymentRequired::new(challenge)` and `PaymentRequired::with_error(challenge, error)`
+  constructors (was a `PaymentRequired(PaymentChallenge)` tuple).
+- `ChargeChallenger::{challenge, verify_payment, verify_payment_for_amount}` now
+  return `MppError` instead of `String`.
+
+Wire change: the HTTP transport and axum extractor previously returned
+`application/json` `{"error": ...}` bodies on `402`; they now return
+`application/problem+json` RFC 9457 documents. The Tower middleware is
+unaffected (its generic response body cannot carry a JSON document).

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,6 +115,17 @@ impl PaymentErrorDetails {
         self.challenge_id = Some(id.into());
         self
     }
+
+    /// Standard RFC 9457 problem for a bare `402` payment challenge (no prior
+    /// error). Used when a server advertises a challenge without a specific
+    /// failure to report.
+    pub fn payment_required(challenge_id: impl Into<String>) -> Self {
+        Self::core("payment-required")
+            .with_title("Payment Required")
+            .with_status(402)
+            .with_detail("Payment is required.")
+            .with_challenge_id(challenge_id)
+    }
 }
 
 /// Trait for errors that can be converted to RFC 9457 Problem Details.

--- a/src/protocol/traits/mod.rs
+++ b/src/protocol/traits/mod.rs
@@ -11,6 +11,8 @@
 mod charge;
 mod session;
 
+use crate::error::{MppError, PaymentError, PaymentErrorDetails};
+
 pub use charge::ChargeMethod;
 pub use session::SessionMethod;
 
@@ -259,29 +261,30 @@ impl From<&str> for VerificationError {
 
 // ==================== Conversion to RFC 9457 Problem Details ====================
 
-use crate::error::{MppError, PaymentError, PaymentErrorDetails};
-
 impl From<VerificationError> for MppError {
     fn from(err: VerificationError) -> Self {
+        // Preserve each code's specific RFC 9457 problem type instead of
+        // collapsing to `verification-failed`. Core codes follow
+        // `ErrorCode::spec_code()`; session/channel codes keep `session/*`.
         match err.code {
-            Some(ErrorCode::Expired) => MppError::PaymentExpired(None),
-            Some(ErrorCode::InvalidCredential) => MppError::MalformedCredential(Some(err.message)),
+            Some(ErrorCode::Expired) => MppError::PaymentExpired(Some(err.message)),
+            Some(ErrorCode::InvalidCredential)
+            | Some(ErrorCode::CredentialMismatch)
+            | Some(ErrorCode::InvalidPayload) => MppError::MalformedCredential(Some(err.message)),
+            Some(ErrorCode::InvalidAmount) => MppError::PaymentInsufficient(Some(err.message)),
+            Some(ErrorCode::ChainIdMismatch) => MppError::UnsupportedPaymentMethod(err.message),
             Some(ErrorCode::ChannelNotFound) => MppError::ChannelNotFound(Some(err.message)),
             Some(ErrorCode::ChannelClosed) => MppError::ChannelClosed(Some(err.message)),
             Some(ErrorCode::InsufficientBalance) => {
                 MppError::InsufficientBalance(Some(err.message))
             }
-            Some(ErrorCode::InvalidPayload) => MppError::InvalidPayload(Some(err.message)),
             Some(ErrorCode::InvalidSignature) => MppError::InvalidSignature(Some(err.message)),
             Some(ErrorCode::AmountExceedsDeposit) => {
                 MppError::AmountExceedsDeposit(Some(err.message))
             }
             Some(ErrorCode::DeltaTooSmall) => MppError::DeltaTooSmall(Some(err.message)),
-            Some(ErrorCode::CredentialMismatch)
-            | Some(ErrorCode::InvalidAmount)
-            | Some(ErrorCode::InvalidRecipient)
+            Some(ErrorCode::InvalidRecipient)
             | Some(ErrorCode::TransactionFailed)
-            | Some(ErrorCode::ChainIdMismatch)
             | Some(ErrorCode::NotFound)
             | Some(ErrorCode::NetworkError)
             | None => MppError::VerificationFailed(Some(err.message)),
@@ -333,5 +336,47 @@ mod tests {
             ErrorCode::TransactionFailed.spec_code(),
             "verification-failed"
         );
+    }
+
+    #[test]
+    fn test_verification_error_preserves_specific_problem_type() {
+        use crate::error::PaymentError;
+
+        // Locks the full mapping: every code keeps its specific problem type
+        // through `From<VerificationError>` rather than collapsing.
+        let cases = [
+            (ErrorCode::Expired, "payment-expired"),
+            (ErrorCode::InvalidCredential, "malformed-credential"),
+            (ErrorCode::CredentialMismatch, "malformed-credential"),
+            (ErrorCode::InvalidPayload, "malformed-credential"),
+            (ErrorCode::InvalidAmount, "payment-insufficient"),
+            (ErrorCode::ChainIdMismatch, "method-unsupported"),
+            (ErrorCode::ChannelNotFound, "channel-not-found"),
+            (ErrorCode::ChannelClosed, "channel-finalized"),
+            (ErrorCode::InsufficientBalance, "insufficient-balance"),
+            (ErrorCode::InvalidSignature, "invalid-signature"),
+            (ErrorCode::AmountExceedsDeposit, "amount-exceeds-deposit"),
+            (ErrorCode::DeltaTooSmall, "delta-too-small"),
+            (ErrorCode::InvalidRecipient, "verification-failed"),
+            (ErrorCode::TransactionFailed, "verification-failed"),
+            (ErrorCode::NotFound, "verification-failed"),
+            (ErrorCode::NetworkError, "verification-failed"),
+        ];
+
+        for (code, suffix) in cases {
+            let err = VerificationError::with_code("detail here", code);
+            let mpp_err = MppError::from(err);
+            let problem = mpp_err.to_problem_details(None);
+            assert!(
+                problem.problem_type.ends_with(suffix),
+                "{code:?} → {} (expected suffix {suffix})",
+                problem.problem_type
+            );
+            // The error detail must survive the conversion.
+            assert!(
+                problem.detail.contains("detail here"),
+                "{code:?} dropped detail"
+            );
+        }
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -74,6 +74,7 @@ use axum_core::extract::{FromRef, FromRequestParts};
 use axum_core::response::IntoResponse;
 use http_types::{header, HeaderValue, StatusCode};
 
+use crate::error::{MppError, PaymentError, PaymentErrorDetails};
 #[cfg(any(feature = "stripe", feature = "tempo"))]
 use crate::protocol::core::headers::parse_authorization;
 use crate::protocol::core::headers::{
@@ -94,21 +95,55 @@ use crate::protocol::core::{PaymentChallenge, Receipt};
 ///
 /// async fn handler() -> PaymentRequired {
 ///     let challenge = mpp.charge("1.00").unwrap();
-///     PaymentRequired(challenge)
+///     PaymentRequired::new(challenge)
 /// }
 /// ```
 #[derive(Debug)]
-pub struct PaymentRequired(pub PaymentChallenge);
+pub struct PaymentRequired {
+    /// The challenge to advertise in `WWW-Authenticate`.
+    pub challenge: PaymentChallenge,
+    /// The typed error that triggered this response, if any.
+    ///
+    /// When `Some`, the body is rendered as that error's RFC 9457 problem
+    /// document; when `None` (a fresh challenge), `payment-required` is used.
+    pub error: Option<MppError>,
+}
+
+impl PaymentRequired {
+    /// Create a fresh-challenge response (no prior error → `payment-required`).
+    pub fn new(challenge: PaymentChallenge) -> Self {
+        Self {
+            challenge,
+            error: None,
+        }
+    }
+
+    /// Create a re-challenge response carrying the error that caused it.
+    pub fn with_error(challenge: PaymentChallenge, error: MppError) -> Self {
+        Self {
+            challenge,
+            error: Some(error),
+        }
+    }
+}
 
 impl IntoResponse for PaymentRequired {
     fn into_response(self) -> axum_core::response::Response {
-        match format_www_authenticate(&self.0) {
+        match format_www_authenticate(&self.challenge) {
             Ok(www_auth) => {
-                let mut resp = (
-                    StatusCode::PAYMENT_REQUIRED,
-                    serde_json::json!({ "error": "Payment Required" }).to_string(),
-                )
-                    .into_response();
+                // RFC 9457 problem body: the specific error's type when present,
+                // otherwise a generic `payment-required` challenge.
+                let mut problem = match &self.error {
+                    Some(err) => err.to_problem_details(Some(self.challenge.id.as_str())),
+                    None => PaymentErrorDetails::payment_required(self.challenge.id.as_str()),
+                };
+                // This is always a 402 re-challenge; keep the problem `status` in
+                // sync with the HTTP status (some errors otherwise carry 400/410).
+                problem.status = 402;
+                let body = serde_json::to_string(&problem)
+                    .expect("PaymentErrorDetails serialization cannot fail");
+
+                let mut resp = (StatusCode::PAYMENT_REQUIRED, body).into_response();
                 resp.headers_mut().insert(
                     WWW_AUTHENTICATE_HEADER,
                     HeaderValue::from_str(&www_auth)
@@ -116,7 +151,7 @@ impl IntoResponse for PaymentRequired {
                 );
                 resp.headers_mut().insert(
                     header::CONTENT_TYPE,
-                    HeaderValue::from_static("application/json"),
+                    HeaderValue::from_static("application/problem+json"),
                 );
                 resp.headers_mut()
                     .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
@@ -250,13 +285,16 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         &self,
         amount: &str,
         options: ChallengeOptions,
-    ) -> Result<PaymentChallenge, String>;
+    ) -> Result<PaymentChallenge, MppError>;
 
     /// Verify a credential string and return a receipt.
+    ///
+    /// Errors are returned as a typed [`MppError`] so the rejection can render
+    /// the correct RFC 9457 problem `type` on the retry challenge.
     fn verify_payment(
         &self,
         credential_str: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>;
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>;
 
     /// Verify a credential string against the route's expected dollar amount.
     ///
@@ -267,7 +305,8 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         &self,
         credential_str: &str,
         _amount: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
+    {
         self.verify_payment(credential_str)
     }
 }
@@ -282,7 +321,7 @@ where
         &self,
         amount: &str,
         options: ChallengeOptions,
-    ) -> Result<PaymentChallenge, String> {
+    ) -> Result<PaymentChallenge, MppError> {
         self.charge_with_options(
             amount,
             super::ChargeOptions {
@@ -290,19 +329,18 @@ where
                 ..Default::default()
             },
         )
-        .map_err(|e| e.to_string())
     }
 
     fn verify_payment(
         &self,
         credential_str: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
+    {
         let credential = match parse_authorization(credential_str) {
             Ok(c) => c,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Invalid credential: {}",
-                    e
+                return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                    Some(e.to_string()),
                 ))))
             }
         };
@@ -310,7 +348,7 @@ where
         Box::pin(async move {
             super::Mpp::verify_credential(&mpp, &credential)
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(MppError::from)
         })
     }
 
@@ -318,34 +356,29 @@ where
         &self,
         credential_str: &str,
         amount: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
+    {
         let credential = match parse_authorization(credential_str) {
             Ok(c) => c,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Invalid credential: {}",
-                    e
+                return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                    Some(e.to_string()),
                 ))))
             }
         };
 
         let expected_challenge = match self.charge(amount) {
             Ok(challenge) => challenge,
-            Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Failed to generate expected challenge: {}",
-                    e
-                ))))
-            }
+            Err(e) => return Box::pin(std::future::ready(Err(e))),
         };
 
         let expected_request = match expected_challenge.request.decode() {
             Ok(request) => request,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
+                return Box::pin(std::future::ready(Err(MppError::InvalidConfig(format!(
                     "Failed to decode expected request: {}",
                     e
-                ))))
+                )))))
             }
         };
 
@@ -357,7 +390,7 @@ where
                 &expected_request,
             )
             .await
-            .map_err(|e| e.to_string())
+            .map_err(MppError::from)
         })
     }
 }
@@ -371,7 +404,7 @@ where
         &self,
         amount: &str,
         options: ChallengeOptions,
-    ) -> Result<PaymentChallenge, String> {
+    ) -> Result<PaymentChallenge, MppError> {
         self.stripe_charge_with_options(
             amount,
             super::StripeChargeOptions {
@@ -379,19 +412,18 @@ where
                 ..Default::default()
             },
         )
-        .map_err(|e| e.to_string())
     }
 
     fn verify_payment(
         &self,
         credential_str: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
+    {
         let credential = match parse_authorization(credential_str) {
             Ok(c) => c,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Invalid credential: {}",
-                    e
+                return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                    Some(e.to_string()),
                 ))))
             }
         };
@@ -399,7 +431,7 @@ where
         Box::pin(async move {
             super::Mpp::verify_credential(&mpp, &credential)
                 .await
-                .map_err(|e| e.to_string())
+                .map_err(MppError::from)
         })
     }
 
@@ -407,34 +439,29 @@ where
         &self,
         credential_str: &str,
         amount: &str,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
+    {
         let credential = match parse_authorization(credential_str) {
             Ok(c) => c,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Invalid credential: {}",
-                    e
+                return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                    Some(e.to_string()),
                 ))))
             }
         };
 
         let expected_challenge = match self.stripe_charge(amount) {
             Ok(challenge) => challenge,
-            Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
-                    "Failed to generate expected challenge: {}",
-                    e
-                ))))
-            }
+            Err(e) => return Box::pin(std::future::ready(Err(e))),
         };
 
         let expected_request = match expected_challenge.request.decode() {
             Ok(request) => request,
             Err(e) => {
-                return Box::pin(std::future::ready(Err(format!(
+                return Box::pin(std::future::ready(Err(MppError::InvalidConfig(format!(
                     "Failed to decode expected request: {}",
                     e
-                ))))
+                )))))
             }
         };
 
@@ -446,7 +473,7 @@ where
                 &expected_request,
             )
             .await
-            .map_err(|e| e.to_string())
+            .map_err(MppError::from)
         })
     }
 }
@@ -464,12 +491,18 @@ where
         state: &S,
     ) -> impl std::future::Future<Output = Result<Self, Self::Rejection>> + Send {
         let challenger: Arc<dyn ChargeChallenger> = FromRef::from_ref(state);
-        let auth_header = parts
-            .headers
-            .get(header::AUTHORIZATION)
-            .and_then(|v| v.to_str().ok())
-            .and_then(extract_payment_scheme)
-            .map(|s| s.to_string());
+        // A non-UTF-8 Authorization header is a malformed credential, not an
+        // absent one; preserve that so it re-challenges as `malformed-credential`.
+        let auth_header: Result<Option<String>, MppError> =
+            match parts.headers.get(header::AUTHORIZATION) {
+                None => Ok(None),
+                Some(v) => match v.to_str() {
+                    Ok(s) => Ok(extract_payment_scheme(s).map(|s| s.to_string())),
+                    Err(e) => Err(MppError::MalformedCredential(Some(format!(
+                        "invalid header: {e}"
+                    )))),
+                },
+            };
 
         async move {
             let options = ChallengeOptions {
@@ -477,12 +510,22 @@ where
             };
 
             let credential_str = match auth_header {
-                Some(c) => c,
-                None => {
+                Ok(Some(c)) => c,
+                Ok(None) => {
                     let challenge = challenger
                         .challenge(C::amount(), options)
-                        .map_err(MppChargeRejection::InternalError)?;
-                    return Err(MppChargeRejection::Challenge(PaymentRequired(challenge)));
+                        .map_err(|e| MppChargeRejection::InternalError(e.to_string()))?;
+                    return Err(MppChargeRejection::Challenge(PaymentRequired::new(
+                        challenge,
+                    )));
+                }
+                Err(err) => {
+                    let challenge = challenger
+                        .challenge(C::amount(), options)
+                        .map_err(|e| MppChargeRejection::InternalError(e.to_string()))?;
+                    return Err(MppChargeRejection::VerificationFailed(
+                        PaymentRequired::with_error(challenge, err),
+                    ));
                 }
             };
 
@@ -491,13 +534,15 @@ where
                 .await
             {
                 Ok(r) => r,
-                Err(_) => {
+                Err(err) => {
+                    // Re-challenge, carrying the typed error so the response
+                    // renders the correct RFC 9457 problem type.
                     let challenge = challenger
                         .challenge(C::amount(), options)
-                        .map_err(MppChargeRejection::InternalError)?;
-                    return Err(MppChargeRejection::VerificationFailed(PaymentRequired(
-                        challenge,
-                    )));
+                        .map_err(|e| MppChargeRejection::InternalError(e.to_string()))?;
+                    return Err(MppChargeRejection::VerificationFailed(
+                        PaymentRequired::with_error(challenge, err),
+                    ));
                 }
             };
 
@@ -574,7 +619,7 @@ mod tests {
             &self,
             amount: &str,
             _options: ChallengeOptions,
-        ) -> Result<PaymentChallenge, String> {
+        ) -> Result<PaymentChallenge, MppError> {
             Ok(PaymentChallenge::new(
                 "mock-id",
                 "mock-realm",
@@ -587,7 +632,7 @@ mod tests {
         fn verify_payment(
             &self,
             _credential_str: &str,
-        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>>
         {
             let accept = self.accept;
             Box::pin(async move {
@@ -600,7 +645,9 @@ mod tests {
                         external_id: None,
                     })
                 } else {
-                    Err("payment rejected".into())
+                    Err(MppError::VerificationFailed(Some(
+                        "payment rejected".into(),
+                    )))
                 }
             })
         }
@@ -616,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_payment_required_into_response() {
-        let resp = PaymentRequired(test_challenge()).into_response();
+        let resp = PaymentRequired::new(test_challenge()).into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
         assert_eq!(
@@ -626,28 +673,35 @@ mod tests {
     }
 
     #[test]
-    fn test_payment_required_has_json_content_type() {
-        let resp = PaymentRequired(test_challenge()).into_response();
+    fn test_payment_required_has_problem_json_content_type() {
+        let resp = PaymentRequired::new(test_challenge()).into_response();
         assert_eq!(
             resp.headers().get(header::CONTENT_TYPE).unwrap(),
-            "application/json"
+            "application/problem+json"
         );
     }
 
     #[test]
     fn test_rejection_challenge_returns_402_with_header() {
-        let rejection = MppChargeRejection::Challenge(PaymentRequired(test_challenge()));
+        let rejection = MppChargeRejection::Challenge(PaymentRequired::new(test_challenge()));
         let resp = rejection.into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
     }
 
     #[test]
-    fn test_rejection_verification_failed_returns_402_with_header() {
-        let rejection = MppChargeRejection::VerificationFailed(PaymentRequired(test_challenge()));
+    fn test_rejection_verification_failed_renders_problem_type() {
+        let rejection = MppChargeRejection::VerificationFailed(PaymentRequired::with_error(
+            test_challenge(),
+            MppError::PaymentExpired(Some("too late".into())),
+        ));
         let resp = rejection.into_response();
         assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
         assert!(resp.headers().contains_key(WWW_AUTHENTICATE_HEADER));
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
     }
 
     #[test]
@@ -783,6 +837,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extractor_non_utf8_header_is_malformed_not_absent() {
+        // A non-UTF-8 Authorization header must re-challenge as a malformed
+        // credential, not be silently treated as "no credential".
+        let state: Arc<dyn ChargeChallenger> = Arc::new(MockChallenger { accept: true });
+        let req = http_types::Request::builder()
+            .uri("/test")
+            .header(header::AUTHORIZATION, &[0xff, 0xfe][..])
+            .body(())
+            .unwrap();
+        let (mut parts, _body) = req.into_parts();
+        let result = MppCharge::<OneCent>::from_request_parts(&mut parts, &state).await;
+        let err = result.unwrap_err();
+        assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
+    }
+
+    #[tokio::test]
     async fn test_extractor_wrong_scheme_returns_challenge() {
         let result =
             run_extractor::<OneCent>(MockChallenger { accept: true }, Some("Bearer some-token"))
@@ -813,15 +889,18 @@ mod tests {
                 &self,
                 _amount: &str,
                 _options: ChallengeOptions,
-            ) -> Result<PaymentChallenge, String> {
-                Err("config error".into())
+            ) -> Result<PaymentChallenge, MppError> {
+                Err(MppError::InvalidConfig("config error".into()))
             }
             fn verify_payment(
                 &self,
                 _credential_str: &str,
-            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
-            {
-                Box::pin(std::future::ready(Err("unused".into())))
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>,
+            > {
+                Box::pin(std::future::ready(Err(MppError::VerificationFailed(Some(
+                    "unused".into(),
+                )))))
             }
         }
 
@@ -862,7 +941,7 @@ mod tests {
                 &self,
                 amount: &str,
                 _options: ChallengeOptions,
-            ) -> Result<PaymentChallenge, String> {
+            ) -> Result<PaymentChallenge, MppError> {
                 Ok(PaymentChallenge::new(
                     "mock-id",
                     "mock-realm",
@@ -875,19 +954,21 @@ mod tests {
             fn verify_payment(
                 &self,
                 _credential_str: &str,
-            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
-            {
-                Box::pin(std::future::ready(Err(
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>,
+            > {
+                Box::pin(std::future::ready(Err(MppError::VerificationFailed(Some(
                     "legacy verifier should not be called".into(),
-                )))
+                )))))
             }
 
             fn verify_payment_for_amount(
                 &self,
                 _credential_str: &str,
                 amount: &str,
-            ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Receipt, String>> + Send>>
-            {
+            ) -> std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<Receipt, MppError>> + Send>,
+            > {
                 *self.seen_amount.lock().unwrap() = Some(amount.to_string());
                 Box::pin(std::future::ready(Ok(Receipt {
                     status: crate::protocol::core::ReceiptStatus::Success,
@@ -977,32 +1058,34 @@ mod tests {
                 &self,
                 amount: &str,
                 options: ChallengeOptions,
-            ) -> Result<PaymentChallenge, String> {
-                self.mpp
-                    .charge_with_options(
-                        amount,
-                        crate::server::ChargeOptions {
-                            description: options.description,
-                            ..Default::default()
-                        },
-                    )
-                    .map_err(|e| e.to_string())
+            ) -> Result<PaymentChallenge, MppError> {
+                self.mpp.charge_with_options(
+                    amount,
+                    crate::server::ChargeOptions {
+                        description: options.description,
+                        ..Default::default()
+                    },
+                )
             }
 
             fn verify_payment(
                 &self,
                 credential_str: &str,
-            ) -> std::pin::Pin<Box<dyn Future<Output = Result<Receipt, String>> + Send>>
+            ) -> std::pin::Pin<Box<dyn Future<Output = Result<Receipt, MppError>> + Send>>
             {
                 let credential = match parse_authorization(credential_str) {
                     Ok(c) => c,
-                    Err(e) => return Box::pin(std::future::ready(Err(e.to_string()))),
+                    Err(e) => {
+                        return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                            Some(e.to_string()),
+                        ))))
+                    }
                 };
                 let mpp = self.mpp.clone();
                 Box::pin(async move {
                     mpp.verify_credential(&credential)
                         .await
-                        .map_err(|e| e.to_string())
+                        .map_err(MppError::from)
                 })
             }
 
@@ -1010,21 +1093,25 @@ mod tests {
                 &self,
                 credential_str: &str,
                 amount: &str,
-            ) -> std::pin::Pin<Box<dyn Future<Output = Result<Receipt, String>> + Send>>
+            ) -> std::pin::Pin<Box<dyn Future<Output = Result<Receipt, MppError>> + Send>>
             {
                 let credential = match parse_authorization(credential_str) {
                     Ok(c) => c,
-                    Err(e) => return Box::pin(std::future::ready(Err(e.to_string()))),
+                    Err(e) => {
+                        return Box::pin(std::future::ready(Err(MppError::MalformedCredential(
+                            Some(e.to_string()),
+                        ))))
+                    }
                 };
                 let expected = match self.mpp.charge(amount).and_then(|c| c.request.decode()) {
                     Ok(req) => req,
-                    Err(e) => return Box::pin(std::future::ready(Err(e.to_string()))),
+                    Err(e) => return Box::pin(std::future::ready(Err(e))),
                 };
                 let mpp = self.mpp.clone();
                 Box::pin(async move {
                     mpp.verify_credential_with_expected_request(&credential, &expected)
                         .await
-                        .map_err(|e| e.to_string())
+                        .map_err(MppError::from)
                 })
             }
         }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -1147,7 +1147,24 @@ mod tests {
                 .await
                 .expect_err("cross-route replay must be rejected");
             assert!(matches!(err, MppChargeRejection::VerificationFailed(_)));
-            assert_eq!(err.into_response().status(), StatusCode::PAYMENT_REQUIRED);
+
+            // The rendered 402 body must be the specific `malformed-credential`
+            // (binding check fails), not a generic `verification-failed`.
+            let resp = err.into_response();
+            assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+            assert_eq!(
+                resp.headers().get(header::CONTENT_TYPE).unwrap(),
+                "application/problem+json"
+            );
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let problem: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(
+                problem["type"],
+                "https://paymentauth.org/problems/malformed-credential"
+            );
+            assert_eq!(problem["status"], 402);
         }
 
         #[tokio::test]

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -29,7 +29,7 @@
 //! }
 //! ```
 
-use crate::error::MppError;
+use crate::error::{MppError, PaymentError, PaymentErrorDetails};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, Receipt};
 
 /// Context passed to [`Transport::respond_challenge`].
@@ -38,8 +38,11 @@ pub struct ChallengeContext<'a, I> {
     pub challenge: &'a PaymentChallenge,
     /// The original transport input (e.g., HTTP request).
     pub input: &'a I,
-    /// Optional error message for the client.
-    pub error: Option<&'a str>,
+    /// The typed error that triggered a re-challenge, if any.
+    ///
+    /// Carried as [`MppError`] so transports can render an RFC 9457
+    /// `application/problem+json` body with the correct problem `type`.
+    pub error: Option<&'a MppError>,
 }
 
 /// Context passed to [`Transport::respond_receipt`].
@@ -129,15 +132,22 @@ impl Transport for HttpTransport {
         let www_auth = crate::protocol::core::format_www_authenticate(ctx.challenge)
             .unwrap_or_else(|_| "Payment".to_string());
 
-        let body = match ctx.error {
-            Some(msg) => serde_json::json!({ "error": msg }).to_string(),
-            None => serde_json::json!({ "error": "Payment Required" }).to_string(),
+        // Render an RFC 9457 problem document. A specific error maps to its own
+        // problem `type`; a bare challenge (no prior error) uses `payment-required`.
+        let mut problem = match ctx.error {
+            Some(err) => err.to_problem_details(Some(ctx.challenge.id.as_str())),
+            None => PaymentErrorDetails::payment_required(ctx.challenge.id.as_str()),
         };
+        // This is always a 402 re-challenge; keep the problem `status` in sync
+        // with the HTTP status (some errors otherwise carry 400/410).
+        problem.status = 402;
+        let body =
+            serde_json::to_string(&problem).expect("PaymentErrorDetails serialization cannot fail");
 
         let mut resp = http_types::Response::builder()
             .status(http_types::StatusCode::PAYMENT_REQUIRED)
             .header(http_types::header::WWW_AUTHENTICATE, &www_auth)
-            .header(http_types::header::CONTENT_TYPE, "application/json")
+            .header(http_types::header::CONTENT_TYPE, "application/problem+json")
             .body(body)
             .expect("response builder cannot fail");
 
@@ -279,14 +289,102 @@ mod tests {
             .body(())
             .unwrap();
 
+        let err = MppError::VerificationFailed(Some("Verification failed".to_string()));
         let resp = transport.respond_challenge(ChallengeContext {
             challenge: &challenge,
             input: &req,
-            error: Some("Verification failed"),
+            error: Some(&err),
         });
 
         assert_eq!(resp.status(), http_types::StatusCode::PAYMENT_REQUIRED);
-        assert!(resp.body().contains("Verification failed"));
+        assert_eq!(
+            resp.headers()
+                .get(http_types::header::CONTENT_TYPE)
+                .unwrap(),
+            "application/problem+json"
+        );
+        // RFC 9457 problem body carries the correct type, status, detail, and id.
+        let problem: serde_json::Value = serde_json::from_str(resp.body()).unwrap();
+        assert_eq!(
+            problem["type"],
+            "https://paymentauth.org/problems/verification-failed"
+        );
+        assert_eq!(problem["status"], 402);
+        assert_eq!(problem["challengeId"], "test-id");
+        assert!(problem["detail"]
+            .as_str()
+            .unwrap()
+            .contains("Verification failed"));
+    }
+
+    #[test]
+    fn test_http_respond_challenge_normalizes_status_to_402() {
+        // A problem whose default status is 400/410 must still report 402 on the
+        // 402 re-challenge path, in sync with the HTTP status.
+        let transport = http();
+        let challenge = PaymentChallenge::new(
+            "test-id",
+            "test.example.com",
+            "tempo",
+            "charge",
+            crate::protocol::core::Base64UrlJson::from_value(
+                &serde_json::json!({"amount": "1000"}),
+            )
+            .unwrap(),
+        );
+        let req = http_types::Request::builder()
+            .uri("/test")
+            .body(())
+            .unwrap();
+
+        // BadRequest defaults to HTTP 400 in to_problem_details().
+        let err = MppError::BadRequest(Some("bad".to_string()));
+        let resp = transport.respond_challenge(ChallengeContext {
+            challenge: &challenge,
+            input: &req,
+            error: Some(&err),
+        });
+
+        assert_eq!(resp.status(), http_types::StatusCode::PAYMENT_REQUIRED);
+        let problem: serde_json::Value = serde_json::from_str(resp.body()).unwrap();
+        assert_eq!(problem["status"], 402);
+        assert_eq!(
+            problem["type"],
+            "https://paymentauth.org/problems/bad-request"
+        );
+    }
+
+    #[test]
+    fn test_http_respond_challenge_bare_uses_payment_required() {
+        let transport = http();
+        let challenge = PaymentChallenge::new(
+            "test-id",
+            "test.example.com",
+            "tempo",
+            "charge",
+            crate::protocol::core::Base64UrlJson::from_value(
+                &serde_json::json!({"amount": "1000"}),
+            )
+            .unwrap(),
+        );
+        let req = http_types::Request::builder()
+            .uri("/test")
+            .body(())
+            .unwrap();
+
+        let resp = transport.respond_challenge(ChallengeContext {
+            challenge: &challenge,
+            input: &req,
+            error: None,
+        });
+
+        let problem: serde_json::Value = serde_json::from_str(resp.body()).unwrap();
+        assert_eq!(
+            problem["type"],
+            "https://paymentauth.org/problems/payment-required"
+        );
+        assert_eq!(problem["status"], 402);
+        assert_eq!(problem["challengeId"], "test-id");
     }
 
     #[test]

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -32,7 +32,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::error::MppError;
+use crate::error::{MppError, PaymentError};
 use crate::protocol::core::PaymentCredential;
 
 use super::transport::{ChallengeContext, ReceiptContext, Transport};
@@ -147,7 +147,11 @@ impl Transport for WsTransport {
 
         WsResponse::Challenge {
             challenge: challenge_json,
-            error: ctx.error.map(|s| s.to_string()),
+            // WS frames already carry JSON, so we surface the human-readable
+            // problem detail rather than a separate problem+json document.
+            error: ctx
+                .error
+                .map(|e| e.to_problem_details(Some(ctx.challenge.id.as_str())).detail),
         }
     }
 


### PR DESCRIPTION
402 challenge/re-challenge responses now return an RFC 9457 `application/problem+json` body typed by the failure (`malformed-credential`, `verification-failed`, etc.), instead of generic `application/json {"error":...}`.

**Breaking Change:**
- `ChallengeContext.error`: `Option<&str>` → `Option<&MppError>`
- `PaymentRequired`: tuple → struct `{ challenge, error }` (use `new`/`with_error`)
- `ChargeChallenger::{challenge,verify_payment,verify_payment_for_amount}` return `MppError` not `String`
- HTTP 402 body/content-type changed (wire break)

Only affects code that hand-implements `Transport`/`ChargeChallenger` or parses the old 402 body. Tower middleware unchanged.