### PR TITLE
feat: add configurable incremental 402 retries

### DIFF
--- a/.changelog/client-incremental-402-retries.md
+++ b/.changelog/client-incremental-402-retries.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Added configurable incremental 402 challenge retries for HTTP clients.

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -12,6 +12,7 @@ use super::events::{
     PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
 use super::provider::PaymentProvider;
+use super::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::client::challenge_selection::{
     expired_payment_error, select_supported_challenge, ChallengeSelectionError,
 };
@@ -60,6 +61,36 @@ pub trait PaymentExt: Sized {
         policy: &AcceptPaymentPolicy,
     ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send;
 
+    /// Like [`send_with_payment`](Self::send_with_payment), with a custom cap
+    /// for incremental payment challenge retries after the initial 402.
+    fn send_with_payment_max_retries<P: PaymentProvider>(
+        self,
+        provider: &P,
+        max_payment_retries: usize,
+    ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send {
+        self.send_with_payment_policy_max_retries(
+            provider,
+            &AcceptPaymentPolicy::Always,
+            max_payment_retries,
+        )
+    }
+
+    /// Like [`send_with_payment_policy`](Self::send_with_payment_policy), with
+    /// a custom cap for incremental payment challenge retries.
+    fn send_with_payment_policy_max_retries<P: PaymentProvider>(
+        self,
+        provider: &P,
+        policy: &AcceptPaymentPolicy,
+        max_payment_retries: usize,
+    ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send {
+        self.send_with_payment_options_max_retries(
+            provider,
+            policy,
+            ClientEvents::default(),
+            max_payment_retries,
+        )
+    }
+
     /// Like [`send_with_payment_policy`](Self::send_with_payment_policy), with
     /// event callbacks for the 402 payment flow.
     fn send_with_payment_options<P: PaymentProvider>(
@@ -71,6 +102,19 @@ pub trait PaymentExt: Sized {
         let _ = events;
         self.send_with_payment_policy(provider, policy)
     }
+
+    /// Like [`send_with_payment_options`](Self::send_with_payment_options),
+    /// with a custom cap for incremental payment challenge retries.
+    fn send_with_payment_options_max_retries<P: PaymentProvider>(
+        self,
+        provider: &P,
+        policy: &AcceptPaymentPolicy,
+        events: ClientEvents,
+        max_payment_retries: usize,
+    ) -> impl std::future::Future<Output = Result<Response, HttpError>> + Send {
+        let _ = max_payment_retries;
+        self.send_with_payment_options(provider, policy, events)
+    }
 }
 
 impl PaymentExt for RequestBuilder {
@@ -79,8 +123,28 @@ impl PaymentExt for RequestBuilder {
         provider: &P,
         policy: &AcceptPaymentPolicy,
     ) -> Result<Response, HttpError> {
-        self.send_with_payment_options(provider, policy, ClientEvents::default())
-            .await
+        self.send_with_payment_options_max_retries(
+            provider,
+            policy,
+            ClientEvents::default(),
+            DEFAULT_MAX_PAYMENT_RETRIES,
+        )
+        .await
+    }
+
+    async fn send_with_payment_policy_max_retries<P: PaymentProvider>(
+        self,
+        provider: &P,
+        policy: &AcceptPaymentPolicy,
+        max_payment_retries: usize,
+    ) -> Result<Response, HttpError> {
+        self.send_with_payment_options_max_retries(
+            provider,
+            policy,
+            ClientEvents::default(),
+            max_payment_retries,
+        )
+        .await
     }
 
     async fn send_with_payment_options<P: PaymentProvider>(
@@ -88,6 +152,22 @@ impl PaymentExt for RequestBuilder {
         provider: &P,
         policy: &AcceptPaymentPolicy,
         events: ClientEvents,
+    ) -> Result<Response, HttpError> {
+        self.send_with_payment_options_max_retries(
+            provider,
+            policy,
+            events,
+            DEFAULT_MAX_PAYMENT_RETRIES,
+        )
+        .await
+    }
+
+    async fn send_with_payment_options_max_retries<P: PaymentProvider>(
+        self,
+        provider: &P,
+        policy: &AcceptPaymentPolicy,
+        events: ClientEvents,
+        max_payment_retries: usize,
     ) -> Result<Response, HttpError> {
         let retry_builder = self.try_clone().ok_or(HttpError::CloneFailed)?;
 
@@ -120,39 +200,42 @@ impl PaymentExt for RequestBuilder {
         // Caller's header (if any) wins for retry-time ranking.
         let ranking_accept = caller_accept.or(provider_accept);
 
-        let resp = this.send().await?;
+        let mut paid_challenge_ids = std::collections::HashSet::new();
+        let mut resp = this.send().await?;
 
-        if resp.status() != StatusCode::PAYMENT_REQUIRED {
-            return Ok(resp);
-        }
+        for attempt in 0..max_payment_retries {
+            if resp.status() != StatusCode::PAYMENT_REQUIRED {
+                return Ok(resp);
+            }
 
-        let www_auth_values: Vec<&str> = resp
-            .headers()
-            .get_all(WWW_AUTHENTICATE)
-            .iter()
-            .filter_map(|v| v.to_str().ok())
-            .collect();
+            let www_auth_values: Vec<&str> = resp
+                .headers()
+                .get_all(WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .collect();
 
-        if www_auth_values.is_empty() {
-            events
-                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                    challenge: None,
-                    error: HttpError::MissingChallenge.to_string(),
-                    reason: None,
-                }))
-                .await;
-            return Err(HttpError::MissingChallenge);
-        }
+            if www_auth_values.is_empty() {
+                events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: None,
+                        error: HttpError::MissingChallenge.to_string(),
+                        reason: None,
+                    }))
+                    .await;
+                return Err(HttpError::MissingChallenge);
+            }
 
-        let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
-            .into_iter()
-            .filter_map(|r| r.ok())
-            .collect();
+            let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
+                .into_iter()
+                .filter_map(|r| r.ok())
+                .collect();
 
-        let challenge =
-            match select_supported_challenge(&challenges, ranking_accept.as_deref(), |challenge| {
-                provider.supports(challenge.method.as_str(), challenge.intent.as_str())
-            }) {
+            let challenge = match select_supported_challenge(
+                &challenges,
+                ranking_accept.as_deref(),
+                |challenge| provider.supports(challenge.method.as_str(), challenge.intent.as_str()),
+            ) {
                 Ok(challenge) => challenge.clone(),
                 Err(ChallengeSelectionError::Expired(challenge)) => {
                     let err = HttpError::Payment(expired_payment_error(&challenge));
@@ -180,19 +263,53 @@ impl PaymentExt for RequestBuilder {
                 }
             };
 
-        let override_credential = events
-            .emit_challenge_received(ChallengeReceivedContext {
-                challenge: challenge.clone(),
-                challenges: challenges.clone(),
-            })
-            .await;
+            if !paid_challenge_ids.insert(challenge.id.clone()) {
+                events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: Some(challenge),
+                        error: "payment retry returned a previously paid challenge".to_string(),
+                        reason: None,
+                    }))
+                    .await;
+                return Ok(resp);
+            }
 
-        let credential = match override_credential {
-            Some(credential) => credential,
-            None => match provider.pay(&challenge).await {
-                Ok(credential) => credential,
+            let override_credential = events
+                .emit_challenge_received(ChallengeReceivedContext {
+                    challenge: challenge.clone(),
+                    challenges: challenges.clone(),
+                })
+                .await;
+
+            let credential = match override_credential {
+                Some(credential) => credential,
+                None => match provider.pay(&challenge).await {
+                    Ok(credential) => credential,
+                    Err(err) => {
+                        let http_err = HttpError::Payment(err);
+                        events
+                            .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                                challenge: Some(challenge),
+                                error: http_err.to_string(),
+                                reason: None,
+                            }))
+                            .await;
+                        return Err(http_err);
+                    }
+                },
+            };
+
+            events
+                .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
+                    challenge: challenge.clone(),
+                    credential: credential.clone(),
+                }))
+                .await;
+
+            let auth_header = match format_authorization(&credential) {
+                Ok(auth_header) => auth_header,
                 Err(err) => {
-                    let http_err = HttpError::Payment(err);
+                    let http_err = HttpError::InvalidCredential(err.to_string());
                     events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
@@ -202,70 +319,49 @@ impl PaymentExt for RequestBuilder {
                         .await;
                     return Err(http_err);
                 }
-            },
-        };
+            };
 
