### PR TITLE
fix: harden Claude changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,10 +19,12 @@ jobs:
           persist-credentials: false
       - name: Install Claude CLI
         run: npm install -g @anthropic-ai/claude-code@2.1.96
+      - name: Remove repo-local Claude settings
+        run: rm -rf .claude/
       - name: Check changelog
         uses: tempoxyz/changelogs/check@29ac40b71b3966761305991d99f21c5195d7466b # master
         with:
-          ai: "claude -p"
+          ai: "claude --bare -p"
           ecosystem: rust
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Motivation

Prevent PR-controlled Claude Code hooks from executing in the changelog workflow before AI changelog checks run.

## Summary

- Remove repo-local Claude settings before the changelog action
- Run Claude in bare mode for the changelog check

## Key design considerations

- Keeps the existing same-repository pull request guard intact
