### PR TITLE
fix(tempo): align proof credentials with account-bound v3

### DIFF
--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -251,6 +251,7 @@ impl TempoCharge {
                 PaymentPayload::proof(
                     proof::sign_proof(
                         signer,
+                        from,
                         self.chain_id,
                         &self.challenge.id,
                         &self.challenge.realm,

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -166,6 +166,7 @@ impl PaymentProvider for TempoProvider {
             let from = self.signing_mode.from_address(self.signer.address());
             let signature = sign_proof(
                 &self.signer,
+                from,
                 charge.chain_id(),
                 &challenge.id,
                 &challenge.realm,

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -1531,6 +1531,7 @@ where
 
                 // Fast path: signer IS the source address (Direct mode).
                 if !proof::verify_proof(
+                    parsed_source.address,
                     expected_chain_id,
                     &credential.challenge.id,
                     &credential.challenge.realm,
@@ -1540,6 +1541,7 @@ where
                     // Keychain fallback: signer may be an access key authorized
                     // for the source wallet. Recover the signer and check on-chain.
                     let recovered = proof::recover_proof_signer(
+                        parsed_source.address,
                         expected_chain_id,
                         &credential.challenge.id,
                         &credential.challenge.realm,
@@ -1746,9 +1748,15 @@ mod tests {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
-            .await
-            .unwrap();
+        let signature = proof::sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             proof::proof_source(signer.address(), 42431),
@@ -1770,9 +1778,15 @@ mod tests {
         let other = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&other, 42431, &challenge.id, &challenge.realm)
-            .await
-            .unwrap();
+        let signature = proof::sign_proof(
+            &other,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
         let payload = crate::protocol::core::PaymentPayload::proof(signature);
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
@@ -1783,6 +1797,7 @@ mod tests {
         let source = credential.source.as_deref().unwrap();
         let parsed = proof::parse_proof_source(source).unwrap();
         assert!(!proof::verify_proof(
+            parsed.address,
             42431,
             &credential.challenge.id,
             &credential.challenge.realm,
@@ -3121,9 +3136,15 @@ mod tests {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
-            .await
-            .unwrap();
+        let signature = proof::sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             proof::proof_source(signer.address(), 42431),
@@ -3159,9 +3180,15 @@ mod tests {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
-            .await
-            .unwrap();
+        let signature = proof::sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
 
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
@@ -3254,9 +3281,15 @@ mod tests {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let request = test_charge_request_with_amount("0");
         let challenge = test_proof_challenge(&request);
-        let signature = proof::sign_proof(&signer, 42431, &challenge.id, &challenge.realm)
-            .await
-            .unwrap();
+        let signature = proof::sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             proof::proof_source(signer.address(), 42431),

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -2,6 +2,8 @@
 
 use alloy::primitives::{keccak256, Address, B256};
 use alloy::sol_types::{eip712_domain, SolStruct};
+#[cfg(feature = "evm")]
+use tempo_primitives::transaction::TempoSignature;
 
 use crate::error::{MppError, ResultExt};
 
@@ -9,11 +11,12 @@ use crate::error::{MppError, ResultExt};
 pub const DOMAIN_NAME: &str = "MPP";
 
 /// EIP-712 domain version for zero-amount proof credentials.
-pub const DOMAIN_VERSION: &str = "2";
+pub const DOMAIN_VERSION: &str = "3";
 
 alloy::sol! {
     #[derive(Debug)]
     struct Proof {
+        address account;
         string challengeId;
         string realm;
     }
@@ -75,25 +78,20 @@ pub fn proof_fingerprint(
     chain_id: u64,
     signature_hex: &str,
 ) -> crate::error::Result<B256> {
-    let signature_bytes: alloy::primitives::Bytes = signature_hex
-        .parse()
-        .map_err(|_| MppError::invalid_payload("invalid proof signature hex"))?;
-    let signature = alloy::signers::Signature::try_from(signature_bytes.as_ref())
-        .map_err(|_| MppError::invalid_payload("invalid proof signature"))?;
+    let signature = parse_signature(signature_hex)?;
+    let signature_bytes = signature.to_bytes();
 
-    let mut buf = Vec::with_capacity(challenge_id.len() + 1 + 20 + 8 + 65);
+    let mut buf = Vec::with_capacity(challenge_id.len() + 1 + 20 + 8 + signature_bytes.len());
     buf.extend_from_slice(challenge_id.as_bytes());
     buf.push(0xff); // separator: variable-length id from fixed-width fields
     buf.extend_from_slice(source_address.as_slice());
     buf.extend_from_slice(&chain_id.to_be_bytes());
-    // normalize_s so a malleated (high-S) variant, which recovery accepts as the
-    // same proof, cannot mint a distinct replay key.
-    buf.extend_from_slice(&signature.normalized_s().as_bytes());
+    buf.extend_from_slice(&signature_bytes);
     Ok(keccak256(&buf))
 }
 
 /// Compute the EIP-712 signing hash for a proof credential.
-pub fn signing_hash(chain_id: u64, challenge_id: &str, realm: &str) -> B256 {
+pub fn signing_hash(account: Address, chain_id: u64, challenge_id: &str, realm: &str) -> B256 {
     let domain = eip712_domain! {
         name: DOMAIN_NAME,
         version: DOMAIN_VERSION,
@@ -101,6 +99,7 @@ pub fn signing_hash(chain_id: u64, challenge_id: &str, realm: &str) -> B256 {
     };
 
     Proof {
+        account,
         challengeId: challenge_id.to_string(),
         realm: realm.to_string(),
     }
@@ -111,12 +110,13 @@ pub fn signing_hash(chain_id: u64, challenge_id: &str, realm: &str) -> B256 {
 #[cfg(feature = "evm")]
 pub async fn sign_proof(
     signer: &impl alloy::signers::Signer,
+    account: Address,
     chain_id: u64,
     challenge_id: &str,
     realm: &str,
 ) -> crate::error::Result<String> {
     let signature = signer
-        .sign_hash(&signing_hash(chain_id, challenge_id, realm))
+        .sign_hash(&signing_hash(account, chain_id, challenge_id, realm))
         .await
         .mpp_http("failed to sign proof")?;
 
@@ -126,25 +126,24 @@ pub async fn sign_proof(
 /// Verify a zero-amount charge proof against the expected signer.
 #[cfg(feature = "evm")]
 pub fn verify_proof(
+    account: Address,
     chain_id: u64,
     challenge_id: &str,
     realm: &str,
     signature_hex: &str,
     expected_signer: Address,
 ) -> bool {
-    let signature_bytes = match signature_hex.parse::<alloy::primitives::Bytes>() {
-        Ok(bytes) => bytes,
+    let signature = match parse_signature(signature_hex) {
+        Ok(signature) => signature,
         Err(_) => return false,
     };
 
-    let signature = match alloy::signers::Signature::try_from(signature_bytes.as_ref()) {
-        Ok(sig) => sig,
-        Err(_) => return false,
-    };
-
-    match signature.recover_address_from_prehash(&signing_hash(chain_id, challenge_id, realm)) {
-        Ok(recovered) => recovered == expected_signer,
-        Err(_) => false,
+    match signature {
+        TempoSignature::Primitive(signature) => signature
+            .recover_signer(&signing_hash(account, chain_id, challenge_id, realm))
+            .is_ok_and(|recovered| recovered == expected_signer),
+        // Keychain envelopes require a separate on-chain authorization check.
+        TempoSignature::Keychain(_) => false,
     }
 }
 
@@ -153,19 +152,28 @@ pub fn verify_proof(
 /// Returns `Ok(address)` on success, or `Err` if the signature is malformed.
 #[cfg(feature = "evm")]
 pub fn recover_proof_signer(
+    account: Address,
     chain_id: u64,
     challenge_id: &str,
     realm: &str,
     signature_hex: &str,
 ) -> Result<Address, crate::error::MppError> {
+    let signature = parse_signature(signature_hex)?;
+    let hash = signing_hash(account, chain_id, challenge_id, realm);
+    match signature {
+        TempoSignature::Primitive(signature) => signature.recover_signer(&hash),
+        TempoSignature::Keychain(signature) => signature.key_id(&hash),
+    }
+    .map_err(|_| MppError::invalid_payload("proof signature recovery failed"))
+}
+
+#[cfg(feature = "evm")]
+fn parse_signature(signature_hex: &str) -> crate::error::Result<TempoSignature> {
     let signature_bytes: alloy::primitives::Bytes = signature_hex
         .parse()
-        .map_err(|_| crate::error::MppError::invalid_payload("invalid proof signature hex"))?;
-    let signature = alloy::signers::Signature::try_from(signature_bytes.as_ref())
-        .map_err(|_| crate::error::MppError::invalid_payload("invalid proof signature"))?;
-    signature
-        .recover_address_from_prehash(&signing_hash(chain_id, challenge_id, realm))
-        .map_err(|_| crate::error::MppError::invalid_payload("proof signature recovery failed"))
+        .map_err(|_| MppError::invalid_payload("invalid proof signature hex"))?;
+    TempoSignature::from_bytes(signature_bytes.as_ref())
+        .map_err(|_| MppError::invalid_payload("invalid proof signature"))
 }
 
 #[cfg(test)]
@@ -216,11 +224,18 @@ mod tests {
     #[tokio::test]
     async fn test_sign_and_verify_proof_roundtrip() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
         assert!(verify_proof(
+            signer.address(),
             42431,
             "challenge-123",
             "api.example.com",
@@ -232,11 +247,18 @@ mod tests {
     #[tokio::test]
     async fn test_verify_proof_rejects_wrong_challenge_id() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
         assert!(!verify_proof(
+            signer.address(),
             42431,
             "challenge-456",
             "api.example.com",
@@ -248,11 +270,18 @@ mod tests {
     #[tokio::test]
     async fn test_verify_proof_rejects_wrong_realm() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
         assert!(!verify_proof(
+            signer.address(),
             42431,
             "challenge-123",
             "payments.example.com",
@@ -265,11 +294,18 @@ mod tests {
     async fn test_verify_proof_rejects_wrong_signer() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
         let other = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
         assert!(!verify_proof(
+            signer.address(),
             42431,
             "challenge-123",
             "api.example.com",
@@ -281,21 +317,39 @@ mod tests {
     #[tokio::test]
     async fn test_recover_proof_signer_returns_signer() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
-        let recovered =
-            recover_proof_signer(42431, "challenge-123", "api.example.com", &signature).unwrap();
+        let recovered = recover_proof_signer(
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+            &signature,
+        )
+        .unwrap();
         assert_eq!(recovered, signer.address());
     }
 
     #[tokio::test]
     async fn test_proof_fingerprint_is_spelling_invariant() {
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let signature = sign_proof(&signer, 42431, "challenge-123", "api.example.com")
-            .await
-            .unwrap();
+        let signature = sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            "challenge-123",
+            "api.example.com",
+        )
+        .await
+        .unwrap();
 
         // Canonical spelling vs. uppercase signature hex — same proof.
         let upper_sig = signature.to_uppercase().replace("0X", "0x");
@@ -312,17 +366,32 @@ mod tests {
 
     #[test]
     fn test_signing_hash_depends_on_chain_id() {
+        let account = Address::repeat_byte(0x11);
         assert_ne!(
-            signing_hash(1, "challenge-123", "api.example.com"),
-            signing_hash(42431, "challenge-123", "api.example.com")
+            signing_hash(account, 1, "challenge-123", "api.example.com"),
+            signing_hash(account, 42431, "challenge-123", "api.example.com")
         );
     }
 
     #[test]
     fn test_signing_hash_depends_on_realm() {
+        let account = Address::repeat_byte(0x11);
         assert_ne!(
-            signing_hash(42431, "challenge-123", "api.example.com"),
-            signing_hash(42431, "challenge-123", "payments.example.com")
+            signing_hash(account, 42431, "challenge-123", "api.example.com"),
+            signing_hash(account, 42431, "challenge-123", "payments.example.com")
+        );
+    }
+
+    #[test]
+    fn test_signing_hash_matches_mppx_v3_vector() {
+        let account = "0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            signing_hash(account, 42431, "kM9xPqWvT2nJrHsY4aDfEb", "api.example.com"),
+            "0x3860a700a55e02ad3c2dc047e92489feceecbdb0a801d948e1d9f0b61ea9bc3f"
+                .parse::<B256>()
+                .unwrap()
         );
     }
 }


### PR DESCRIPTION
## Summary

- update Tempo proof EIP-712 data to MPP v3 and bind it to the payer account
- parse native Tempo primitive signatures for verification and recovery
- validate the signing hash against the MPPx cross-SDK vector

This fixes the current Rust v2 proof shape, which does not match the account-bound v3 proof used by MPPx and deployed Tempo MPP services. It is intentionally independent of the WebSocket and session-store PRs.

## Validation

- `cargo test --features tempo,client` (645 unit tests; 50 doctests passed, 13 ignored)
- `cargo test --all-features protocol::methods::tempo::proof` (14 passed)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`