-        events
-            .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
-                challenge: challenge.clone(),
-                credential: credential.clone(),
-            }))
-            .await;
+            let retry = retry_builder.try_clone().ok_or(HttpError::CloneFailed)?;
+            resp = match retry.header(AUTHORIZATION_HEADER, auth_header).send().await {
+                Ok(resp) => resp,
+                Err(err) => {
+                    let http_err = HttpError::Request(err);
+                    events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: Some(challenge),
+                            error: http_err.to_string(),
+                            reason: None,
+                        }))
+                        .await;
+                    return Err(http_err);
+                }
+            };
 
-        let auth_header = match format_authorization(&credential) {
-            Ok(auth_header) => auth_header,
-            Err(err) => {
-                let http_err = HttpError::InvalidCredential(err.to_string());
+            let status = resp.status();
+            if status.is_success() {
+                events
+                    .emit(ClientEvent::PaymentResponse(PaymentResponseContext {
+                        challenge,
+                        credential,
+                        status,
+                    }))
+                    .await;
+                return Ok(resp);
+            }
+
+            if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == max_payment_retries {
                 events
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
-                        error: http_err.to_string(),
+                        error: format!("payment retry returned unsuccessful status: {status}"),
                         reason: None,
                     }))
                     .await;
-                return Err(http_err);
+                return Ok(resp);
             }
