### PR TITLE
feat: add canonical application WebSocket transport

### DIFF
--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -29,7 +29,10 @@ alloy-transport-ws = { version = "2.1.0", default-features = false }
 mpp = { path = "../..", default-features = false, features = ["ws"] }
 
 futures = "0.3"
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 serde_json = "1"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
 tracing = "0.1"
 url = "2"
 
@@ -42,6 +45,7 @@ tokio-tungstenite = "0.28"
 rustls = { version = "0.23", default-features = false, optional = true }
 
 [dev-dependencies]
+axum = { version = "0.8", features = ["ws"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
 # Pinned to match the version used by alloy-transport-ws 2.0.x so the

--- a/crates/alloy-transport-mpp/README.md
+++ b/crates/alloy-transport-mpp/README.md
@@ -3,13 +3,14 @@
 [Machine Payments Protocol (MPP)](https://github.com/tempoxyz/mpp-rs)
 WebSocket transport for [alloy](https://github.com/alloy-rs/alloy).
 
-This crate adds an opt-in WebSocket transport that speaks the MPP wire
-protocol while remaining a drop-in `PubSubConnect` implementation for the
-rest of alloy. JSON-RPC frames are wrapped in MPP `message` envelopes;
-payment `challenge`, `needVoucher`, `receipt` and `error` frames are
-handled internally via a user-supplied
+This crate adds opt-in WebSocket transports that speak the MPP wire protocol.
+`MppWsConnect` is a drop-in Alloy `PubSubConnect` implementation for JSON-RPC,
+while `MppApplicationWsConnect` carries arbitrary text application messages.
+Both wrap payloads in canonical MPP `message` envelopes and handle payment
+`challenge`, `needVoucher`, `receipt`, signed session close, and `error` frames
+internally via a user-supplied
 [`PaymentProvider`](https://docs.rs/mpp/latest/mpp/client/trait.PaymentProvider.html)
-(and an optional `VoucherProvider` for streaming/session intents).
+(and a `VoucherProvider` for streaming/session intents).
 
 ```rust,ignore
 use alloy_provider::ProviderBuilder;
@@ -17,4 +18,26 @@ use alloy_transport_mpp::MppWsConnect;
 
 let connect = MppWsConnect::new("wss://paid.example/rpc", my_provider);
 let provider = ProviderBuilder::new().connect_pubsub(connect).await?;
+```
+
+For non-JSON-RPC protocols, such as the OpenAI Responses WebSocket API, use
+the application transport directly:
+
+```rust,ignore
+use alloy_transport_mpp::MppApplicationWsConnect;
+
+let connect = MppApplicationWsConnect::new(
+    "wss://paid.example/v1/responses",
+    payment_provider,
+    voucher_provider,
+);
+let mut socket = connect.connect().await?;
+
+socket.send(r#"{"type":"response.create","model":"gpt-5.6-sol"}"#).await?;
+while let Ok(message) = socket.next().await {
+    // Handle application messages. Payment frames stay inside the transport.
+}
+
+// Performs the canonical close-request/close-ready/signed-close handshake.
+let final_receipt = socket.close().await?;
 ```

--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -1,0 +1,437 @@
+//! Canonical MPP WebSocket transport for arbitrary application messages.
+//!
+//! This is the protocol-neutral layer beneath Alloy JSON-RPC and other
+//! persistent WebSocket consumers. It performs the HTTP 402 probe, creates the
+//! initial credential, authorizes the upgraded socket in-band, and services
+//! session voucher requests while exposing only application payloads.
+
+use std::{fmt, time::Duration};
+
+use futures::{SinkExt, StreamExt};
+use http::{HeaderMap, HeaderName, HeaderValue};
+use mpp::{
+    client::PaymentProvider, format_authorization, MppError, PaymentChallenge, PaymentCredential,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::net::TcpStream;
+use tokio::sync::{broadcast, watch};
+use tokio::time::timeout;
+use tokio_tungstenite::{
+    connect_async_with_config,
+    tungstenite::{self, client::IntoClientRequest, Message},
+    MaybeTlsStream, WebSocketStream,
+};
+use url::Url;
+
+use crate::{CloseProvider, VoucherProvider, VoucherRequest};
+
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_EVENTS_CAPACITY: usize = 64;
+
+/// Errors produced by the canonical paid WebSocket transport.
+#[derive(Debug, thiserror::Error)]
+pub enum MppWsError {
+    /// The endpoint URL is not a valid WebSocket URL.
+    #[error("invalid MPP WebSocket URL")]
+    InvalidUrl(#[source] url::ParseError),
+    /// The HTTP payment probe failed.
+    #[error("MPP HTTP payment probe failed")]
+    Probe(#[source] reqwest::Error),
+    /// The probe did not return a payment challenge.
+    #[error("MPP payment probe returned HTTP {status} instead of 402")]
+    ProbeStatus { status: u16 },
+    /// No challenge offered by the server is supported by the provider.
+    #[error("MPP server offered no supported payment challenge")]
+    UnsupportedChallenge,
+    /// A challenge or credential could not be parsed or created.
+    #[error("MPP payment failed")]
+    Payment(#[from] MppError),
+    /// A configured request header is invalid.
+    #[error("invalid MPP WebSocket request header")]
+    InvalidHeader(#[from] http::Error),
+    /// The WebSocket handshake or frame exchange failed.
+    #[error("MPP WebSocket failed")]
+    WebSocket(#[from] tungstenite::Error),
+    /// The payment handshake exceeded its deadline.
+    #[error("MPP WebSocket payment handshake timed out")]
+    HandshakeTimeout,
+    /// The server sent a malformed protocol frame.
+    #[error("malformed MPP WebSocket frame: {0}")]
+    MalformedFrame(#[from] serde_json::Error),
+    /// The server rejected the payment flow.
+    #[error("MPP server returned payment error {status}: {message}")]
+    PaymentError { status: u16, message: String },
+    /// The server closed before the requested application payload arrived.
+    #[error("MPP WebSocket closed")]
+    Closed,
+}
+
+/// Significant canonical MPP events hidden from the application stream.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum MppApplicationEvent {
+    /// The HTTP probe selected this challenge.
+    Challenge(PaymentChallenge),
+    /// The initial credential was sent in-band.
+    CredentialSent,
+    /// The server requested a larger cumulative voucher.
+    NeedVoucher(VoucherRequest),
+    /// A follow-up voucher was sent in-band.
+    VoucherSent,
+    /// The final signed session close credential was sent in-band.
+    CloseCredentialSent,
+    /// The server accepted a credential or voucher.
+    Receipt(Value),
+    /// The session is ready to be closed and settled.
+    CloseReady(Value),
+}
+
+/// Observation handle for a canonical paid application socket.
+#[derive(Debug)]
+pub struct MppApplicationHandle {
+    /// Latest accepted session receipt.
+    pub receipt: watch::Receiver<Option<Value>>,
+    /// Lossy stream of payment lifecycle events.
+    pub events: broadcast::Receiver<MppApplicationEvent>,
+}
+
+/// Builder for a canonical paid WebSocket carrying arbitrary text messages.
+#[derive(Clone)]
+pub struct MppApplicationWsConnect<P, V> {
+    url: String,
+    headers: HeaderMap,
+    payment_provider: P,
+    voucher_provider: V,
+    handshake_timeout: Duration,
+    receipt_tx: watch::Sender<Option<Value>>,
+    events_tx: broadcast::Sender<MppApplicationEvent>,
+}
+
+impl<P: fmt::Debug, V: fmt::Debug> fmt::Debug for MppApplicationWsConnect<P, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MppApplicationWsConnect")
+            .field("url", &redact_url(&self.url))
+            .field("headers", &"<redacted>")
+            .field("handshake_timeout", &self.handshake_timeout)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P, V> MppApplicationWsConnect<P, V> {
+    /// Creates a connector backed by the supplied payment and voucher providers.
+    pub fn new(url: impl Into<String>, payment_provider: P, voucher_provider: V) -> Self {
+        let (receipt_tx, _) = watch::channel(None);
+        let (events_tx, _) = broadcast::channel(DEFAULT_EVENTS_CAPACITY);
+        Self {
+            url: url.into(),
+            headers: HeaderMap::new(),
+            payment_provider,
+            voucher_provider,
+            handshake_timeout: DEFAULT_HANDSHAKE_TIMEOUT,
+            receipt_tx,
+            events_tx,
+        }
+    }
+
+    /// Adds a header to the WebSocket upgrade request.
+    pub fn with_header(mut self, name: HeaderName, value: HeaderValue) -> Self {
+        self.headers.insert(name, value);
+        self
+    }
+
+    /// Sets the deadline for the probe, credential creation, and initial receipt.
+    pub const fn with_handshake_timeout(mut self, value: Duration) -> Self {
+        self.handshake_timeout = value;
+        self
+    }
+
+    /// Returns an observation handle that remains valid for this connector.
+    pub fn mpp_handle(&self) -> MppApplicationHandle {
+        MppApplicationHandle {
+            receipt: self.receipt_tx.subscribe(),
+            events: self.events_tx.subscribe(),
+        }
+    }
+}
+
+impl<P, V> MppApplicationWsConnect<P, V>
+where
+    P: PaymentProvider + 'static,
+    V: VoucherProvider,
+{
+    /// Opens and authorizes a canonical MPP WebSocket.
+    pub async fn connect(&self) -> Result<MppApplicationWs<V>, MppWsError> {
+        timeout(self.handshake_timeout, self.connect_inner())
+            .await
+            .map_err(|_| MppWsError::HandshakeTimeout)?
+    }
+
+    async fn connect_inner(&self) -> Result<MppApplicationWs<V>, MppWsError> {
+        install_default_crypto_provider();
+        let probe_url = probe_url(&self.url)?;
+        let mut probe = reqwest::Client::new()
+            .get(probe_url)
+            .headers(self.headers.clone());
+        if let Some(accept) = self.payment_provider.accept_payment_header() {
+            probe = probe.header("Accept-Payment", accept);
+        }
+        let response = probe.send().await.map_err(MppWsError::Probe)?;
+        if response.status() != reqwest::StatusCode::PAYMENT_REQUIRED {
+            return Err(MppWsError::ProbeStatus {
+                status: response.status().as_u16(),
+            });
+        }
+
+        let challenge = PaymentChallenge::from_headers(
+            response
+                .headers()
+                .get_all(reqwest::header::WWW_AUTHENTICATE)
+                .iter()
+                .filter_map(|value| value.to_str().ok()),
+        )
+        .into_iter()
+        .filter_map(Result::ok)
+        .find(|challenge| {
+            self.payment_provider
+                .supports(challenge.method.as_str(), challenge.intent.as_str())
+        })
+        .ok_or(MppWsError::UnsupportedChallenge)?;
+        let _ = self
+            .events_tx
+            .send(MppApplicationEvent::Challenge(challenge.clone()));
+        let credential = self.payment_provider.pay(&challenge).await?;
+
+        let mut request = self.url.as_str().into_client_request()?;
+        request.headers_mut().extend(self.headers.clone());
+        let (mut socket, _) = connect_async_with_config(request, None, false).await?;
+        send_authorization(&mut socket, &credential).await?;
+        let _ = self.events_tx.send(MppApplicationEvent::CredentialSent);
+
+        let mut client = MppApplicationWs {
+            socket,
+            voucher_provider: self.voucher_provider.clone(),
+            receipt_tx: self.receipt_tx.clone(),
+            events_tx: self.events_tx.clone(),
+        };
+        client.wait_for_receipt().await?;
+        Ok(client)
+    }
+}
+
+/// An authorized canonical MPP WebSocket carrying arbitrary text messages.
+pub struct MppApplicationWs<V> {
+    socket: Socket,
+    voucher_provider: V,
+    receipt_tx: watch::Sender<Option<Value>>,
+    events_tx: broadcast::Sender<MppApplicationEvent>,
+}
+
+impl<V: VoucherProvider> MppApplicationWs<V> {
+    /// Sends one application text payload inside an MPP message envelope.
+    pub async fn send(&mut self, data: impl Into<String>) -> Result<(), MppWsError> {
+        let frame = ClientFrame::Message { data: data.into() };
+        self.socket
+            .send(Message::Text(serde_json::to_string(&frame)?.into()))
+            .await?;
+        Ok(())
+    }
+
+    /// Returns the next application text payload, servicing payment frames in-band.
+    pub async fn next(&mut self) -> Result<String, MppWsError> {
+        loop {
+            match self.next_frame().await? {
+                ServerFrame::Message { data } => return Ok(data),
+                ServerFrame::NeedVoucher { data } => {
+                    let _ = self
+                        .events_tx
+                        .send(MppApplicationEvent::NeedVoucher(data.clone()));
+                    let voucher = self.voucher_provider.next_voucher(&data).await?;
+                    send_authorization(&mut self.socket, &voucher).await?;
+                    let _ = self.events_tx.send(MppApplicationEvent::VoucherSent);
+                }
+                ServerFrame::Receipt { data } => self.accept_receipt(data, false),
+                ServerFrame::CloseReady { data } => {
+                    self.accept_receipt(data, true);
+                    return Err(MppWsError::Closed);
+                }
+                ServerFrame::Error { status, message } => {
+                    return Err(MppWsError::PaymentError { status, message });
+                }
+            }
+        }
+    }
+
+    /// Requests a final session receipt and channel settlement handshake.
+    pub async fn close(mut self) -> Result<Value, MppWsError>
+    where
+        V: CloseProvider,
+    {
+        let frame = ClientFrame::CloseRequest;
+        self.socket
+            .send(Message::Text(serde_json::to_string(&frame)?.into()))
+            .await?;
+        let mut close_credential_sent = false;
+        loop {
+            match self.next_frame().await? {
+                ServerFrame::CloseReady { data } => {
+                    self.accept_receipt(data.clone(), true);
+                    let channel_id =
+                        data.get("channelId")
+                            .and_then(Value::as_str)
+                            .ok_or_else(|| MppWsError::PaymentError {
+                                status: 400,
+                                message: "close-ready receipt is missing channelId".to_owned(),
+                            })?;
+                    let credential = self.voucher_provider.close_credential(channel_id).await?;
+                    send_authorization(&mut self.socket, &credential).await?;
+                    let _ = self
+                        .events_tx
+                        .send(MppApplicationEvent::CloseCredentialSent);
+                    close_credential_sent = true;
+                }
+                ServerFrame::Receipt { data } => {
+                    self.accept_receipt(data.clone(), false);
+                    if close_credential_sent {
+                        self.socket.close(None).await?;
+                        return Ok(data);
+                    }
+                }
+                ServerFrame::NeedVoucher { data } => {
+                    let voucher = self.voucher_provider.next_voucher(&data).await?;
+                    send_authorization(&mut self.socket, &voucher).await?;
+                }
+                ServerFrame::Error { status, message } => {
+                    return Err(MppWsError::PaymentError { status, message });
+                }
+                ServerFrame::Message { .. } => {}
+            }
+        }
+    }
+
+    async fn wait_for_receipt(&mut self) -> Result<(), MppWsError> {
+        match self.next_frame().await? {
+            ServerFrame::Receipt { data } => {
+                self.accept_receipt(data, false);
+                Ok(())
+            }
+            ServerFrame::Error { status, message } => {
+                Err(MppWsError::PaymentError { status, message })
+            }
+            ServerFrame::NeedVoucher { .. }
+            | ServerFrame::Message { .. }
+            | ServerFrame::CloseReady { .. } => Err(MppWsError::PaymentError {
+                status: 400,
+                message: "unexpected frame before initial payment receipt".to_owned(),
+            }),
+        }
+    }
+
+    async fn next_frame(&mut self) -> Result<ServerFrame, MppWsError> {
+        loop {
+            match self.socket.next().await {
+                Some(Ok(Message::Text(text))) => return Ok(serde_json::from_str(&text)?),
+                Some(Ok(Message::Ping(payload))) => {
+                    self.socket.send(Message::Pong(payload)).await?;
+                }
+                Some(Ok(Message::Pong(_) | Message::Frame(_))) => {}
+                Some(Ok(Message::Close(_))) | None => return Err(MppWsError::Closed),
+                Some(Ok(Message::Binary(_))) => {
+                    return Err(MppWsError::PaymentError {
+                        status: 400,
+                        message: "binary MPP frames are not supported".to_owned(),
+                    });
+                }
+                Some(Err(error)) => return Err(error.into()),
+            }
+        }
+    }
+
+    fn accept_receipt(&self, receipt: Value, close_ready: bool) {
+        let _ = self.receipt_tx.send(Some(receipt.clone()));
+        let event = if close_ready {
+            MppApplicationEvent::CloseReady(receipt)
+        } else {
+            MppApplicationEvent::Receipt(receipt)
+        };
+        let _ = self.events_tx.send(event);
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "mpp")]
+enum ClientFrame {
+    #[serde(rename = "authorization")]
+    Authorization { authorization: String },
+    #[serde(rename = "message")]
+    Message { data: String },
+    #[serde(rename = "payment-close-request")]
+    CloseRequest,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "mpp")]
+enum ServerFrame {
+    #[serde(rename = "message")]
+    Message { data: String },
+    #[serde(rename = "payment-need-voucher")]
+    NeedVoucher { data: VoucherRequest },
+    #[serde(rename = "payment-receipt")]
+    Receipt { data: Value },
+    #[serde(rename = "payment-close-ready")]
+    CloseReady { data: Value },
+    #[serde(rename = "payment-error")]
+    Error { status: u16, message: String },
+}
+
+async fn send_authorization(
+    socket: &mut Socket,
+    credential: &PaymentCredential,
+) -> Result<(), MppWsError> {
+    let frame = ClientFrame::Authorization {
+        authorization: format_authorization(credential)?,
+    };
+    socket
+        .send(Message::Text(serde_json::to_string(&frame)?.into()))
+        .await?;
+    Ok(())
+}
+
+fn probe_url(raw: &str) -> Result<Url, MppWsError> {
+    let mut url = Url::parse(raw).map_err(MppWsError::InvalidUrl)?;
+    let scheme = match url.scheme() {
+        "ws" => "http",
+        "wss" => "https",
+        _ => {
+            return Err(MppWsError::InvalidUrl(
+                url::ParseError::RelativeUrlWithoutBase,
+            ))
+        }
+    };
+    url.set_scheme(scheme)
+        .map_err(|()| MppWsError::InvalidUrl(url::ParseError::RelativeUrlWithoutBase))?;
+    Ok(url)
+}
+
+fn redact_url(raw: &str) -> String {
+    let Ok(mut url) = Url::parse(raw) else {
+        return "<invalid>".to_owned();
+    };
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.to_string()
+}
+
+fn install_default_crypto_provider() {
+    #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        #[cfg(feature = "aws-lc-rs")]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+        let provider = rustls::crypto::ring::default_provider();
+        #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+        let _ = rustls::crypto::CryptoProvider::install_default(provider);
+    }
+}

--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -24,7 +24,7 @@ use tokio_tungstenite::{
 };
 use url::Url;
 
-use crate::{CloseProvider, VoucherProvider, VoucherRequest};
+use crate::{CloseProvider, CloseRequest, VoucherProvider, VoucherRequest};
 
 type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -278,14 +278,8 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
             match self.next_frame().await? {
                 ServerFrame::CloseReady { data } => {
                     self.accept_receipt(data.clone(), true);
-                    let channel_id =
-                        data.get("channelId")
-                            .and_then(Value::as_str)
-                            .ok_or_else(|| MppWsError::PaymentError {
-                                status: 400,
-                                message: "close-ready receipt is missing channelId".to_owned(),
-                            })?;
-                    let credential = self.voucher_provider.close_credential(channel_id).await?;
+                    let request = close_request(&data)?;
+                    let credential = self.voucher_provider.close_credential(&request).await?;
                     send_authorization(&mut self.socket, &credential).await?;
                     let _ = self
                         .events_tx
@@ -358,6 +352,23 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
         };
         let _ = self.events_tx.send(event);
     }
+}
+
+fn close_request(receipt: &Value) -> Result<CloseRequest, MppWsError> {
+    let required = |name: &str| {
+        receipt
+            .get(name)
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| MppWsError::PaymentError {
+                status: 400,
+                message: format!("close-ready receipt is missing {name}"),
+            })
+    };
+    Ok(CloseRequest {
+        channel_id: required("channelId")?,
+        cumulative_amount: required("spent")?,
+    })
 }
 
 #[derive(Serialize)]

--- a/crates/alloy-transport-mpp/src/lib.rs
+++ b/crates/alloy-transport-mpp/src/lib.rs
@@ -16,7 +16,8 @@ pub use application::{
 };
 #[cfg(not(target_family = "wasm"))]
 pub use ws::{
-    CloseProvider, MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider, VoucherRequest,
+    CloseProvider, CloseRequest, MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider,
+    VoucherRequest,
 };
 
 // Re-exports for ergonomics.

--- a/crates/alloy-transport-mpp/src/lib.rs
+++ b/crates/alloy-transport-mpp/src/lib.rs
@@ -6,9 +6,18 @@
 extern crate tracing;
 
 #[cfg(not(target_family = "wasm"))]
+mod application;
+#[cfg(not(target_family = "wasm"))]
 mod ws;
 #[cfg(not(target_family = "wasm"))]
-pub use ws::{MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider, VoucherRequest};
+pub use application::{
+    MppApplicationEvent, MppApplicationHandle, MppApplicationWs, MppApplicationWsConnect,
+    MppWsError,
+};
+#[cfg(not(target_family = "wasm"))]
+pub use ws::{
+    CloseProvider, MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider, VoucherRequest,
+};
 
 // Re-exports for ergonomics.
 #[cfg(not(target_family = "wasm"))]

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -81,6 +81,21 @@ pub struct VoucherRequest {
     pub deposit: String,
 }
 
+/// Server-issued parameters for the final signed session close action.
+///
+/// The cumulative amount is the authoritative `spent` value from the
+/// `payment-close-ready` receipt. It can be lower than the most recent voucher
+/// ceiling, so clients must sign this exact amount instead of reusing their
+/// locally authorized maximum.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloseRequest {
+    /// Channel ID (`"0x…"`).
+    pub channel_id: String,
+    /// Exact cumulative amount requested by the close-ready receipt.
+    pub cumulative_amount: String,
+}
+
 /// Optional companion to [`PaymentProvider`] for streaming/session intents.
 ///
 /// When the server emits a `needVoucher` frame, the translator calls
@@ -100,7 +115,7 @@ pub trait CloseProvider: Clone + Send + Sync + 'static {
     /// Produce a close credential for the authorized session channel.
     fn close_credential(
         &self,
-        channel_id: &str,
+        request: &CloseRequest,
     ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
 }
 
@@ -120,7 +135,7 @@ impl VoucherProvider for NoVoucher {
 }
 
 impl CloseProvider for NoVoucher {
-    async fn close_credential(&self, _: &str) -> Result<PaymentCredential, MppError> {
+    async fn close_credential(&self, _: &CloseRequest) -> Result<PaymentCredential, MppError> {
         Err(MppError::bad_request(
             "close provider not configured for this MPP session",
         ))

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -23,6 +23,7 @@ use mpp::{
     },
     format_authorization, MppError, PaymentChallenge, PaymentCredential, Receipt,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::{
     from_str as json_from_str, from_value as json_from_value, value::RawValue, Value,
 };
@@ -67,7 +68,8 @@ const FATAL_TERMINATION_MESSAGE: &str =
 /// Emitted as part of an MPP `needVoucher` frame when a streaming session's
 /// channel balance has been exhausted and the server is asking the client
 /// for a new signed cumulative voucher.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct VoucherRequest {
     /// Channel ID (`"0x…"`).
     pub channel_id: String,
@@ -93,6 +95,15 @@ pub trait VoucherProvider: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
 }
 
+/// Companion provider for the final signed session close action.
+pub trait CloseProvider: Clone + Send + Sync + 'static {
+    /// Produce a close credential for the authorized session channel.
+    fn close_credential(
+        &self,
+        channel_id: &str,
+    ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
+}
+
 /// Default no-op [`VoucherProvider`].
 ///
 /// Returns an error for every voucher request. Use this when your
@@ -104,6 +115,14 @@ impl VoucherProvider for NoVoucher {
     async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
         Err(MppError::bad_request(
             "voucher provider not configured; configure MppWsConnect::with_voucher_provider",
+        ))
+    }
+}
+
+impl CloseProvider for NoVoucher {
+    async fn close_credential(&self, _: &str) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request(
+            "close provider not configured for this MPP session",
         ))
     }
 }
@@ -915,6 +934,19 @@ mod tests {
             deposit: "200".into(),
         };
         assert!(NoVoucher.next_voucher(&req).await.is_err());
+    }
+
+    #[test]
+    fn voucher_request_uses_canonical_camel_case_wire_fields() {
+        let request: VoucherRequest = serde_json::from_value(serde_json::json!({
+            "channelId": "0xabc",
+            "requiredCumulative": "100",
+            "acceptedCumulative": "50",
+            "deposit": "200"
+        }))
+        .unwrap();
+        assert_eq!(request.channel_id, "0xabc");
+        assert_eq!(request.required_cumulative, "100");
     }
 
     #[test]

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -1,5 +1,5 @@
 use alloy_transport_mpp::{
-    CloseProvider, MppApplicationWsConnect, VoucherProvider, VoucherRequest,
+    CloseProvider, CloseRequest, MppApplicationWsConnect, VoucherProvider, VoucherRequest,
 };
 use axum::{
     extract::ws::{rejection::WebSocketUpgradeRejection, Message, WebSocketUpgrade},
@@ -42,8 +42,12 @@ impl VoucherProvider for StubProvider {
 }
 
 impl CloseProvider for StubProvider {
-    async fn close_credential(&self, channel_id: &str) -> Result<PaymentCredential, MppError> {
-        assert_eq!(channel_id, "0xchannel");
+    async fn close_credential(
+        &self,
+        request: &CloseRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        assert_eq!(request.channel_id, "0xchannel");
+        assert_eq!(request.cumulative_amount, "37");
         Ok(PaymentCredential::new(
             challenge().to_echo(),
             PaymentPayload::hash("0xclose"),
@@ -75,8 +79,8 @@ fn receipt() -> Value {
         "reference": "0xchannel",
         "challengeId": "challenge-1",
         "channelId": "0xchannel",
-        "acceptedCumulative": "0",
-        "spent": "0"
+        "acceptedCumulative": "100",
+        "spent": "37"
     })
 }
 

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -1,0 +1,180 @@
+use alloy_transport_mpp::{
+    CloseProvider, MppApplicationWsConnect, VoucherProvider, VoucherRequest,
+};
+use axum::{
+    extract::ws::{rejection::WebSocketUpgradeRejection, Message, WebSocketUpgrade},
+    http::{header::WWW_AUTHENTICATE, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use futures::StreamExt;
+use mpp::{
+    client::PaymentProvider, protocol::core::Base64UrlJson, MppError, PaymentChallenge,
+    PaymentCredential, PaymentPayload,
+};
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+
+#[derive(Clone)]
+struct StubProvider;
+
+impl PaymentProvider for StubProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "tempo" && intent == "session"
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("0xopen"),
+        ))
+    }
+}
+
+impl VoucherProvider for StubProvider {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            challenge().to_echo(),
+            PaymentPayload::hash("0xvoucher"),
+        ))
+    }
+}
+
+impl CloseProvider for StubProvider {
+    async fn close_credential(&self, channel_id: &str) -> Result<PaymentCredential, MppError> {
+        assert_eq!(channel_id, "0xchannel");
+        Ok(PaymentCredential::new(
+            challenge().to_echo(),
+            PaymentPayload::hash("0xclose"),
+        ))
+    }
+}
+
+fn challenge() -> PaymentChallenge {
+    PaymentChallenge::new(
+        "challenge-1",
+        "application-test",
+        "tempo",
+        "session",
+        Base64UrlJson::from_value(&json!({
+            "amount": "0",
+            "currency": "0x0000000000000000000000000000000000000001",
+            "recipient": "0x0000000000000000000000000000000000000002"
+        }))
+        .unwrap(),
+    )
+}
+
+fn receipt() -> Value {
+    json!({
+        "method": "tempo",
+        "intent": "session",
+        "status": "success",
+        "timestamp": "2026-07-19T00:00:00Z",
+        "reference": "0xchannel",
+        "challengeId": "challenge-1",
+        "channelId": "0xchannel",
+        "acceptedCumulative": "0",
+        "spent": "0"
+    })
+}
+
+async fn route(upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>) -> Response {
+    let Ok(upgrade) = upgrade else {
+        let header = HeaderValue::from_str(&challenge().to_header().unwrap()).unwrap();
+        return (StatusCode::PAYMENT_REQUIRED, [(WWW_AUTHENTICATE, header)]).into_response();
+    };
+
+    upgrade
+        .on_upgrade(|mut socket| async move {
+            let authorization = socket.next().await.unwrap().unwrap();
+            let Message::Text(authorization) = authorization else {
+                panic!("expected authorization text frame")
+            };
+            let authorization: Value = serde_json::from_str(&authorization).unwrap();
+            assert_eq!(authorization["mpp"], "authorization");
+            assert!(authorization["authorization"]
+                .as_str()
+                .unwrap()
+                .starts_with("Payment "));
+
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "payment-receipt", "data": receipt() })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+
+            let application = socket.next().await.unwrap().unwrap();
+            let Message::Text(application) = application else {
+                panic!("expected application text frame")
+            };
+            let application: Value = serde_json::from_str(&application).unwrap();
+            assert_eq!(application, json!({ "mpp": "message", "data": "hello" }));
+
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "message", "data": "world" })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+
+            let close_request = socket.next().await.unwrap().unwrap();
+            let Message::Text(close_request) = close_request else {
+                panic!("expected close request text frame")
+            };
+            assert_eq!(
+                serde_json::from_str::<Value>(&close_request).unwrap(),
+                json!({ "mpp": "payment-close-request" })
+            );
+
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "payment-close-ready", "data": receipt() })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+
+            let close_authorization = socket.next().await.unwrap().unwrap();
+            let Message::Text(close_authorization) = close_authorization else {
+                panic!("expected close authorization text frame")
+            };
+            let close_authorization: Value = serde_json::from_str(&close_authorization).unwrap();
+            assert_eq!(close_authorization["mpp"], "authorization");
+
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "payment-receipt", "data": receipt() })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        })
+        .into_response()
+}
+
+#[tokio::test]
+async fn probes_then_authorizes_and_translates_application_messages() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, Router::new().route("/", get(route)))
+            .await
+            .unwrap();
+    });
+
+    let connector =
+        MppApplicationWsConnect::new(format!("ws://{address}/"), StubProvider, StubProvider);
+    let mut socket = connector.connect().await.unwrap();
+    socket.send("hello").await.unwrap();
+    assert_eq!(socket.next().await.unwrap(), "world");
+    assert_eq!(socket.close().await.unwrap()["channelId"], "0xchannel");
+}

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -64,6 +64,8 @@ pub struct ChannelEntry {
     pub chain_id: u64,
     /// Whether the channel has been opened on-chain.
     pub opened: bool,
+    /// TIP-1034 descriptor required on every native session action.
+    pub descriptor: Option<ChannelDescriptor>,
 }
 
 /// Resolve chain ID from a session challenge's methodDetails.
