### PR TITLE
feat: add Receipt.subscriptionId

### DIFF
--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -790,7 +790,8 @@ impl PaymentCredential {
 
 /// Payment receipt from server (parsed from Payment-Receipt header).
 ///
-/// Per IETF spec, contains: status, method, timestamp, reference.
+/// Per IETF spec, contains: status, method, timestamp, reference. Payment
+/// methods MAY add fields; the Tempo subscription method adds `subscriptionId`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Receipt {
     /// Receipt status ("success" or "failed")
@@ -808,6 +809,11 @@ pub struct Receipt {
     /// Merchant correlation reference, echoed from the credential payload.
     #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
+
+    /// Server-issued subscription identifier, present on receipts for the
+    /// subscription intent (activation and renewal).
+    #[serde(rename = "subscriptionId", skip_serializing_if = "Option::is_none")]
+    pub subscription_id: Option<String>,
 }
 
 impl Receipt {
@@ -820,6 +826,7 @@ impl Receipt {
             timestamp: now_iso8601(),
             reference: reference.into(),
             external_id: None,
+            subscription_id: None,
         }
     }
 
@@ -827,6 +834,13 @@ impl Receipt {
     #[must_use]
     pub fn with_external_id(mut self, external_id: impl Into<String>) -> Self {
         self.external_id = Some(external_id.into());
+        self
+    }
+
+    /// Set the server-issued subscription identifier.
+    #[must_use]
+    pub fn with_subscription_id(mut self, subscription_id: impl Into<String>) -> Self {
+        self.subscription_id = Some(subscription_id.into());
         self
     }
 
@@ -1073,6 +1087,7 @@ mod tests {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             reference: "0xabc".to_string(),
             external_id: None,
+            subscription_id: None,
         };
         assert!(success.is_success());
         assert!(success.external_id.is_none());
@@ -1092,6 +1107,22 @@ mod tests {
         let bare = Receipt::success("tempo", "0xabc");
         let bare_json = serde_json::to_string(&bare).unwrap();
         assert!(!bare_json.contains("externalId"));
+    }
+
+    #[test]
+    fn test_receipt_with_subscription_id() {
+        let receipt = Receipt::success("tempo", "0xabc").with_subscription_id("sub_123");
+        assert_eq!(receipt.subscription_id.as_deref(), Some("sub_123"));
+
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(json.contains("\"subscriptionId\":\"sub_123\""));
+
+        let parsed: Receipt = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.subscription_id.as_deref(), Some("sub_123"));
+
+        let bare = Receipt::success("tempo", "0xabc");
+        let bare_json = serde_json::to_string(&bare).unwrap();
+        assert!(!bare_json.contains("subscriptionId"));
     }
 
     #[test]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -735,6 +735,7 @@ mod tests {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             reference: "0xabc123".to_string(),
             external_id: None,
+            subscription_id: None,
         };
 
         let header = format_receipt(&receipt).unwrap();
@@ -743,6 +744,35 @@ mod tests {
         assert_eq!(parsed.status, ReceiptStatus::Success);
         assert_eq!(parsed.method.as_str(), "tempo");
         assert_eq!(parsed.reference, "0xabc123");
+    }
+
+    #[test]
+    fn test_receipt_subscription_id_round_trip() {
+        let receipt = Receipt {
+            status: ReceiptStatus::Success,
+            method: "tempo".into(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            reference: "0xabc123".to_string(),
+            external_id: None,
+            subscription_id: Some("sub_123".to_string()),
+        };
+
+        let header = format_receipt(&receipt).unwrap();
+        let parsed = parse_receipt(&header).unwrap();
+
+        assert_eq!(parsed.subscription_id.as_deref(), Some("sub_123"));
+    }
+
+    #[test]
+    fn test_parse_receipt_preserves_foreign_subscription_id() {
+        // A receipt produced by a non-Rust SDK (e.g. mppx) carrying subscriptionId
+        // must survive parsing rather than being silently dropped.
+        let json = r#"{"status":"success","method":"tempo","timestamp":"2024-01-01T00:00:00Z","reference":"0xabc123","subscriptionId":"sub_123"}"#;
+        let header = base64url_encode(json.as_bytes());
+
+        let parsed = parse_receipt(&header).unwrap();
+
+        assert_eq!(parsed.subscription_id.as_deref(), Some("sub_123"));
     }
 
     #[test]

--- a/src/protocol/methods/tempo/session_receipt.rs
+++ b/src/protocol/methods/tempo/session_receipt.rs
@@ -126,6 +126,7 @@ impl SessionReceipt {
             timestamp: self.timestamp.clone(),
             reference: self.reference.clone(),
             external_id: None,
+            subscription_id: None,
         }
     }
 }

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -611,6 +611,7 @@ mod tests {
                         timestamp: "2025-01-01T00:00:00Z".into(),
                         reference: "0xabc".into(),
                         external_id: None,
+                        subscription_id: None,
                     })
                 } else {
                     Err("payment rejected".into())
@@ -711,6 +712,7 @@ mod tests {
             timestamp: "2025-01-01T00:00:00Z".into(),
             reference: "0xabc".into(),
             external_id: None,
+            subscription_id: None,
         };
 
         let resp = WithReceipt {
@@ -913,6 +915,7 @@ mod tests {
                     timestamp: "2025-01-01T00:00:00Z".into(),
                     reference: "0xroute-aware".into(),
                     external_id: None,
+                    subscription_id: None,
                 })))
             }
         }


### PR DESCRIPTION
Adds optional `subscriptionId` to `Receipt` so subscription receipts from mppx/Tempo servers aren't silently dropped on parse.

Breaking: new public field on `Receipt` (source-breaking for struct literals).