-        };
-
-        let retry_resp = match retry_builder
-            .header(AUTHORIZATION_HEADER, auth_header)
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
-            Err(err) => {
-                let http_err = HttpError::Request(err);
-                events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: Some(challenge),
-                        error: http_err.to_string(),
-                        reason: None,
-                    }))
-                    .await;
-                return Err(http_err);
-            }
-        };
-
-        let status = retry_resp.status();
-        if status.is_success() {
-            events
-                .emit(ClientEvent::PaymentResponse(PaymentResponseContext {
-                    challenge,
-                    credential,
-                    status,
-                }))
-                .await;
-        } else {
-            events
-                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                    challenge: Some(challenge),
-                    error: format!("payment retry returned unsuccessful status: {status}"),
-                    reason: None,
-                }))
-                .await;
         }
 
-        Ok(retry_resp)
+        Ok(resp)
     }
 }
 
@@ -295,13 +391,14 @@ mod tests {
         use axum::routing::get;
         use axum::Router;
         use std::sync::atomic::{AtomicU32, Ordering};
-        use std::sync::Arc;
+        use std::sync::{Arc, Mutex};
         use tokio::net::TcpListener;
 
         /// Mock provider that records calls and returns a fixed credential.
         #[derive(Clone)]
         struct MockProvider {
             pay_count: Arc<AtomicU32>,
+            challenge_ids: Arc<Mutex<Vec<String>>>,
             fail: bool,
         }
 
@@ -309,6 +406,7 @@ mod tests {
             fn new() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: false,
                 }
             }
@@ -316,12 +414,17 @@ mod tests {
             fn failing() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: true,
                 }
             }
 
             fn call_count(&self) -> u32 {
                 self.pay_count.load(Ordering::SeqCst)
+            }
+
+            fn challenge_ids(&self) -> Vec<String> {
+                self.challenge_ids.lock().unwrap().clone()
             }
         }
 