@@ -450,6 +452,7 @@ where
         escrow_contract: options.escrow_contract,
         chain_id: options.chain_id,
         opened: true,
+        descriptor: None,
     };
 
     let payload = SessionCredentialPayload::Open {
@@ -859,6 +862,7 @@ where
         escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
         chain_id: options.chain_id,
         opened: true,
+        descriptor: Some(descriptor.clone()),
     };
 
     let payload = SessionCredentialPayload::Open {
@@ -990,6 +994,7 @@ pub async fn try_recover_channel<P: Provider<TempoNetwork>>(
             escrow_contract,
             chain_id,
             opened: true,
+            descriptor: None,
         })
     } else {
         None
@@ -1132,6 +1137,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
         let cloned = entry.clone();
         assert_eq!(cloned.cumulative_amount, 1000);
@@ -1653,6 +1659,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: false,
+            descriptor: None,
         };
         let debug = format!("{:?}", entry);
         assert!(debug.contains("ChannelEntry"));

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -337,6 +337,28 @@ impl TempoSessionProvider {
         &self,
         channel_id_hex: &str,
     ) -> Result<PaymentCredential, MppError> {
+        self.close_credential_inner(channel_id_hex, None).await
+    }
+
+    /// Create a signed close credential for an exact server-confirmed spend.
+    ///
+    /// Canonical bidirectional transports obtain this amount from the
+    /// `payment-close-ready` receipt. It may be lower than the latest voucher
+    /// ceiling, but it may never exceed the amount this provider authorized.
+    pub async fn close_credential_at(
+        &self,
+        channel_id_hex: &str,
+        cumulative_amount: u128,
+    ) -> Result<PaymentCredential, MppError> {
+        self.close_credential_inner(channel_id_hex, Some(cumulative_amount))
+            .await
+    }
+
+    async fn close_credential_inner(
+        &self,
+        channel_id_hex: &str,
+        requested_cumulative: Option<u128>,
+    ) -> Result<PaymentCredential, MppError> {
         let challenge =
             self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
                 MppError::InvalidConfig("no challenge available for close".into())
@@ -369,6 +391,13 @@ impl TempoSessionProvider {
                 "channel does not match active session".into(),
             ));
         }
