### PR TITLE
chore: remove temporary alloy pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ client = ["dep:reqwest"]
 server = ["tokio", "futures-core", "async-stream", "http-types"]
 
 # Method implementations
-evm = ["alloy", "dep:alloy-sol-type-parser", "dep:alloy-sol-types", "hex", "rand"]
+evm = ["alloy", "hex", "rand"]
 tempo = ["evm", "tempo-alloy", "tempo-primitives", "dep:tempo-contracts", "uuid"]
 stripe = ["dep:reqwest", "reqwest?/form"]
 
@@ -97,8 +97,6 @@ tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional =
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.1.0", features = ["full"], optional = true }
-alloy-sol-type-parser = { version = "1.6.0", optional = true }
-alloy-sol-types = { version = "=1.6.0", optional = true }
 
 # Tempo dependencies (optional)
 tempo-alloy = { version = "1.8.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional =
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
 alloy = { version = "2.1.0", features = ["full"], optional = true }
-alloy-sol-type-parser = { version = "=1.6.0", optional = true }
+alloy-sol-type-parser = { version = "1.6.0", optional = true }
 alloy-sol-types = { version = "=1.6.0", optional = true }
 
 # Tempo dependencies (optional)


### PR DESCRIPTION
## Summary

Remove the temporary direct `alloy-sol-type-parser` and `alloy-sol-types` dependency pins and their `evm` feature entries. Both crates remain available transitively through Alloy.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo check --all-features`

Prompted by: @DaniPopes