@@ -335,6 +438,10 @@ mod tests {
                 challenge: &crate::protocol::core::PaymentChallenge,
             ) -> Result<PaymentCredential, MppError> {
                 self.pay_count.fetch_add(1, Ordering::SeqCst);
+                self.challenge_ids
+                    .lock()
+                    .unwrap()
+                    .push(challenge.id.clone());
                 if self.fail {
                     return Err(MppError::Http("mock provider failure".into()));
                 }
@@ -348,15 +455,14 @@ mod tests {
 
         /// Build a test challenge and its formatted WWW-Authenticate header value.
         fn test_challenge() -> (PaymentChallenge, String) {
+            test_challenge_with_id("test-id-123")
+        }
+
+        fn test_challenge_with_id(id: &str) -> (PaymentChallenge, String) {
             let request =
                 Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
-            let challenge = PaymentChallenge::new(
-                "test-id-123",
-                "test.example.com",
-                "tempo",
-                "charge",
-                request,
-            );
+            let challenge =
+                PaymentChallenge::new(id, "test.example.com", "tempo", "charge", request);
             let header = format_www_authenticate(&challenge).unwrap();
             (challenge, header)
         }
@@ -496,7 +602,7 @@ mod tests {
                     let www_auth = www_auth.clone();
                     async move {
                         if req.headers().get("authorization").is_some() {
-                            AxumStatusCode::PAYMENT_REQUIRED.into_response()
+                            AxumStatusCode::FORBIDDEN.into_response()
                         } else {
                             (
                                 AxumStatusCode::PAYMENT_REQUIRED,
@@ -529,7 +635,117 @@ mod tests {
                     failed_count.fetch_add(1, Ordering::SeqCst);
                     async move {
                         assert!(ctx.challenge.is_some());
-                        assert!(ctx.error.contains("402 Payment Required"));
+                        assert!(ctx.error.contains("403 Forbidden"));
+                    }
+                }
+            });
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_options(&provider, &AcceptPaymentPolicy::Always, events)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(response_count.load(Ordering::SeqCst), 0);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_incremental_402_retries_stop_at_default_cap() {
+            let headers = Arc::new(
+                (0..DEFAULT_MAX_PAYMENT_RETRIES)
+                    .map(|i| test_challenge_with_id(&format!("cap-{i}")).1)
+                    .collect::<Vec<_>>(),
+            );
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        let www_auth = headers
+                            .get(index)
+                            .unwrap_or_else(|| headers.last().unwrap())
+                            .clone();
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let client = reqwest::Client::new();
+            let events = ClientEvents::default();
+            let failed_count = Arc::new(AtomicU32::new(0));
+
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                move |_| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                }
+            });
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_options(&provider, &AcceptPaymentPolicy::Always, events)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+            assert_eq!(provider.call_count(), DEFAULT_MAX_PAYMENT_RETRIES as u32);
+            assert_eq!(
+                request_count.load(Ordering::SeqCst),
+                DEFAULT_MAX_PAYMENT_RETRIES as u32 + 1
+            );
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_incremental_402_retries_do_not_pay_repeated_challenge() {
+            let (_, www_auth) = test_challenge();
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let www_auth = www_auth.clone();
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let client = reqwest::Client::new();
+            let events = ClientEvents::default();
+            let failed_count = Arc::new(AtomicU32::new(0));
+
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                move |ctx| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        assert!(ctx.challenge.is_some());
+                        assert!(ctx.error.contains("previously paid challenge"));
                     }
                 }
             });