+        let cumulative_amount = requested_cumulative.unwrap_or(entry.cumulative_amount);
+        if cumulative_amount > entry.cumulative_amount {
+            return Err(MppError::InvalidConfig(format!(
+                "close amount {cumulative_amount} exceeds locally authorized cumulative amount {}",
+                entry.cumulative_amount
+            )));
+        }
 
         let payload = if is_precompile_escrow(entry.escrow_contract) {
             create_precompile_close_payload_with_descriptor(
@@ -377,7 +406,7 @@ impl TempoSessionProvider {
                 entry.descriptor.ok_or_else(|| {
                     MppError::InvalidConfig("TIP-1034 channel descriptor is missing".into())
                 })?,
-                entry.cumulative_amount,
+                cumulative_amount,
                 entry.chain_id,
             )
             .await?
@@ -385,7 +414,7 @@ impl TempoSessionProvider {
             create_close_payload(
                 &self.signer,
                 entry.channel_id,
-                entry.cumulative_amount,
+                cumulative_amount,
                 entry.escrow_contract,
                 entry.chain_id,
             )
@@ -1620,8 +1649,14 @@ mod tests {
             other => panic!("expected voucher payload, got {other:?}"),
         }
 
+        let close_amount = 1_200;
+        let expected_close_sig =
+            sign_precompile_voucher(&signer, channel_id, close_amount, chain_id)
+                .await
+                .unwrap();
+        let expected_close_hex = alloy::hex::encode_prefixed(&expected_close_sig);
         let close = provider
-            .close_credential(&channel_id.to_string())
+            .close_credential_at(&channel_id.to_string(), close_amount)
             .await
             .expect("close credential succeeds");
         match close
@@ -1636,10 +1671,18 @@ mod tests {
             } => {
                 assert_eq!(actual_channel_id, channel_id.to_string());
                 assert_eq!(actual_descriptor, Some(descriptor));
-                assert_eq!(cumulative_amount, "1500");
-                assert_eq!(signature, expected_hex);
+                assert_eq!(cumulative_amount, close_amount.to_string());
+                assert_eq!(signature, expected_close_hex);
             }
             other => panic!("expected close payload, got {other:?}"),
         }
+
+        let error = provider
+            .close_credential_at(&channel_id.to_string(), 1_501)
+            .await
+            .expect_err("close amount above the voucher ceiling must fail");
+        assert!(error
+            .to_string()
+            .contains("exceeds locally authorized cumulative amount"));
     }
 }

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -13,8 +13,9 @@ use std::sync::{Arc, Mutex};
 use alloy::primitives::{Address, B256};
 
 use self::channel_ops::{
-    build_credential, create_close_payload, create_open_payload, create_precompile_close_payload,
-    create_precompile_open_payload, create_precompile_voucher_payload, create_voucher_payload,
+    build_credential, create_close_payload, create_open_payload,
+    create_precompile_close_payload_with_descriptor, create_precompile_open_payload,
+    create_precompile_voucher_payload_with_descriptor, create_voucher_payload,
     is_precompile_escrow, resolve_chain_id, resolve_escrow, try_recover_channel, ChannelEntry,
     OpenPayloadOptions, OpenPrecompilePayloadOptions,
 };
