### PR TITLE
feat(tempo): use wallet access keys for payments

### DIFF
--- a/.changelog/calm-wallet-access-key.md
+++ b/.changelog/calm-wallet-access-key.md
@@ -1,0 +1,6 @@
+---
+"mpp": minor
+---
+
+Support Tempo Wallet P-256 access keys for charge payments and expose the
+shared `store.json` loader for native command-line clients.

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -33,11 +33,13 @@ pub mod tx_builder;
 use std::num::NonZeroU64;
 
 use alloy::primitives::{Address, TxKind, U256};
-use tempo_primitives::transaction::{Call, SignedKeyAuthorization};
+use tempo_primitives::transaction::{Call, SignedKeyAuthorization, TempoTransaction};
 
 use self::tx_builder::{build_charge_credential, build_tempo_tx, estimate_gas, TempoTxOptions};
 use crate::client::tempo::signing::{
-    sign_and_encode_async, sign_and_encode_fee_payer_envelope_async, TempoSigningMode,
+    sign_and_encode_async, sign_and_encode_fee_payer_envelope_async,
+    sign_and_encode_fee_payer_request_primitive_async, sign_and_encode_primitive_async,
+    TempoPrimitiveSigner, TempoSigningMode,
 };
 use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, PaymentPayload};
@@ -242,34 +244,46 @@ impl TempoCharge {
         signer: &(impl alloy::signers::Signer + Clone),
         options: SignOptions,
     ) -> Result<SignedTempoCharge, MppError> {
-        if self.amount.is_zero() {
-            let signing_mode = options.signing_mode.unwrap_or_default();
-            let from = signing_mode.from_address(signer.address());
-            let credential = PaymentCredential::with_source(
-                self.challenge.to_echo(),
-                proof::proof_source(from, self.chain_id),
-                PaymentPayload::proof(
-                    proof::sign_proof(
-                        signer,
-                        from,
-                        self.chain_id,
-                        &self.challenge.id,
-                        &self.challenge.realm,
-                    )
-                    .await?,
-                ),
-            );
+        self.prepare(signer.address(), options)
+            .await?
+            .sign_secp256k1(signer)
+            .await
+    }
 
-            return Ok(SignedTempoCharge {
-                credential,
-                tx_bytes: None,
+    /// Sign the charge with a native Tempo primitive signer.
+    ///
+    /// This accepts either a secp256k1 key or an Accounts SDK-compatible P-256
+    /// access key through [`TempoPrimitiveSigner`] and Alloy's existing signer
+    /// interface.
+    pub async fn sign_with_primitive_options(
+        self,
+        signer: &TempoPrimitiveSigner,
+        options: SignOptions,
+    ) -> Result<SignedTempoCharge, MppError> {
+        self.prepare(alloy::signers::Signer::address(signer), options)
+            .await?
+            .sign_primitive(signer)
+            .await
+    }
+
+    async fn prepare(
+        self,
+        signer_address: Address,
+        options: SignOptions,
+    ) -> Result<PreparedTempoCharge, MppError> {
+        let signing_mode = options.signing_mode.unwrap_or_default();
+        let from = signing_mode.from_address(signer_address);
+
+        if self.amount.is_zero() {
+            return Ok(PreparedTempoCharge {
+                challenge: self.challenge,
                 chain_id: self.chain_id,
+                fee_payer: self.fee_payer,
                 from,
+                signing_mode,
+                transaction: None,
             });
         }
-
-        let signing_mode = options.signing_mode.unwrap_or_default();
-        let from = signing_mode.from_address(signer.address());
 
         // Resolve RPC provider + build calls
         let rpc_url = match options.rpc_url {
@@ -372,22 +386,102 @@ impl TempoCharge {
             key_authorization: tx_key_authorization,
         });
 
-        // If fee sponsorship is requested, send the `0x78` fee payer envelope
-        // so MPPx servers can co-sign and broadcast (standard `0x76`).
-        let tx_bytes = if self.fee_payer {
-            sign_and_encode_fee_payer_envelope_async(tx, signer, &signing_mode).await?
-        } else {
-            sign_and_encode_async(tx, signer, &signing_mode).await?
+        Ok(PreparedTempoCharge {
+            challenge: self.challenge,
+            chain_id: self.chain_id,
+            fee_payer: self.fee_payer,
+            from,
+            signing_mode,
+            transaction: Some(tx),
+        })
+    }
+}
+
+struct PreparedTempoCharge {
+    challenge: PaymentChallenge,
+    chain_id: u64,
+    fee_payer: bool,
+    from: Address,
+    signing_mode: TempoSigningMode,
+    transaction: Option<TempoTransaction>,
+}
+
+impl PreparedTempoCharge {
+    async fn sign_secp256k1(
+        mut self,
+        signer: &(impl alloy::signers::Signer + Clone),
+    ) -> Result<SignedTempoCharge, MppError> {
+        let Some(transaction) = self.transaction.take() else {
+            let signature = proof::sign_proof(
+                signer,
+                self.from,
+                self.chain_id,
+                &self.challenge.id,
+                &self.challenge.realm,
+            )
+            .await?;
+            return Ok(self.proof(signature));
         };
+        let tx_bytes = if self.fee_payer {
+            sign_and_encode_fee_payer_envelope_async(transaction, signer, &self.signing_mode)
+                .await?
+        } else {
+            sign_and_encode_async(transaction, signer, &self.signing_mode).await?
+        };
+        Ok(self.transaction(tx_bytes))
+    }
 
-        let credential = build_charge_credential(&self.challenge, &tx_bytes, self.chain_id, from);
+    async fn sign_primitive(
+        mut self,
+        signer: &TempoPrimitiveSigner,
+    ) -> Result<SignedTempoCharge, MppError> {
+        let Some(transaction) = self.transaction.take() else {
+            let signature = proof::sign_proof_primitive(
+                signer,
+                self.from,
+                self.chain_id,
+                &self.challenge.id,
+                &self.challenge.realm,
+            )
+            .await?;
+            return Ok(self.proof(signature));
+        };
+        let tx_bytes = if self.fee_payer {
+            sign_and_encode_fee_payer_request_primitive_async(
+                transaction,
+                signer,
+                &self.signing_mode,
+            )
+            .await?
+        } else {
+            sign_and_encode_primitive_async(transaction, signer, &self.signing_mode).await?
+        };
+        Ok(self.transaction(tx_bytes))
+    }
 
-        Ok(SignedTempoCharge {
+    fn proof(self, signature: String) -> SignedTempoCharge {
+        let credential = PaymentCredential::with_source(
+            self.challenge.to_echo(),
+            proof::proof_source(self.from, self.chain_id),
+            PaymentPayload::proof(signature),
+        );
+        SignedTempoCharge {
+            credential,
+            tx_bytes: None,
+            chain_id: self.chain_id,
+            from: self.from,
+        }
+    }
+
+    fn transaction(self, tx_bytes: Vec<u8>) -> SignedTempoCharge {
+        let credential =
+            build_charge_credential(&self.challenge, &tx_bytes, self.chain_id, self.from);
+        SignedTempoCharge {
             credential,
             tx_bytes: Some(tx_bytes),
             chain_id: self.chain_id,
-            from,
-        })
+            from: self.from,
+        }
     }
 }
 

--- a/src/client/tempo/mod.rs
+++ b/src/client/tempo/mod.rs
@@ -9,9 +9,30 @@ mod error;
 mod provider;
 pub mod session;
 pub mod signing;
+#[cfg(feature = "sqlite")]
+pub mod wallet;
 
 pub use autoswap::AutoswapConfig;
 pub use error::TempoClientError;
+
+#[cfg(all(feature = "sqlite", not(windows)))]
+fn default_wallet_directory() -> Option<std::path::PathBuf> {
+    std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .map(|home| home.join(".tempo").join("wallet"))
+}
+
+#[cfg(all(feature = "sqlite", windows))]
+fn default_wallet_directory() -> Option<std::path::PathBuf> {
+    std::env::var_os("USERPROFILE")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let path = std::env::var_os("HOMEPATH")?;
+            Some(std::path::PathBuf::from(drive).join(path))
+        })
+        .map(|home| home.join(".tempo").join("wallet"))
+}
 pub use provider::TempoProvider;
 
 /// Static max fee per gas: 41 gwei (`base_fee * 2 + priority_fee`).

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -2,14 +2,13 @@
 
 use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
-use crate::protocol::methods::tempo::proof::sign_proof;
 
 use super::autoswap::AutoswapConfig;
 use super::charge::SignOptions;
-use super::signing::TempoSigningMode;
+use super::signing::{TempoPrimitiveSigner, TempoSigningMode};
 use crate::client::PaymentProvider;
 
-/// Tempo payment provider using EVM signing.
+/// Tempo payment provider using native primitive signing.
 ///
 /// Signs TIP-20 token transfer transactions for charge requests. The signed
 /// transaction is returned in the credential for the server to broadcast,
@@ -38,7 +37,7 @@ use crate::client::PaymentProvider;
 
 #[derive(Clone)]
 pub struct TempoProvider {
-    signer: alloy::signers::local::PrivateKeySigner,
+    signer: TempoPrimitiveSigner,
     rpc_url: reqwest::Url,
     client_id: Option<String>,
     signing_mode: TempoSigningMode,
@@ -53,12 +52,12 @@ impl TempoProvider {
     ///
     /// Returns an error if the RPC URL is invalid.
     pub fn new(
-        signer: alloy::signers::local::PrivateKeySigner,
+        signer: impl Into<TempoPrimitiveSigner>,
         rpc_url: impl AsRef<str>,
     ) -> Result<Self, MppError> {
         let url = rpc_url.as_ref().parse().mpp_config("invalid RPC URL")?;
         Ok(Self {
-            signer,
+            signer: signer.into(),
             rpc_url: url,
             client_id: None,
             signing_mode: TempoSigningMode::Direct,
@@ -125,7 +124,7 @@ impl TempoProvider {
     }
 
     /// Get a reference to the signer.
-    pub fn signer(&self) -> &alloy::signers::local::PrivateKeySigner {
+    pub fn signer(&self) -> &TempoPrimitiveSigner {
         &self.signer
     }
 
@@ -162,25 +161,6 @@ impl PaymentProvider for TempoProvider {
             }
         }
 
-        if charge.amount().is_zero() {
-            let from = self.signing_mode.from_address(self.signer.address());
-            let signature = sign_proof(
-                &self.signer,
-                from,
-                charge.chain_id(),
-                &challenge.id,
-                &challenge.realm,
-            )
-            .await?;
-            let source = PaymentCredential::evm_did(charge.chain_id(), &from.to_string());
-
-            return Ok(PaymentCredential::with_source(
-                challenge.to_echo(),
-                source,
-                crate::protocol::core::PaymentPayload::proof(signature),
-            ));
-        }
-
         // Auto-generate an attribution memo when the server doesn't provide one,
         // so MPP transactions are identifiable on-chain via `TransferWithMemo` events.
         if charge.memo().is_none() {
@@ -194,7 +174,9 @@ impl PaymentProvider for TempoProvider {
 
         // If autoswap is enabled, check balance and prepend a swap call if needed.
         if let Some(autoswap_config) = &self.autoswap {
-            let from = self.signing_mode.from_address(self.signer.address());
+            let from = self
+                .signing_mode
+                .from_address(alloy::signers::Signer::address(&self.signer));
             let rpc_url: reqwest::Url = self.rpc_url.clone();
             let provider =
                 alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
@@ -217,7 +199,9 @@ impl PaymentProvider for TempoProvider {
             signing_mode: Some(self.signing_mode.clone()),
             ..Default::default()
         };
-        let signed = charge.sign_with_options(&self.signer, options).await?;
+        let signed = charge
+            .sign_with_primitive_options(&self.signer, options)
+            .await?;
         Ok(signed.into_credential())
     }
 }
@@ -225,6 +209,7 @@ impl PaymentProvider for TempoProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::signers::Signer;
 
     #[test]
     fn test_tempo_provider_new() {
@@ -378,6 +363,102 @@ mod tests {
 
         // Sanity: wallet and access key are different addresses.
         assert_ne!(wallet_address, access_key.address());
+    }
+
+    #[tokio::test]
+    async fn test_p256_access_key_signs_wallet_bound_charge_proof() {
+        use crate::client::tempo::signing::{
+            KeychainVersion, TempoP256Signer, TempoPrimitiveSigner,
+        };
+        use crate::protocol::core::Base64UrlJson;
+
+        let access_key = TempoP256Signer::from_slice(&[7_u8; 32]).unwrap();
+        let wallet_address: alloy::primitives::Address =
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+                .parse()
+                .unwrap();
+        let provider = TempoProvider::new(access_key, "https://rpc.example.com")
+            .unwrap()
+            .with_signing_mode(TempoSigningMode::Keychain {
+                wallet: wallet_address,
+                key_authorization: None,
+                version: KeychainVersion::V2,
+            });
+        assert!(matches!(provider.signer(), TempoPrimitiveSigner::P256(_)));
+
+        let request = Base64UrlJson::from_value(&serde_json::json!({
+            "amount": "0",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": { "chainId": 42431 }
+        }))
+        .unwrap();
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+        );
+
+        let credential = provider.pay(&challenge).await.unwrap();
+
+        assert!(credential.charge_payload().unwrap().is_proof());
+        assert_eq!(
+            credential.source,
+            Some(PaymentCredential::evm_did(
+                42431,
+                &wallet_address.to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_p256_access_key_signs_sponsored_charge_transaction() {
+        use crate::client::tempo::signing::{KeychainVersion, TempoP256Signer};
+        use crate::protocol::core::Base64UrlJson;
+
+        let access_key = TempoP256Signer::from_slice(&[9_u8; 32]).unwrap();
+        let wallet_address: alloy::primitives::Address =
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+                .parse()
+                .unwrap();
+        let provider = TempoProvider::new(access_key, "https://rpc.example.com")
+            .unwrap()
+            .with_signing_mode(TempoSigningMode::Keychain {
+                wallet: wallet_address,
+                key_authorization: None,
+                version: KeychainVersion::V2,
+            });
+        let request = Base64UrlJson::from_value(&serde_json::json!({
+            "amount": "100",
+            "currency": "0x20c0000000000000000000000000000000000000",
+            "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            "methodDetails": { "chainId": 42431, "feePayer": true }
+        }))
+        .unwrap();
+        let challenge = PaymentChallenge::new(
+            "challenge-123",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+        );
+
+        let credential = provider.pay(&challenge).await.unwrap();
+        let payload = credential.charge_payload().unwrap();
+
+        assert!(payload.is_transaction());
+        assert!(payload
+            .signed_tx()
+            .is_some_and(|transaction| transaction.len() > 4));
+        assert_eq!(
+            credential.source,
+            Some(PaymentCredential::evm_did(
+                42431,
+                &wallet_address.to_string()
+            ))
+        );
     }
 
     #[test]

--- a/src/client/tempo/session/store.rs
+++ b/src/client/tempo/session/store.rs
@@ -208,25 +208,9 @@ mod sqlite {
 
     /// Return the database path shared by Tempo command-line applications.
     pub fn default_channel_database_path() -> ChannelStoreResult<PathBuf> {
-        home_directory()
-            .map(|home| home.join(".tempo").join("wallet").join("channels.db"))
+        super::super::super::default_wallet_directory()
+            .map(|directory| directory.join("channels.db"))
             .ok_or_else(|| ChannelStoreError::Io("home directory is unavailable".into()))
-    }
-
-    #[cfg(not(windows))]
-    fn home_directory() -> Option<PathBuf> {
-        std::env::var_os("HOME").map(PathBuf::from)
-    }
-
-    #[cfg(windows)]
-    fn home_directory() -> Option<PathBuf> {
-        std::env::var_os("USERPROFILE")
-            .map(PathBuf::from)
-            .or_else(|| {
-                let drive = std::env::var_os("HOMEDRIVE")?;
-                let path = std::env::var_os("HOMEPATH")?;
-                Some(PathBuf::from(drive).join(path))
-            })
     }
 
     impl SqliteChannelStore {

--- a/src/client/tempo/wallet.rs
+++ b/src/client/tempo/wallet.rs
@@ -1,0 +1,243 @@
+//! Tempo Wallet state shared by native MPP command-line clients.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+use alloy::primitives::Address;
+use alloy::signers::Signer;
+use serde::Deserialize;
+
+use super::signing::{P256Jwk, TempoP256Signer};
+
+/// A Tempo Wallet account and its active P-256 access key.
+#[derive(Debug)]
+pub struct TempoWallet {
+    /// Root Tempo account controlled by the access key.
+    pub account: Address,
+    /// On-chain address of the active access key.
+    pub access_key: Address,
+    /// Chain selected by Tempo Wallet.
+    pub chain_id: u64,
+    /// Native signer reconstructed from the persisted WebCrypto JWK.
+    pub signer: TempoP256Signer,
+}
+
+/// Errors returned while loading Tempo Wallet state.
+#[derive(Debug, thiserror::Error)]
+pub enum TempoWalletError {
+    /// The platform did not expose a home directory.
+    #[error("home directory is unavailable")]
+    HomeUnavailable,
+    /// The wallet file could not be read.
+    #[error("failed to read Tempo Wallet state at {path}: {source}")]
+    Read {
+        /// Wallet path.
+        path: PathBuf,
+        /// Filesystem error.
+        source: std::io::Error,
+    },
+    /// The wallet file was not valid JSON state.
+    #[error("invalid Tempo Wallet state at {path}: {source}")]
+    Decode {
+        /// Wallet path.
+        path: PathBuf,
+        /// JSON error.
+        source: serde_json::Error,
+    },
+    /// The active account selector was missing or invalid.
+    #[error("Tempo Wallet active account is missing or invalid")]
+    ActiveAccount,
+    /// No matching access key was available for the active account and chain.
+    #[error("Tempo Wallet has no access key for active chain {0}")]
+    MissingAccessKey(u64),
+    /// The stored key is not an extractable WebCrypto P-256 JWK.
+    #[error("Tempo Wallet access key must be an extractable P-256 JWK")]
+    UnsupportedAccessKey,
+    /// The persisted JWK could not be reconstructed.
+    #[error("failed to load Tempo Wallet access key: {0}")]
+    InvalidAccessKey(#[from] super::signing::P256SignerError),
+    /// The JWK-derived address did not match the stored access-key address.
+    #[error("Tempo Wallet access-key address does not match its persisted JWK")]
+    AccessKeyAddressMismatch,
+}
+
+impl TempoWallet {
+    /// Load the active account and access key from a Tempo Wallet store.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, TempoWalletError> {
+        let path = path.as_ref();
+        let bytes = fs::read(path).map_err(|source| TempoWalletError::Read {
+            path: path.to_owned(),
+            source,
+        })?;
+        let file: TempoWalletFile =
+            serde_json::from_slice(&bytes).map_err(|source| TempoWalletError::Decode {
+                path: path.to_owned(),
+                source,
+            })?;
+        let state = file.store.state;
+        let account = active_account(&state)?;
+        let access_key = state
+            .access_keys
+            .into_iter()
+            .find(|key| key.chain_id == state.chain_id && key.access == account)
+            .ok_or(TempoWalletError::MissingAccessKey(state.chain_id))?;
+        if access_key.key_type != "p256" || access_key.handle.kind != "webcrypto-p256" {
+            return Err(TempoWalletError::UnsupportedAccessKey);
+        }
+        let signer = TempoP256Signer::from_webcrypto_jwk(&access_key.handle.jwk)?;
+        if signer.address() != access_key.address {
+            return Err(TempoWalletError::AccessKeyAddressMismatch);
+        }
+        Ok(Self {
+            account,
+            access_key: access_key.address,
+            chain_id: state.chain_id,
+            signer,
+        })
+    }
+
+    /// Load `~/.tempo/wallet/store.json`.
+    pub fn load_default() -> Result<Self, TempoWalletError> {
+        Self::load(default_wallet_store_path()?)
+    }
+}
+
+/// Return the wallet path shared by Tempo command-line applications.
+pub fn default_wallet_store_path() -> Result<PathBuf, TempoWalletError> {
+    super::default_wallet_directory()
+        .map(|directory| directory.join("store.json"))
+        .ok_or(TempoWalletError::HomeUnavailable)
+}
+
+#[derive(Deserialize)]
+struct TempoWalletFile {
+    #[serde(rename = "tempo-cli.store")]
+    store: TempoWalletEnvelope,
+}
+
+#[derive(Deserialize)]
+struct TempoWalletEnvelope {
+    state: TempoWalletState,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TempoWalletState {
+    active_account: serde_json::Value,
+    chain_id: u64,
+    accounts: Vec<TempoWalletAccount>,
+    access_keys: Vec<TempoAccessKey>,
+}
+
+#[derive(Deserialize)]
+struct TempoWalletAccount {
+    address: Address,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TempoAccessKey {
+    address: Address,
+    access: Address,
+    chain_id: u64,
+    key_type: String,
+    handle: TempoAccessKeyHandle,
+}
+
+#[derive(Deserialize)]
+struct TempoAccessKeyHandle {
+    kind: String,
+    jwk: P256Jwk,
+}
+
+fn active_account(state: &TempoWalletState) -> Result<Address, TempoWalletError> {
+    if let Some(index) = state.active_account.as_u64() {
+        return usize::try_from(index)
+            .ok()
+            .and_then(|index| state.accounts.get(index))
+            .map(|account| account.address)
+            .ok_or(TempoWalletError::ActiveAccount);
+    }
+    if let Some(address) = state.active_account.as_str() {
+        let address = Address::from_str(address).map_err(|_| TempoWalletError::ActiveAccount)?;
+        if state
+            .accounts
+            .iter()
+            .any(|account| account.address == address)
+        {
+            return Ok(address);
+        }
+    }
+    Err(TempoWalletError::ActiveAccount)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_active_account_by_index_or_address() {
+        let address: Address = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+            .parse()
+            .unwrap();
+        let state = TempoWalletState {
+            active_account: serde_json::json!(0),
+            chain_id: 4217,
+            accounts: vec![TempoWalletAccount { address }],
+            access_keys: vec![],
+        };
+        assert_eq!(active_account(&state).unwrap(), address);
+
+        let state = TempoWalletState {
+            active_account: serde_json::json!(address.to_string()),
+            ..state
+        };
+        assert_eq!(active_account(&state).unwrap(), address);
+    }
+
+    #[test]
+    fn loads_accounts_sdk_access_key() {
+        let path =
+            std::env::temp_dir().join(format!("mpp-rs-tempo-wallet-{}.json", std::process::id()));
+        let json = r#"{
+          "tempo-cli.store": {
+            "state": {
+              "activeAccount": 0,
+              "chainId": 4217,
+              "accounts": [{"address":"0x1111111111111111111111111111111111111111"}],
+              "accessKeys": [{
+                "address":"0xf0159a522607cd6ab1097204c9fafb7bbe6afb6c",
+                "access":"0x1111111111111111111111111111111111111111",
+                "chainId":4217,
+                "keyType":"p256",
+                "handle":{"kind":"webcrypto-p256","jwk":{
+                  "kty":"EC","crv":"P-256",
+                  "x":"OtOGGpViE5JRa7WT7wVYPtLlhm9ctiYKMBcjf9ibkK8",
+                  "y":"0JYcfjcHWmeRo5xh9WKVsCttJlZ7YV5gqkHuHI6DOI0",
+                  "d":"QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI"
+                }}
+              }]
+            }
+          }
+        }"#;
+        fs::write(&path, json).unwrap();
+        let wallet = TempoWallet::load(&path).unwrap();
+        fs::remove_file(path).unwrap();
+
+        assert_eq!(
+            wallet.account,
+            "0x1111111111111111111111111111111111111111"
+                .parse::<Address>()
+                .unwrap()
+        );
+        assert_eq!(
+            wallet.access_key,
+            "0xf0159a522607cd6ab1097204c9fafb7bbe6afb6c"
+                .parse::<Address>()
+                .unwrap()
+        );
+    }
+}

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -3,7 +3,7 @@
 use alloy::primitives::{keccak256, Address, B256};
 use alloy::sol_types::{eip712_domain, SolStruct};
 #[cfg(feature = "evm")]
-use tempo_primitives::transaction::TempoSignature;
+use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
 
 use crate::error::{MppError, ResultExt};
 
@@ -121,6 +121,28 @@ pub async fn sign_proof(
         .mpp_http("failed to sign proof")?;
 
     Ok(alloy::hex::encode_prefixed(signature.as_bytes()))
+}
+
+/// Sign a wallet-bound proof with any native Tempo primitive signer.
+///
+/// This supports secp256k1, P-256, and WebAuthn-shaped primitive signatures.
+/// When `account` is a root wallet and the signer is an access key, the server
+/// verifies the recovered primitive signer against that wallet's on-chain
+/// keychain authorization.
+#[cfg(feature = "evm")]
+pub async fn sign_proof_primitive(
+    signer: &impl alloy::signers::Signer<PrimitiveSignature>,
+    account: Address,
+    chain_id: u64,
+    challenge_id: &str,
+    realm: &str,
+) -> crate::error::Result<String> {
+    let signature = signer
+        .sign_hash(&signing_hash(account, chain_id, challenge_id, realm))
+        .await
+        .mpp_http("failed to sign proof")?;
+    let envelope = TempoSignature::Primitive(signature);
+    Ok(alloy::hex::encode_prefixed(envelope.to_bytes()))
 }
 
 /// Verify a zero-amount charge proof against the expected signer.


### PR DESCRIPTION
## Summary
- load the active Tempo Wallet account and extractable P-256 access key from `~/.tempo/wallet/store.json`
- use the wallet-bound access key for Tempo charge proofs, sponsored transactions, and native session vouchers
- share the default `~/.tempo/wallet` directory between `store.json` and `channels.db`

## Validation
- `cargo test --features tempo,client,sqlite` (662 unit tests, 50 doctests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`