@@ -542,8 +758,97 @@ mod tests {
 
             assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
             assert_eq!(provider.call_count(), 1);
-            assert_eq!(response_count.load(Ordering::SeqCst), 0);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
             assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_incremental_402_retries_use_configured_cap() {
+            let (_, www_auth) = test_challenge();
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let www_auth = www_auth.clone();
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_max_retries(&provider, 1)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::PAYMENT_REQUIRED);
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn test_incremental_402_retries_pay_replacement_challenges() {
+            let (_, first_header) = test_challenge_with_id("first");
+            let (_, second_header) = test_challenge_with_id("second");
+            let (_, third_header) = test_challenge_with_id("third");
+            let headers = Arc::new([first_header, second_header, third_header]);
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        if let Some(www_auth) = headers.get(index) {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth.clone())],
+                                "pay up",
+                            )
+                                .into_response()
+                        } else {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let client = reqwest::Client::new();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment(&provider)
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(
+                provider.challenge_ids(),
+                vec![
+                    "first".to_string(),
+                    "second".to_string(),
+                    "third".to_string()
+                ]
+            );
+            assert_eq!(request_count.load(Ordering::SeqCst), 4);
         }
 
         #[tokio::test]

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -17,6 +17,7 @@ use crate::client::events::{
     CredentialCreatedContext, PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
 use crate::client::provider::PaymentProvider;
+use crate::client::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
 use crate::protocol::core::{
     format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
@@ -48,6 +49,7 @@ pub struct PaymentMiddleware<P> {
     provider: P,
     accept_payment_policy: AcceptPaymentPolicy,
     events: ClientEvents,
+    max_payment_retries: usize,
 }
 
 impl<P> PaymentMiddleware<P> {
@@ -58,6 +60,7 @@ impl<P> PaymentMiddleware<P> {
             provider,
             accept_payment_policy: AcceptPaymentPolicy::default(),
             events: ClientEvents::default(),
+            max_payment_retries: DEFAULT_MAX_PAYMENT_RETRIES,
         }
     }
 
@@ -71,6 +74,13 @@ impl<P> PaymentMiddleware<P> {
     /// Use an existing event registry for payment callbacks.
     pub fn with_events(mut self, events: ClientEvents) -> Self {
         self.events = events;
+        self
+    }
+
+    /// Set the maximum number of payment challenge retries after the initial
+    /// 402 response.
+    pub fn with_max_payment_retries(mut self, max_payment_retries: usize) -> Self {
+        self.max_payment_retries = max_payment_retries;
         self
     }
 
@@ -152,13 +162,13 @@ where
         let ranking_accept = caller_accept.or(provider_accept);
 
         let retry_req = req.try_clone();
-        let resp = next.clone().run(req, extensions).await?;
+        let mut resp = next.clone().run(req, extensions).await?;
 
         if resp.status() != StatusCode::PAYMENT_REQUIRED {
             return Ok(resp);
         }
 
-        let retry_req = match retry_req {
+        let base_retry_req = match retry_req {
             Some(req) => req,
             None => {
                 let err = anyhow::anyhow!("request could not be cloned for payment retry");
@@ -173,36 +183,46 @@ where
             }
         };
 
-        let www_auth_values: Vec<&str> = resp
-            .headers()
-            .get_all(WWW_AUTHENTICATE)
-            .iter()
-            .filter_map(|v| v.to_str().ok())
-            .collect();
+        let mut paid_challenge_ids = std::collections::HashSet::new();
 
-        if www_auth_values.is_empty() {
-            self.events
-                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                    challenge: None,
-                    error: "402 response missing WWW-Authenticate header".to_string(),
-                    reason: None,
-                }))
-                .await;
-            return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
-                "402 response missing WWW-Authenticate header"
-            )));
-        }
+        for attempt in 0..self.max_payment_retries {
+            if resp.status() != StatusCode::PAYMENT_REQUIRED {
+                return Ok(resp);
+            }
 
-        let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
-            .into_iter()
-            .filter_map(|r| r.ok())
-            .collect();
+            let www_auth_values: Vec<&str> = resp
+                .headers()
+                .get_all(WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|v| v.to_str().ok())
+                .collect();
 
-        let challenge =
-            match select_supported_challenge(&challenges, ranking_accept.as_deref(), |challenge| {
-                self.provider
-                    .supports(challenge.method.as_str(), challenge.intent.as_str())
-            }) {
+            if www_auth_values.is_empty() {
+                self.events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: None,
+                        error: "402 response missing WWW-Authenticate header".to_string(),
+                        reason: None,
+                    }))
+                    .await;
+                return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "402 response missing WWW-Authenticate header"
+                )));
+            }
+
+            let challenges: Vec<_> = parse_www_authenticate_all(www_auth_values)
+                .into_iter()
+                .filter_map(|r| r.ok())
+                .collect();
+
+            let challenge = match select_supported_challenge(
+                &challenges,
+                ranking_accept.as_deref(),
+                |challenge| {
+                    self.provider
+                        .supports(challenge.method.as_str(), challenge.intent.as_str())
+                },
+            ) {
                 Ok(challenge) => challenge.clone(),
                 Err(ChallengeSelectionError::Expired(challenge)) => {
                     let mpp_error = expired_payment_error(&challenge);
@@ -232,20 +252,91 @@ where
                 }
             };
 