@@ -252,20 +253,16 @@ impl TempoSessionProvider {
             .unwrap_or(0)
     }
 
-    /// Send a voucher for a need-voucher SSE event.
+    /// Create a signed voucher credential for an active session channel.
     ///
-    /// Called during SSE session metering when the server emits a `payment-need-voucher`
-    /// event. Updates the internal cumulative amount and POSTs a signed voucher
-    /// credential to the server.
-    ///
-    /// Mirrors the TypeScript SDK's `SessionManager.sse` need-voucher handling.
-    pub async fn send_voucher(
+    /// This is used by streaming transports such as SSE and WebSocket, where
+    /// the server requests a new cumulative voucher in-band rather than with a
+    /// fresh HTTP 402 response.
+    pub async fn voucher_credential(
         &self,
-        client: &reqwest::Client,
-        url: &str,
         channel_id_hex: &str,
         required_cumulative: u128,
-    ) -> Result<(), MppError> {
+    ) -> Result<PaymentCredential, MppError> {
         let challenge =
             self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
                 MppError::InvalidConfig("no challenge available for voucher".into())
@@ -303,9 +300,11 @@ impl TempoSessionProvider {
         }
 
         let payload = if is_precompile_escrow(entry.escrow_contract) {
-            create_precompile_voucher_payload(
+            create_precompile_voucher_payload_with_descriptor(
                 &self.signer,
-                entry.channel_id,
+                entry.descriptor.clone().ok_or_else(|| {
+                    MppError::InvalidConfig("TIP-1034 channel descriptor is missing".into())
+                })?,
                 entry.cumulative_amount,
                 entry.chain_id,
             )
@@ -321,12 +320,102 @@ impl TempoSessionProvider {
             .await?
         };
 
-        // Update the registry
+        // Update the registry only after the voucher has been signed.
         self.channels.lock().unwrap().insert(key, entry.clone());
         self.notify_update(&entry);
 
-        let credential =
-            build_credential(&challenge, payload, entry.chain_id, self.signer.address());
+        Ok(build_credential(
+            &challenge,
+            payload,
+            entry.chain_id,
+            self.signer.address(),
+        ))
+    }
+
+    /// Create the final signed close credential for an active session channel.
+    pub async fn close_credential(
+        &self,
+        channel_id_hex: &str,
+    ) -> Result<PaymentCredential, MppError> {
+        let challenge =
+            self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
+                MppError::InvalidConfig("no challenge available for close".into())
+            })?;
+        let key = self
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .get(channel_id_hex)
+            .cloned()
+            .ok_or_else(|| {
+                MppError::InvalidConfig(format!("no channel found for id {channel_id_hex}"))
+            })?;
+        let (expected_key, expected_chain_id) = self.expected_channel_key(&challenge)?;
+        if key != expected_key {
+            return Err(MppError::InvalidConfig(
+                "channel does not match active session".into(),
+            ));
+        }
+        let entry = self
+            .channels
+            .lock()
+            .unwrap()
+            .get(&key)
+            .filter(|entry| entry.opened)
+            .cloned()
+            .ok_or_else(|| MppError::InvalidConfig("channel not found".into()))?;
+        if entry.chain_id != expected_chain_id || entry.channel_id.to_string() != channel_id_hex {
+            return Err(MppError::InvalidConfig(
+                "channel does not match active session".into(),
+            ));
+        }
+
+        let payload = if is_precompile_escrow(entry.escrow_contract) {
+            create_precompile_close_payload_with_descriptor(
+                &self.signer,
+                entry.channel_id,
+                entry.descriptor.ok_or_else(|| {
+                    MppError::InvalidConfig("TIP-1034 channel descriptor is missing".into())
+                })?,
+                entry.cumulative_amount,
+                entry.chain_id,
+            )
+            .await?
+        } else {
+            create_close_payload(
+                &self.signer,
+                entry.channel_id,
+                entry.cumulative_amount,
+                entry.escrow_contract,
+                entry.chain_id,
+            )
+            .await?
+        };
+        Ok(build_credential(
+            &challenge,
+            payload,
+            entry.chain_id,
+            self.signer.address(),
+        ))
+    }
+
+    /// Send a voucher for a need-voucher SSE event.
+    ///
+    /// Called during SSE session metering when the server emits a `payment-need-voucher`
+    /// event. Updates the internal cumulative amount and POSTs a signed voucher
+    /// credential to the server.
+    ///
+    /// Mirrors the TypeScript SDK's `SessionManager.sse` need-voucher handling.
+    pub async fn send_voucher(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        channel_id_hex: &str,
+        required_cumulative: u128,
+    ) -> Result<(), MppError> {
+        let credential = self
+            .voucher_credential(channel_id_hex, required_cumulative)
+            .await?;
         let auth_header = crate::protocol::core::format_authorization(&credential)?;
 
         let resp = client
@@ -396,28 +485,7 @@ impl TempoSessionProvider {
             ));
         }
 
-        let payer = self.signer.address();
-
-        let payload = if is_precompile_escrow(entry.escrow_contract) {
-            create_precompile_close_payload(
-                &self.signer,
-                entry.channel_id,
-                entry.cumulative_amount,
-                entry.chain_id,
-            )
-            .await?
-        } else {
-            create_close_payload(
-                &self.signer,
-                entry.channel_id,
-                entry.cumulative_amount,
-                entry.escrow_contract,
-                entry.chain_id,
-            )
-            .await?
-        };
-
-        let credential = build_credential(&challenge, payload, entry.chain_id, payer);
+        let credential = self.close_credential(&entry.channel_id.to_string()).await?;
 
         let auth_header = crate::protocol::core::format_authorization(&credential)?;
 
@@ -521,9 +589,11 @@ impl PaymentProvider for TempoSessionProvider {
                 entry.cumulative_amount += amount;
 
                 let payload = if precompile {
-                    create_precompile_voucher_payload(
+                    create_precompile_voucher_payload_with_descriptor(
                         &self.signer,
-                        entry.channel_id,
+                        entry.descriptor.clone().ok_or_else(|| {
+                            MppError::InvalidConfig("TIP-1034 channel descriptor is missing".into())
+                        })?,
                         entry.cumulative_amount,
                         chain_id,
                     )
@@ -811,6 +881,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
         provider
             .channels
@@ -842,6 +913,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
 
         provider.notify_update(&entry);
@@ -873,6 +945,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
         provider
             .channels
@@ -895,6 +968,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: false,
+            descriptor: None,
         };
         provider
             .channels
@@ -1008,6 +1082,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
 
         // Should not panic when no callback is set
@@ -1033,6 +1108,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened: true,
+            descriptor: None,
         };
         provider
             .channels
@@ -1057,6 +1133,7 @@ mod tests {
             escrow_contract: Address::ZERO,
             chain_id: 42431,
             opened,
+            descriptor: None,
         }
     }
 