-        let override_credential = self
-            .events
-            .emit_challenge_received(ChallengeReceivedContext {
-                challenge: challenge.clone(),
-                challenges: challenges.clone(),
-            })
-            .await;
+            if !paid_challenge_ids.insert(challenge.id.clone()) {
+                self.events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: Some(challenge),
+                        error: "payment retry returned a previously paid challenge".to_string(),
+                        reason: None,
+                    }))
+                    .await;
+                return Ok(resp);
+            }
 
-        let credential = match override_credential {
-            Some(credential) => credential,
-            None => match self.provider.pay(&challenge).await {
-                Ok(credential) => credential,
+            let override_credential = self
+                .events
+                .emit_challenge_received(ChallengeReceivedContext {
+                    challenge: challenge.clone(),
+                    challenges: challenges.clone(),
+                })
+                .await;
+
+            let credential = match override_credential {
+                Some(credential) => credential,
+                None => match self.provider.pay(&challenge).await {
+                    Ok(credential) => credential,
+                    Err(err) => {
+                        let err = anyhow::anyhow!(err).context("payment failed");
+                        self.events
+                            .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                                challenge: Some(challenge),
+                                error: err.to_string(),
+                                reason: None,
+                            }))
+                            .await;
+                        return Err(reqwest_middleware::Error::Middleware(err));
+                    }
+                },
+            };
+
+            self.events
+                .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
+                    challenge: challenge.clone(),
+                    credential: credential.clone(),
+                }))
+                .await;
+
+            let auth_header =
+                match format_authorization(&credential).context("failed to format credential") {
+                    Ok(auth_header) => auth_header,
+                    Err(err) => {
+                        self.events
+                            .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                                challenge: Some(challenge),
+                                error: err.to_string(),
+                                reason: None,
+                            }))
+                            .await;
+                        return Err(reqwest_middleware::Error::Middleware(err));
+                    }
+                };
+
+            let auth_header_value =
+                match auth_header.parse().context("invalid authorization header") {
+                    Ok(value) => value,
+                    Err(err) => {
+                        self.events
+                            .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                                challenge: Some(challenge),
+                                error: err.to_string(),
+                                reason: None,
+                            }))
+                            .await;
+                        return Err(reqwest_middleware::Error::Middleware(err));
+                    }
+                };
+            let mut retry_req = base_retry_req.try_clone().ok_or_else(|| {
+                reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "request could not be cloned for payment retry"
+                ))
+            })?;
+            retry_req
+                .headers_mut()
+                .insert(AUTHORIZATION_HEADER, auth_header_value);
+
+            resp = match next.clone().run(retry_req, extensions).await {
+                Ok(resp) => resp,
                 Err(err) => {
-                    let err = anyhow::anyhow!(err).context("payment failed");
                     self.events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),
@@ -253,85 +344,35 @@ where
                             reason: None,
                         }))
                         .await;
-                    return Err(reqwest_middleware::Error::Middleware(err));
-                }
-            },
-        };
-
-        self.events
-            .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
-                challenge: challenge.clone(),
-                credential: credential.clone(),
-            }))
-            .await;
-
-        let auth_header =
-            match format_authorization(&credential).context("failed to format credential") {
-                Ok(auth_header) => auth_header,
-                Err(err) => {
-                    self.events
-                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: Some(challenge),
-                            error: err.to_string(),
-                            reason: None,
-                        }))
-                        .await;
-                    return Err(reqwest_middleware::Error::Middleware(err));
+                    return Err(err);
                 }
             };
 
-        let mut retry_req = retry_req;
-        let auth_header_value = match auth_header.parse().context("invalid authorization header") {
-            Ok(value) => value,
-            Err(err) => {
+            let status = resp.status();
+            if status.is_success() {
                 self.events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: Some(challenge),
-                        error: err.to_string(),
-                        reason: None,
+                    .emit(ClientEvent::PaymentResponse(PaymentResponseContext {
+                        challenge,
+                        credential,
+                        status,
                     }))
                     .await;
-                return Err(reqwest_middleware::Error::Middleware(err));
+                return Ok(resp);
             }
-        };
-        retry_req
-            .headers_mut()
-            .insert(AUTHORIZATION_HEADER, auth_header_value);
 
-        let retry_resp = next.run(retry_req, extensions).await;
-        match retry_resp {
-            Ok(resp) => {
-                let status = resp.status();
-                if status.is_success() {
-                    self.events
-                        .emit(ClientEvent::PaymentResponse(PaymentResponseContext {
-                            challenge,
-                            credential,
-                            status,
-                        }))
-                        .await;
-                } else {
-                    self.events
-                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: Some(challenge),
-                            error: format!("payment retry returned unsuccessful status: {status}"),
-                            reason: None,
-                        }))
-                        .await;
-                }
-                Ok(resp)
-            }
-            Err(err) => {
+            if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == self.max_payment_retries {
                 self.events
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
-                        error: err.to_string(),
+                        error: format!("payment retry returned unsuccessful status: {status}"),
                         reason: None,
                     }))
                     .await;