@@ -1097,6 +1174,57 @@ mod tests {
     }
 
     // --- send_voucher error paths ---
+
+    #[tokio::test]
+    async fn test_voucher_credential_returns_signed_cumulative_voucher() {
+        use crate::protocol::methods::tempo::session::SessionCredentialPayload;
+
+        let provider = make_test_provider();
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let escrow = Address::repeat_byte(0x33);
+        let channel_id = B256::repeat_byte(0x44);
+        let channel_id_hex = channel_id.to_string();
+
+        *provider.last_challenge.lock().unwrap() =
+            Some(make_scoped_challenge(payee, currency, escrow));
+        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, None);
+        provider
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .insert(channel_id_hex.clone(), key.clone());
+        provider.channels.lock().unwrap().insert(
+            key.clone(),
+            ChannelEntry {
+                channel_id,
+                salt: B256::ZERO,
+                cumulative_amount: 1000,
+                escrow_contract: escrow,
+                chain_id: 42431,
+                opened: true,
+                descriptor: None,
+            },
+        );
+
+        let credential = provider
+            .voucher_credential(&channel_id_hex, 2000)
+            .await
+            .unwrap();
+
+        match credential.payload_as::<SessionCredentialPayload>().unwrap() {
+            SessionCredentialPayload::Voucher {
+                channel_id,
+                cumulative_amount,
+                ..
+            } => {
+                assert_eq!(channel_id, channel_id_hex);
+                assert_eq!(cumulative_amount, "2000");
+            }
+            other => panic!("expected voucher payload, got {other:?}"),
+        }
+        assert_eq!(provider.cumulative(), 2000);
+    }
 
     #[tokio::test]
     async fn test_send_voucher_missing_challenge() {
@@ -1158,6 +1286,7 @@ mod tests {
                 escrow_contract: escrow,
                 chain_id: 42431,
                 opened: true,
+                descriptor: None,
             },
         );
 