-                Err(err)
+                return Ok(resp);
             }
         }
+
+        Ok(resp)
     }
 }
 
@@ -377,12 +418,13 @@ mod tests {
         use axum::Router;
         use reqwest_middleware::ClientBuilder;
         use std::sync::atomic::{AtomicU32, Ordering};
-        use std::sync::Arc;
+        use std::sync::{Arc, Mutex};
         use tokio::net::TcpListener;
 
         #[derive(Clone)]
         struct TestProvider {
             pay_count: Arc<AtomicU32>,
+            challenge_ids: Arc<Mutex<Vec<String>>>,
             fail: bool,
         }
 
@@ -390,6 +432,7 @@ mod tests {
             fn new() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: false,
                 }
             }
@@ -397,12 +440,17 @@ mod tests {
             fn failing() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: true,
                 }
             }
 
             fn call_count(&self) -> u32 {
                 self.pay_count.load(Ordering::SeqCst)
+            }
+
+            fn challenge_ids(&self) -> Vec<String> {
+                self.challenge_ids.lock().unwrap().clone()
             }
         }
 
@@ -416,6 +464,10 @@ mod tests {
                 challenge: &PaymentChallenge,
             ) -> Result<PaymentCredential, MppError> {
                 self.pay_count.fetch_add(1, Ordering::SeqCst);
+                self.challenge_ids
+                    .lock()
+                    .unwrap()
+                    .push(challenge.id.clone());
                 if self.fail {
                     return Err(MppError::Http("test provider failure".into()));
                 }
@@ -428,18 +480,24 @@ mod tests {
         }
 
         fn test_challenge() -> (PaymentChallenge, String) {
-            test_challenge_with_expires(None)
+            test_challenge_with_id_and_expires("mw-test-id", None)
         }
 
         fn test_challenge_with_expires(expires: Option<&str>) -> (PaymentChallenge, String) {
+            test_challenge_with_id_and_expires("mw-test-id", expires)
+        }
+
+        fn test_challenge_with_id(id: &str) -> (PaymentChallenge, String) {
+            test_challenge_with_id_and_expires(id, None)
+        }
+
+        fn test_challenge_with_id_and_expires(
+            id: &str,
+            expires: Option<&str>,
+        ) -> (PaymentChallenge, String) {
             let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "500"})).unwrap();
-            let mut challenge = PaymentChallenge::new(
-                "mw-test-id",
-                "middleware.example.com",
-                "tempo",
-                "charge",
-                request,
-            );
+            let mut challenge =
+                PaymentChallenge::new(id, "middleware.example.com", "tempo", "charge", request);
             if let Some(expires) = expires {
                 challenge = challenge.with_expires(expires);
             }
@@ -586,7 +644,7 @@ mod tests {
                     let www_auth = www_auth.clone();
                     async move {
                         if req.headers().get("authorization").is_some() {
-                            AxumStatusCode::PAYMENT_REQUIRED.into_response()
+                            AxumStatusCode::FORBIDDEN.into_response()
                         } else {
                             (
                                 AxumStatusCode::PAYMENT_REQUIRED,
@@ -618,7 +676,121 @@ mod tests {
                     failed_count.fetch_add(1, Ordering::SeqCst);
                     async move {
                         assert!(ctx.challenge.is_some());
-                        assert!(ctx.error.contains("402 Payment Required"));
+                        assert!(ctx.error.contains("403 Forbidden"));
+                    }
+                }
+            });
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_events(events))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(response_count.load(Ordering::SeqCst), 0);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_incremental_402_retries_stop_at_default_cap() {
+            let headers = Arc::new(
+                (0..DEFAULT_MAX_PAYMENT_RETRIES)
+                    .map(|i| test_challenge_with_id(&format!("cap-{i}")).1)
+                    .collect::<Vec<_>>(),
+            );
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        let www_auth = headers
+                            .get(index)
+                            .unwrap_or_else(|| headers.last().unwrap())
+                            .clone();
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let events = ClientEvents::default();
+            let failed_count = Arc::new(AtomicU32::new(0));
+
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                move |_| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    async {}
+                }
+            });
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_events(events))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::PAYMENT_REQUIRED);
+            assert_eq!(provider.call_count(), DEFAULT_MAX_PAYMENT_RETRIES as u32);
+            assert_eq!(
+                request_count.load(Ordering::SeqCst),
+                DEFAULT_MAX_PAYMENT_RETRIES as u32 + 1
+            );
+            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_incremental_402_retries_do_not_pay_repeated_challenge() {
+            let (_, www_auth) = test_challenge();
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let www_auth = www_auth.clone();
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let events = ClientEvents::default();
+            let failed_count = Arc::new(AtomicU32::new(0));
+
+            let _failed_sub = events.on_payment_failed({
+                let failed_count = failed_count.clone();
+                move |ctx| {
+                    failed_count.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        assert!(ctx.challenge.is_some());
+                        assert!(ctx.error.contains("previously paid challenge"));
                     }
                 }
             });
@@ -634,8 +806,101 @@ mod tests {
 
             assert_eq!(resp.status(), reqwest::StatusCode::PAYMENT_REQUIRED);
             assert_eq!(provider.call_count(), 1);
-            assert_eq!(response_count.load(Ordering::SeqCst), 0);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
             assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_incremental_402_retries_use_configured_cap() {
+            let (_, www_auth) = test_challenge();
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let www_auth = www_auth.clone();
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, www_auth)],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_max_payment_retries(1))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::PAYMENT_REQUIRED);
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_incremental_402_retries_pay_replacement_challenges() {
+            let (_, first_header) = test_challenge_with_id("first");
+            let (_, second_header) = test_challenge_with_id("second");
+            let (_, third_header) = test_challenge_with_id("third");
+            let headers = Arc::new([first_header, second_header, third_header]);
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        if let Some(www_auth) = headers.get(index) {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTH_NAME, www_auth.clone())],
+                                "pay up",
+                            )
+                                .into_response()
+                        } else {
+                            (AxumStatusCode::OK, "ok").into_response()
+                        }
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()))
+                .build();
+
+            let resp = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(resp.status(), reqwest::StatusCode::OK);
+            assert_eq!(
+                provider.challenge_ids(),
+                vec![
+                    "first".to_string(),
+                    "second".to_string(),
+                    "third".to_string()
+                ]
+            );
+            assert_eq!(request_count.load(Ordering::SeqCst), 4);
         }
 
         #[tokio::test]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -41,6 +41,10 @@ mod middleware;
 pub use error::HttpError;
 pub use provider::{MultiProvider, PaymentProvider};
 
+/// Default number of payment challenge retries after the initial 402 response.
+#[cfg(any(feature = "client", feature = "middleware"))]
+pub const DEFAULT_MAX_PAYMENT_RETRIES: usize = 3;
+
 #[cfg(feature = "client")]
 pub use accept_payment_policy::AcceptPaymentPolicy;
 


### PR DESCRIPTION
## Summary

- Added configurable incremental 402 retry limits to reqwest client helpers and middleware
- Defaulted payment retry caps to 3 after the initial 402 response
- Added coverage for default caps, custom caps, and replacement 402 challenges

## Motivation

Incremental 402 challenge flows can return replacement challenges after a paid retry, but clients still need a bounded retry limit to avoid unbounded payment attempts.

## Key design considerations

- Kept the default retry limit shared across client entrypoints
- Preserved existing event behavior for successful and failed payment responses
- Kept new extension-trait methods defaulted so custom implementors are not forced to add methods immediately