@@ -1219,6 +1348,7 @@ mod tests {
                 escrow_contract: escrow,
                 chain_id: 42431,
                 opened: true,
+                descriptor: None,
             },
         );
 
@@ -1374,7 +1504,7 @@ mod tests {
         use alloy::signers::local::PrivateKeySigner;
         use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
 
-        use crate::client::tempo::session::channel_ops::ChannelEntry;
+        use crate::client::tempo::session::channel_ops::{build_channel_descriptor, ChannelEntry};
         use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
         use crate::protocol::methods::tempo::precompile_voucher::{
             compute_precompile_channel_id, sign_precompile_voucher,
@@ -1400,6 +1530,15 @@ mod tests {
             expiring_nonce_hash,
             chain_id,
         );
+        let descriptor = build_channel_descriptor(
+            payer,
+            payee,
+            operator,
+            currency,
+            salt,
+            authorized_signer,
+            expiring_nonce_hash,
+        );
 
         let provider =
             TempoSessionProvider::new(signer.clone(), "https://rpc.example.com").unwrap();
@@ -1412,7 +1551,7 @@ mod tests {
             Some(operator),
         );
         provider.channels.lock().unwrap().insert(
-            key,
+            key.clone(),
             ChannelEntry {
                 channel_id,
                 salt,
@@ -1420,8 +1559,14 @@ mod tests {
                 escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
                 chain_id,
                 opened: true,
+                descriptor: Some(descriptor.clone()),
             },
         );
+        provider
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .insert(channel_id.to_string(), key);
 
         let req = SessionRequest {
             amount: "500".to_string(),
@@ -1458,16 +1603,43 @@ mod tests {
                 signature,
                 cumulative_amount,
                 channel_id: cid,
+                descriptor: actual_descriptor,
                 ..
             } => {
                 assert_eq!(cumulative_amount, "1500");
                 assert_eq!(cid, channel_id.to_string());
+                assert_eq!(
+                    serde_json::to_value(actual_descriptor).unwrap(),
+                    serde_json::to_value(Some(descriptor.clone())).unwrap()
+                );
                 assert_eq!(
                     signature, expected_hex,
                     "voucher must use precompile EIP-712 domain"
                 );
             }
             other => panic!("expected voucher payload, got {other:?}"),
+        }
+
+        let close = provider
+            .close_credential(&channel_id.to_string())
+            .await
+            .expect("close credential succeeds");
+        match close
+            .payload_as::<crate::protocol::methods::tempo::session::SessionCredentialPayload>()
+            .unwrap()
+        {
+            crate::protocol::methods::tempo::session::SessionCredentialPayload::Close {
+                channel_id: actual_channel_id,
+                descriptor: actual_descriptor,
+                cumulative_amount,
+                signature,
+            } => {
+                assert_eq!(actual_channel_id, channel_id.to_string());
+                assert_eq!(actual_descriptor, Some(descriptor));
+                assert_eq!(cumulative_amount, "1500");
+                assert_eq!(signature, expected_hex);
+            }
+            other => panic!("expected close payload, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
Adds a protocol-neutral canonical MPP WebSocket connector alongside the existing Alloy JSON-RPC connector.

- probes HTTP 402 challenges and selects any challenge supported by the payment provider
- performs canonical in-band authorization, receipt, dynamic voucher, and signed close flows
- exposes arbitrary application text messages while keeping MPP frames inside the transport
- adds reusable native Tempo session voucher and close credentials with TIP-1034 descriptors
- fixes VoucherRequest camelCase compatibility
- includes a deterministic end-to-end WebSocket integration test

This is the transport used to carry the OpenAI Responses WebSocket API through MPP without coupling application/library code to payments.

Validation:
- cargo test -p alloy-transport-mpp --all-features (14 unit, 1 new application integration, 23 existing WS integration tests)
- cargo clippy -p alloy-transport-mpp --all-targets --all-features --no-deps (new crate clean; six pre-existing mpp all-feature warnings remain)
- full mpp tests and doc tests passed locally