### PR TITLE
feat(tempo): complete native session websocket lifecycle

### DIFF
--- a/.changelog/calm-channels-top-up.md
+++ b/.changelog/calm-channels-top-up.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Added automatic native TIP-1034 channel top-ups before session vouchers exceed the current deposit, with credentials bound to each active WebSocket challenge across reconnects.

--- a/.changelog/calm-echo-description.md
+++ b/.changelog/calm-echo-description.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Preserve the server challenge description in credential echoes so applications can route out-of-band session management requests consistently with MPPx.

--- a/.changelog/gentle-websocket-authorization.md
+++ b/.changelog/gentle-websocket-authorization.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Authorize canonical application WebSockets without charging their session base tick before the server requests a billable voucher.

--- a/.changelog/gentle-websocket-authorization.md
+++ b/.changelog/gentle-websocket-authorization.md
@@ -2,4 +2,5 @@
 "mpp": patch
 ---
 
-Authorize canonical application WebSockets without charging their session base tick before the server requests a billable voucher.
+Authorize canonical application WebSockets with their advertised opening amount,
+and provide a top-up-aware authorization path for full reusable channels.

--- a/.changelog/quiet-application-disconnect.md
+++ b/.changelog/quiet-application-disconnect.md
@@ -1,0 +1,6 @@
+---
+"alloy-transport-mpp": minor
+---
+
+Add `MppApplicationWs::disconnect` to close an application WebSocket without
+settling its reusable payment session.

--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -269,6 +269,16 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
         }
     }
 
+    /// Closes only the application WebSocket, leaving the payment session open.
+    ///
+    /// Use this when an application transport is shutting down but its channel
+    /// should remain reusable by a later connection. To settle and refund the
+    /// channel instead, use [`Self::close`].
+    pub async fn disconnect(mut self) -> Result<(), MppWsError> {
+        self.socket.close(None).await?;
+        Ok(())
+    }
+
     /// Requests a final session receipt and channel settlement handshake.
     pub async fn close(mut self) -> Result<Value, MppWsError>
     where

--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -212,6 +212,7 @@ where
 
         let mut client = MppApplicationWs {
             socket,
+            challenge,
             voucher_provider: self.voucher_provider.clone(),
             receipt_tx: self.receipt_tx.clone(),
             events_tx: self.events_tx.clone(),
@@ -224,6 +225,7 @@ where
 /// An authorized canonical MPP WebSocket carrying arbitrary text messages.
 pub struct MppApplicationWs<V> {
     socket: Socket,
+    challenge: PaymentChallenge,
     voucher_provider: V,
     receipt_tx: watch::Sender<Option<Value>>,
     events_tx: broadcast::Sender<MppApplicationEvent>,
@@ -248,7 +250,10 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
                     let _ = self
                         .events_tx
                         .send(MppApplicationEvent::NeedVoucher(data.clone()));
-                    let voucher = self.voucher_provider.next_voucher(&data).await?;
+                    let voucher = self
+                        .voucher_provider
+                        .next_voucher_for_challenge(&self.challenge, &data)
+                        .await?;
                     send_authorization(&mut self.socket, &voucher).await?;
                     let _ = self.events_tx.send(MppApplicationEvent::VoucherSent);
                 }
@@ -279,7 +284,10 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
                 ServerFrame::CloseReady { data } => {
                     self.accept_receipt(data.clone(), true);
                     let request = close_request(&data)?;
-                    let credential = self.voucher_provider.close_credential(&request).await?;
+                    let credential = self
+                        .voucher_provider
+                        .close_credential_for_challenge(&self.challenge, &request)
+                        .await?;
                     send_authorization(&mut self.socket, &credential).await?;
                     let _ = self
                         .events_tx
@@ -294,7 +302,10 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
                     }
                 }
                 ServerFrame::NeedVoucher { data } => {
-                    let voucher = self.voucher_provider.next_voucher(&data).await?;
+                    let voucher = self
+                        .voucher_provider
+                        .next_voucher_for_challenge(&self.challenge, &data)
+                        .await?;
                     send_authorization(&mut self.socket, &voucher).await?;
                 }
                 ServerFrame::Error { status, message } => {

--- a/crates/alloy-transport-mpp/src/ws.rs
+++ b/crates/alloy-transport-mpp/src/ws.rs
@@ -108,6 +108,19 @@ pub trait VoucherProvider: Clone + Send + Sync + 'static {
         &self,
         request: &VoucherRequest,
     ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
+
+    /// Produce a voucher bound to the challenge selected for this socket.
+    ///
+    /// Providers that do not retain mutable challenge state can use the
+    /// default implementation. Session managers should override this so
+    /// overlapping reconnects cannot cross-sign credentials.
+    fn next_voucher_for_challenge(
+        &self,
+        _challenge: &PaymentChallenge,
+        request: &VoucherRequest,
+    ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send {
+        self.next_voucher(request)
+    }
 }
 
 /// Companion provider for the final signed session close action.
@@ -117,6 +130,15 @@ pub trait CloseProvider: Clone + Send + Sync + 'static {
         &self,
         request: &CloseRequest,
     ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
+
+    /// Produce a close credential bound to this socket's selected challenge.
+    fn close_credential_for_challenge(
+        &self,
+        _challenge: &PaymentChallenge,
+        request: &CloseRequest,
+    ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send {
+        self.close_credential(request)
+    }
 }
 
 /// Default no-op [`VoucherProvider`].

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -2,7 +2,10 @@ use alloy_transport_mpp::{
     CloseProvider, CloseRequest, MppApplicationWsConnect, VoucherProvider, VoucherRequest,
 };
 use axum::{
-    extract::ws::{rejection::WebSocketUpgradeRejection, Message, WebSocketUpgrade},
+    extract::{
+        ws::{rejection::WebSocketUpgradeRejection, Message, WebSocketUpgrade},
+        State,
+    },
     http::{header::WWW_AUTHENTICATE, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
@@ -15,6 +18,9 @@ use mpp::{
 };
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
+use tokio::sync::{oneshot, Mutex};
+
+use std::sync::Arc;
 
 #[derive(Clone)]
 struct StubProvider;
@@ -209,6 +215,38 @@ async fn route(upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>) -> 
         .into_response()
 }
 
+type DisconnectSignal = Arc<Mutex<Option<oneshot::Sender<bool>>>>;
+
+async fn disconnect_route(
+    State(signal): State<DisconnectSignal>,
+    upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+) -> Response {
+    let Ok(upgrade) = upgrade else {
+        let header = HeaderValue::from_str(&challenge().to_header().unwrap()).unwrap();
+        return (StatusCode::PAYMENT_REQUIRED, [(WWW_AUTHENTICATE, header)]).into_response();
+    };
+
+    upgrade
+        .on_upgrade(|mut socket| async move {
+            let authorization = socket.next().await.unwrap().unwrap();
+            assert!(matches!(authorization, Message::Text(_)));
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "payment-receipt", "data": receipt() })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+
+            let transport_only_close = matches!(socket.next().await, Some(Ok(Message::Close(_))));
+            if let Some(signal) = signal.lock().await.take() {
+                let _ = signal.send(transport_only_close);
+            }
+        })
+        .into_response()
+}
+
 #[tokio::test]
 async fn probes_then_authorizes_and_translates_application_messages() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -225,4 +263,34 @@ async fn probes_then_authorizes_and_translates_application_messages() {
     socket.send("hello").await.unwrap();
     assert_eq!(socket.next().await.unwrap(), "world");
     assert_eq!(socket.close().await.unwrap()["channelId"], "0xchannel");
+}
+
+#[tokio::test]
+async fn disconnect_closes_transport_without_requesting_session_settlement() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (signal_tx, signal_rx) = oneshot::channel();
+    let signal = Arc::new(Mutex::new(Some(signal_tx)));
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new()
+                .route("/", get(disconnect_route))
+                .with_state(signal),
+        )
+        .await
+        .unwrap();
+    });
+
+    let connector =
+        MppApplicationWsConnect::new(format!("ws://{address}/"), StubProvider, StubProvider);
+    connector
+        .connect()
+        .await
+        .unwrap()
+        .disconnect()
+        .await
+        .unwrap();
+
+    assert!(signal_rx.await.unwrap());
 }

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -34,22 +34,41 @@ impl PaymentProvider for StubProvider {
 
 impl VoucherProvider for StubProvider {
     async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request(
+            "socket-bound voucher challenge was not forwarded",
+        ))
+    }
+
+    async fn next_voucher_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        _: &VoucherRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        assert_eq!(challenge.id, "challenge-1");
         Ok(PaymentCredential::new(
-            challenge().to_echo(),
+            challenge.to_echo(),
             PaymentPayload::hash("0xvoucher"),
         ))
     }
 }
 
 impl CloseProvider for StubProvider {
-    async fn close_credential(
+    async fn close_credential(&self, _: &CloseRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request(
+            "socket-bound close challenge was not forwarded",
+        ))
+    }
+
+    async fn close_credential_for_challenge(
         &self,
+        challenge: &PaymentChallenge,
         request: &CloseRequest,
     ) -> Result<PaymentCredential, MppError> {
+        assert_eq!(challenge.id, "challenge-1");
         assert_eq!(request.channel_id, "0xchannel");
         assert_eq!(request.cumulative_amount, "37");
         Ok(PaymentCredential::new(
-            challenge().to_echo(),
+            challenge.to_echo(),
             PaymentPayload::hash("0xclose"),
         ))
     }
@@ -118,6 +137,31 @@ async fn route(upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>) -> 
             };
             let application: Value = serde_json::from_str(&application).unwrap();
             assert_eq!(application, json!({ "mpp": "message", "data": "hello" }));
+
+            socket
+                .send(Message::Text(
+                    json!({
+                        "mpp": "payment-need-voucher",
+                        "data": {
+                            "channelId": "0xchannel",
+                            "requiredCumulative": "100",
+                            "acceptedCumulative": "0",
+                            "deposit": "100"
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+            let voucher = socket.next().await.unwrap().unwrap();
+            let Message::Text(voucher) = voucher else {
+                panic!("expected voucher authorization text frame")
+            };
+            assert_eq!(
+                serde_json::from_str::<Value>(&voucher).unwrap()["mpp"],
+                "authorization"
+            );
 
             socket
                 .send(Message::Text(

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -837,6 +837,18 @@ pub struct OpenPrecompilePayloadOptions {
     pub fee_payer: bool,
 }
 
+/// Options for a descriptor-backed TIP-1034 top-up transaction.
+pub struct TopUpPrecompilePayloadOptions<'a> {
+    /// Existing channel descriptor.
+    pub descriptor: &'a ChannelDescriptor,
+    /// Amount added to the existing channel deposit.
+    pub additional_deposit: u128,
+    /// Tempo chain ID.
+    pub chain_id: u64,
+    /// Whether the server may sponsor this management transaction.
+    pub fee_payer: bool,
+}
+
 /// Open payload targeting the TIP-1034 reserve precompile. Single-call tx
 /// (no `approve` needed: precompile is on the TIP-1035 implicit approvals
 /// list). Channel id is derived against the unsigned tx's `expiringNonceHash`.
@@ -993,6 +1005,98 @@ where
     };
 
     Ok((entry, payload))
+}
+
+/// Prepare and sign a descriptor-backed TIP-1034 top-up transaction.
+///
+/// This mirrors MPPx's `createTopUpPayload`: the returned transaction is sent
+/// to the MPP server as a management credential, and the server broadcasts it
+/// before accepting a voucher that requires the additional headroom.
+#[cfg(feature = "tempo")]
+pub async fn create_precompile_top_up_transaction_payload<P, S>(
+    provider: &P,
+    signer: &S,
+    signing_mode: Option<&crate::client::tempo::signing::TempoSigningMode>,
+    payer: Address,
+    options: TopUpPrecompilePayloadOptions<'_>,
+) -> Result<SessionCredentialPayload, MppError>
+where
+    P: Provider<TempoNetwork>,
+    S: Clone + Into<crate::client::tempo::signing::TempoPrimitiveSigner>,
+{
+    let additional_deposit =
+        parse_precompile_amount(options.additional_deposit, "additional_deposit")?;
+    if additional_deposit.is_zero() {
+        return Err(MppError::InvalidConfig(
+            "top-up amount must be greater than zero".into(),
+        ));
+    }
+
+    let default_mode = crate::client::tempo::signing::TempoSigningMode::Direct;
+    let signing_mode = signing_mode.unwrap_or(&default_mode);
+    let primitive_signer = signer.clone().into();
+    let descriptor = precompile_descriptor_from_wire(options.descriptor)?;
+    let calls = vec![Call {
+        to: TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS),
+        value: U256::ZERO,
+        input: Bytes::from(
+            ITIP20ChannelReserve::topUpCall::new((descriptor, additional_deposit)).abi_encode(),
+        ),
+    }];
+    let nonce = if options.fee_payer {
+        0
+    } else {
+        provider
+            .get_transaction_count(payer)
+            .await
+            .mpp_http("failed to get nonce")?
+    };
+    let gas_price = provider
+        .get_gas_price()
+        .await
+        .mpp_http("failed to get gas price")?;
+    let (nonce, nonce_key, valid_before) =
+        precompile_open_tx_nonce_fields(options.fee_payer, nonce);
+    let unsigned_tx = build_tempo_tx(TempoTxOptions {
+        calls,
+        chain_id: options.chain_id,
+        fee_token: options
+            .descriptor
+            .token
+            .parse()
+            .mpp_config("invalid TIP-1034 descriptor token")?,
+        nonce,
+        nonce_key,
+        gas_limit: 2_000_000,
+        max_fee_per_gas: gas_price,
+        max_priority_fee_per_gas: gas_price,
+        fee_payer: options.fee_payer,
+        valid_before,
+        key_authorization: signing_mode.key_authorization().cloned(),
+    });
+    let tx_bytes = if options.fee_payer {
+        crate::client::tempo::signing::sign_and_encode_fee_payer_request_primitive_async(
+            unsigned_tx,
+            &primitive_signer,
+            signing_mode,
+        )
+        .await?
+    } else {
+        crate::client::tempo::signing::sign_and_encode_primitive_async(
+            unsigned_tx,
+            &primitive_signer,
+            signing_mode,
+        )
+        .await?
+    };
+    let channel_id =
+        compute_precompile_channel_id_from_descriptor(options.descriptor, options.chain_id)?;
+    Ok(create_precompile_top_up_payload(
+        channel_id,
+        options.descriptor.clone(),
+        alloy::hex::encode_prefixed(&tx_bytes),
+        options.additional_deposit,
+    ))
 }
 
 /// On-chain channel state returned by the escrow contract.

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -1116,6 +1116,7 @@ impl TempoSessionProvider {
                         })?;
                 }
                 if entry.cumulative_amount > entry.deposit {
+                    self.assert_within_max_deposit(entry.cumulative_amount)?;
                     let Some(top_up) = top_up else {
                         return Err(MppError::InvalidConfig(
                             "session cumulative amount exceeds channel deposit".into(),

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -985,13 +985,25 @@ impl TempoSessionProvider {
     }
 }
 
-impl PaymentProvider for TempoSessionProvider {
-    fn supports(&self, method: &str, intent: &str) -> bool {
-        method == crate::protocol::methods::tempo::METHOD_NAME
-            && intent == crate::protocol::methods::tempo::INTENT_SESSION
+impl TempoSessionProvider {
+    /// Creates the initial authorization for a canonical application WebSocket.
+    ///
+    /// Opening or reconnecting the socket is not itself a billable request.
+    /// Existing channels therefore echo their current highest voucher, while
+    /// new channels open with a zero cumulative amount. The server requests
+    /// each billable increment later with `payment-need-voucher` frames.
+    pub async fn application_websocket_credential(
+        &self,
+        challenge: &PaymentChallenge,
+    ) -> Result<PaymentCredential, MppError> {
+        self.payment_credential(challenge, false).await
     }
 
-    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+    async fn payment_credential(
+        &self,
+        challenge: &PaymentChallenge,
+        include_request_amount: bool,
+    ) -> Result<PaymentCredential, MppError> {
         use alloy::providers::ProviderBuilder;
         use tempo_alloy::TempoNetwork;
 
@@ -1021,7 +1033,11 @@ impl PaymentProvider for TempoSessionProvider {
             .parse()
             .map_err(|_| MppError::InvalidConfig("invalid currency address".to_string()))?;
 
-        let amount: u128 = session_req.parse_amount()?;
+        let amount = if include_request_amount {
+            session_req.parse_amount()?
+        } else {
+            0
+        };
         let payer = self.signing_mode.from_address(self.signer.address());
         let authorized_signer = self.authorized_signer.unwrap_or(self.signer.address());
         let precompile = is_precompile_escrow(escrow_contract);
@@ -1213,6 +1229,17 @@ impl PaymentProvider for TempoSessionProvider {
         self.notify_update(&entry);
 
         Ok(build_credential(challenge, payload, chain_id, payer))
+    }
+}
+
+impl PaymentProvider for TempoSessionProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == crate::protocol::methods::tempo::METHOD_NAME
+            && intent == crate::protocol::methods::tempo::INTENT_SESSION
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        self.payment_credential(challenge, true).await
     }
 }
 
@@ -2086,7 +2113,7 @@ mod tests {
             .channel_id_to_key
             .lock()
             .unwrap()
-            .insert(channel_id.to_string(), key);
+            .insert(channel_id.to_string(), key.clone());
 
         let req = SessionRequest {
             amount: "500".to_string(),
@@ -2139,6 +2166,35 @@ mod tests {
             }
             other => panic!("expected voucher payload, got {other:?}"),
         }
+
+        provider
+            .channels
+            .lock()
+            .unwrap()
+            .get_mut(&key)
+            .unwrap()
+            .cumulative_amount = 10_000;
+        let socket_credential = provider
+            .application_websocket_credential(&challenge)
+            .await
+            .expect("a full channel can still authorize a websocket");
+        match socket_credential
+            .payload_as::<crate::protocol::methods::tempo::session::SessionCredentialPayload>()
+            .unwrap()
+        {
+            crate::protocol::methods::tempo::session::SessionCredentialPayload::Voucher {
+                cumulative_amount,
+                ..
+            } => assert_eq!(cumulative_amount, "10000"),
+            other => panic!("expected voucher payload, got {other:?}"),
+        }
+        provider
+            .channels
+            .lock()
+            .unwrap()
+            .get_mut(&key)
+            .unwrap()
+            .cumulative_amount = 1_500;
 
         let close_amount = 1_200;
         let expected_close_sig =

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -85,6 +85,12 @@ pub struct TempoSessionProvider {
     last_challenge: Arc<Mutex<Option<PaymentChallenge>>>,
 }
 
+struct ApplicationTopUp<'a> {
+    client: &'a reqwest::Client,
+    url: &'a str,
+    headers: reqwest::header::HeaderMap,
+}
+
 impl TempoSessionProvider {
     /// Create a new Tempo session provider.
     ///
@@ -988,21 +994,40 @@ impl TempoSessionProvider {
 impl TempoSessionProvider {
     /// Creates the initial authorization for a canonical application WebSocket.
     ///
-    /// Opening or reconnecting the socket is not itself a billable request.
-    /// Existing channels therefore echo their current highest voucher, while
-    /// new channels open with a zero cumulative amount. The server requests
-    /// each billable increment later with `payment-need-voucher` frames.
+    /// The opening credential satisfies the amount advertised by the socket's
+    /// HTTP payment challenge. The server requests later increments with
+    /// `payment-need-voucher` frames.
     pub async fn application_websocket_credential(
         &self,
         challenge: &PaymentChallenge,
     ) -> Result<PaymentCredential, MppError> {
-        self.payment_credential(challenge, false).await
+        self.payment_credential(challenge, None).await
+    }
+
+    /// Creates an application WebSocket authorization and tops up an existing
+    /// channel first when its opening challenge would exceed the deposit.
+    pub async fn application_websocket_credential_with_top_up(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        headers: reqwest::header::HeaderMap,
+        challenge: &PaymentChallenge,
+    ) -> Result<PaymentCredential, MppError> {
+        self.payment_credential(
+            challenge,
+            Some(ApplicationTopUp {
+                client,
+                url,
+                headers,
+            }),
+        )
+        .await
     }
 
     async fn payment_credential(
         &self,
         challenge: &PaymentChallenge,
-        include_request_amount: bool,
+        top_up: Option<ApplicationTopUp<'_>>,
     ) -> Result<PaymentCredential, MppError> {
         use alloy::providers::ProviderBuilder;
         use tempo_alloy::TempoNetwork;
@@ -1033,11 +1058,7 @@ impl TempoSessionProvider {
             .parse()
             .map_err(|_| MppError::InvalidConfig("invalid currency address".to_string()))?;
 
-        let amount = if include_request_amount {
-            session_req.parse_amount()?
-        } else {
-            0
-        };
+        let amount = session_req.parse_amount()?;
         let payer = self.signing_mode.from_address(self.signer.address());
         let authorized_signer = self.authorized_signer.unwrap_or(self.signer.address());
         let precompile = is_precompile_escrow(escrow_contract);
@@ -1095,9 +1116,27 @@ impl TempoSessionProvider {
                         })?;
                 }
                 if entry.cumulative_amount > entry.deposit {
-                    return Err(MppError::InvalidConfig(
-                        "session cumulative amount exceeds channel deposit".into(),
-                    ));
+                    let Some(top_up) = top_up else {
+                        return Err(MppError::InvalidConfig(
+                            "session cumulative amount exceeds channel deposit".into(),
+                        ));
+                    };
+                    let additional_deposit = entry
+                        .cumulative_amount
+                        .checked_sub(entry.deposit)
+                        .ok_or_else(|| {
+                            MppError::InvalidConfig("session top-up amount underflowed".into())
+                        })?;
+                    self.top_up_with_headers_for_challenge(
+                        top_up.client,
+                        top_up.url,
+                        top_up.headers,
+                        challenge,
+                        &entry.channel_id.to_string(),
+                        additional_deposit,
+                    )
+                    .await?;
+                    entry.deposit = entry.cumulative_amount;
                 }
 
                 let payload = if precompile {
@@ -1239,7 +1278,7 @@ impl PaymentProvider for TempoSessionProvider {
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
-        self.payment_credential(challenge, true).await
+        self.payment_credential(challenge, None).await
     }
 }
 
@@ -2173,11 +2212,11 @@ mod tests {
             .unwrap()
             .get_mut(&key)
             .unwrap()
-            .cumulative_amount = 10_000;
+            .cumulative_amount = 9_500;
         let socket_credential = provider
             .application_websocket_credential(&challenge)
             .await
-            .expect("a full channel can still authorize a websocket");
+            .expect("socket authorization satisfies its opening challenge");
         match socket_credential
             .payload_as::<crate::protocol::methods::tempo::session::SessionCredentialPayload>()
             .unwrap()

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -20,9 +20,10 @@ use alloy::{
 use self::channel_ops::{
     build_credential, create_close_payload, create_open_payload,
     create_precompile_close_payload_with_descriptor_primitive, create_precompile_open_payload,
+    create_precompile_top_up_transaction_payload,
     create_precompile_voucher_payload_with_descriptor_primitive, create_voucher_payload,
     is_precompile_escrow, resolve_chain_id, resolve_escrow, try_recover_channel, ChannelEntry,
-    OpenPayloadOptions, OpenPrecompilePayloadOptions,
+    OpenPayloadOptions, OpenPrecompilePayloadOptions, TopUpPrecompilePayloadOptions,
 };
 use self::recovery::{
     hydrate_session_snapshot, read_on_chain_channel_state, recover_stored_channel, RecoveryScope,
@@ -192,6 +193,29 @@ impl TempoSessionProvider {
         if let Some(ref cb) = self.on_channel_update {
             cb(entry);
         }
+    }
+
+    fn assert_within_max_deposit(&self, cumulative_amount: u128) -> Result<(), MppError> {
+        if let Some(max_deposit) = self.max_deposit {
+            if cumulative_amount > max_deposit {
+                return Err(MppError::InvalidConfig(format!(
+                    "requested voucher amount {cumulative_amount} exceeds local max_deposit \
+                     {max_deposit}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn required_top_up(
+        &self,
+        required_cumulative: u128,
+        deposit: u128,
+    ) -> Result<Option<u128>, MppError> {
+        self.assert_within_max_deposit(required_cumulative)?;
+        Ok(required_cumulative
+            .checked_sub(deposit)
+            .filter(|additional| *additional > 0))
     }
 
     fn store_error(error: self::store::ChannelStoreError) -> MppError {
@@ -423,6 +447,19 @@ impl TempoSessionProvider {
             self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
                 MppError::InvalidConfig("no challenge available for voucher".into())
             })?;
+        self.voucher_credential_for_challenge(&challenge, channel_id_hex, required_cumulative)
+            .await
+    }
+
+    /// Create a voucher bound to the challenge selected for one transport
+    /// connection, avoiding cross-signing during overlapping reconnects.
+    pub async fn voucher_credential_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        channel_id_hex: &str,
+        required_cumulative: u128,
+    ) -> Result<PaymentCredential, MppError> {
+        self.assert_within_max_deposit(required_cumulative)?;
 
         // Find the channel entry by channel ID
         let key = {
@@ -432,7 +469,7 @@ impl TempoSessionProvider {
         let key = key.ok_or_else(|| {
             MppError::InvalidConfig(format!("no channel found for id {}", channel_id_hex))
         })?;
-        let (expected_key, expected_chain_id) = self.expected_channel_key(&challenge)?;
+        let (expected_key, expected_chain_id) = self.expected_channel_key(challenge)?;
         if key != expected_key {
             return Err(MppError::InvalidConfig(
                 "channel does not match active session".into(),
@@ -487,7 +524,200 @@ impl TempoSessionProvider {
         self.notify_update(&entry);
 
         let payer = self.signing_mode.from_address(self.signer.address());
-        Ok(build_credential(&challenge, payload, entry.chain_id, payer))
+        Ok(build_credential(challenge, payload, entry.chain_id, payer))
+    }
+
+    /// Top up the active TIP-1034 channel through the service's HTTP management
+    /// endpoint, then update the durable local channel view after acceptance.
+    pub async fn top_up_with_headers(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        headers: reqwest::header::HeaderMap,
+        channel_id_hex: &str,
+        additional_deposit: u128,
+    ) -> Result<Option<Receipt>, MppError> {
+        let challenge =
+            self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
+                MppError::InvalidConfig("no challenge available for top-up".into())
+            })?;
+        self.top_up_with_headers_for_challenge(
+            client,
+            url,
+            headers,
+            &challenge,
+            channel_id_hex,
+            additional_deposit,
+        )
+        .await
+    }
+
+    /// Top up using the challenge selected for one transport connection.
+    pub async fn top_up_with_headers_for_challenge(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        mut headers: reqwest::header::HeaderMap,
+        challenge: &PaymentChallenge,
+        channel_id_hex: &str,
+        additional_deposit: u128,
+    ) -> Result<Option<Receipt>, MppError> {
+        use alloy::providers::ProviderBuilder;
+        use reqwest::header::AUTHORIZATION;
+        use tempo_alloy::TempoNetwork;
+
+        if additional_deposit == 0 {
+            return Err(MppError::InvalidConfig(
+                "top-up amount must be greater than zero".into(),
+            ));
+        }
+        let key = self
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .get(channel_id_hex)
+            .cloned()
+            .ok_or_else(|| {
+                MppError::InvalidConfig(format!("no channel found for id {channel_id_hex}"))
+            })?;
+        let (expected_key, expected_chain_id) = self.expected_channel_key(challenge)?;
+        if key != expected_key {
+            return Err(MppError::InvalidConfig(
+                "channel does not match active session".into(),
+            ));
+        }
+        let mut entry = self
+            .channels
+            .lock()
+            .unwrap()
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| MppError::InvalidConfig("channel not found".into()))?;
+        if entry.chain_id != expected_chain_id || entry.channel_id.to_string() != channel_id_hex {
+            return Err(MppError::InvalidConfig(
+                "channel does not match active session".into(),
+            ));
+        }
+        if !is_precompile_escrow(entry.escrow_contract) {
+            return Err(MppError::InvalidConfig(
+                "automatic top-up requires the native TIP-1034 precompile".into(),
+            ));
+        }
+        let new_deposit = entry
+            .deposit
+            .checked_add(additional_deposit)
+            .ok_or_else(|| MppError::InvalidConfig("channel deposit overflowed".into()))?;
+        let session_req: SessionRequest = challenge
+            .request
+            .decode()
+            .mpp_config("failed to decode session request")?;
+        let descriptor = entry.descriptor.clone().ok_or_else(|| {
+            MppError::InvalidConfig("TIP-1034 channel descriptor is missing".into())
+        })?;
+        let payer = self.signing_mode.from_address(self.signer.address());
+        let provider =
+            ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(self.rpc_url.clone());
+        let payload = create_precompile_top_up_transaction_payload(
+            &provider,
+            &self.signer,
+            Some(&self.signing_mode),
+            payer,
+            TopUpPrecompilePayloadOptions {
+                descriptor: &descriptor,
+                additional_deposit,
+                chain_id: entry.chain_id,
+                fee_payer: session_req.fee_payer(),
+            },
+        )
+        .await?;
+        let credential = build_credential(challenge, payload, entry.chain_id, payer);
+        headers.insert(
+            AUTHORIZATION,
+            crate::protocol::core::format_authorization(&credential)?
+                .parse()
+                .mpp_config("invalid top-up authorization header")?,
+        );
+        let response = client
+            .post(url)
+            .headers(headers)
+            .send()
+            .await
+            .mpp_http("top-up POST failed")?;
+        let status = response.status();
+        let receipt = response
+            .headers()
+            .get("payment-receipt")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| crate::protocol::core::parse_receipt(value).ok());
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(MppError::Http(format!(
+                "top-up POST returned {status}: {body}"
+            )));
+        }
+
+        entry.deposit = new_deposit;
+        entry.opened = true;
+        self.persist_channel(&entry).await?;
+        self.channels.lock().unwrap().insert(key, entry.clone());
+        self.notify_update(&entry);
+        Ok(receipt)
+    }
+
+    /// Mirror MPPx need-voucher handling: top up over HTTP when required, then
+    /// return the voucher that the WebSocket transport sends in-band.
+    pub async fn voucher_credential_with_top_up(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        headers: reqwest::header::HeaderMap,
+        channel_id_hex: &str,
+        required_cumulative: u128,
+        server_deposit: u128,
+    ) -> Result<PaymentCredential, MppError> {
+        let challenge =
+            self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
+                MppError::InvalidConfig("no challenge available for voucher".into())
+            })?;
+        self.voucher_credential_with_top_up_for_challenge(
+            client,
+            url,
+            headers,
+            &challenge,
+            channel_id_hex,
+            required_cumulative,
+            server_deposit,
+        )
+        .await
+    }
+
+    /// Handle a need-voucher event using its socket-bound challenge.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn voucher_credential_with_top_up_for_challenge(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        headers: reqwest::header::HeaderMap,
+        challenge: &PaymentChallenge,
+        channel_id_hex: &str,
+        required_cumulative: u128,
+        server_deposit: u128,
+    ) -> Result<PaymentCredential, MppError> {
+        if let Some(additional_deposit) =
+            self.required_top_up(required_cumulative, server_deposit)?
+        {
+            self.top_up_with_headers_for_challenge(
+                client,
+                url,
+                headers,
+                challenge,
+                channel_id_hex,
+                additional_deposit,
+            )
+            .await?;
+        }
+        self.voucher_credential_for_challenge(challenge, channel_id_hex, required_cumulative)
+            .await
     }
 
     /// Create the final signed close credential for an active session channel.
@@ -512,6 +742,21 @@ impl TempoSessionProvider {
             .await
     }
 
+    /// Create an exact close credential bound to one transport connection.
+    pub async fn close_credential_at_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        channel_id_hex: &str,
+        cumulative_amount: u128,
+    ) -> Result<PaymentCredential, MppError> {
+        self.close_credential_for_challenge_inner(
+            challenge,
+            channel_id_hex,
+            Some(cumulative_amount),
+        )
+        .await
+    }
+
     async fn close_credential_inner(
         &self,
         channel_id_hex: &str,
@@ -521,6 +766,16 @@ impl TempoSessionProvider {
             self.last_challenge.lock().unwrap().clone().ok_or_else(|| {
                 MppError::InvalidConfig("no challenge available for close".into())
             })?;
+        self.close_credential_for_challenge_inner(&challenge, channel_id_hex, requested_cumulative)
+            .await
+    }
+
+    async fn close_credential_for_challenge_inner(
+        &self,
+        challenge: &PaymentChallenge,
+        channel_id_hex: &str,
+        requested_cumulative: Option<u128>,
+    ) -> Result<PaymentCredential, MppError> {
         let key = self
             .channel_id_to_key
             .lock()
@@ -530,7 +785,7 @@ impl TempoSessionProvider {
             .ok_or_else(|| {
                 MppError::InvalidConfig(format!("no channel found for id {channel_id_hex}"))
             })?;
-        let (expected_key, expected_chain_id) = self.expected_channel_key(&challenge)?;
+        let (expected_key, expected_chain_id) = self.expected_channel_key(challenge)?;
         if key != expected_key {
             return Err(MppError::InvalidConfig(
                 "channel does not match active session".into(),
@@ -579,7 +834,7 @@ impl TempoSessionProvider {
             .await?
         };
         let payer = self.signing_mode.from_address(self.signer.address());
-        Ok(build_credential(&challenge, payload, entry.chain_id, payer))
+        Ok(build_credential(challenge, payload, entry.chain_id, payer))
     }
 
     /// Send a voucher for a need-voucher SSE event.
@@ -905,6 +1160,11 @@ impl PaymentProvider for TempoSessionProvider {
 
         // No existing channel — open a new one
         let deposit = self.resolve_deposit(session_req.suggested_deposit.as_deref())?;
+        if deposit < amount {
+            return Err(MppError::InvalidConfig(format!(
+                "opening deposit {deposit} below request amount {amount}"
+            )));
+        }
 
         let (entry, payload) = if precompile {
             create_precompile_open_payload(
@@ -1073,6 +1333,18 @@ mod tests {
         let provider = TempoSessionProvider::new(signer, "https://rpc.example.com").unwrap();
 
         assert!(provider.resolve_deposit(None).is_err());
+    }
+
+    #[test]
+    fn need_voucher_requires_top_up_before_signing_beyond_deposit() {
+        let provider = make_test_provider().with_max_deposit(1_000_000);
+
+        assert_eq!(provider.required_top_up(12_000, 20_000).unwrap(), None);
+        assert_eq!(
+            provider.required_top_up(25_000, 20_000).unwrap(),
+            Some(5_000)
+        );
+        assert!(provider.required_top_up(1_000_001, 20_000).is_err());
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -229,6 +229,7 @@ mod tests {
                 intent: "charge".into(),
                 request: Base64UrlJson::from_raw("eyJhbW91bnQiOiIxMDAwIn0"),
                 expires: None,
+                description: None,
                 digest: None,
                 opaque: None,
             },

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -260,6 +260,7 @@ impl PaymentChallenge {
             intent: self.intent.clone(),
             request: self.request.clone(),
             expires: self.expires.clone(),
+            description: self.description.clone(),
             digest: self.digest.clone(),
             opaque: self.opaque.clone(),
         }
@@ -517,6 +518,13 @@ pub struct ChallengeEcho {
     /// Challenge expiration time (ISO 8601)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<String>,
+
+    /// Human-readable description echoed from the server challenge.
+    ///
+    /// Some applications use this stable server-issued value to route
+    /// out-of-band session management credentials back to the paid resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 
     /// Request body digest for body binding (RFC 9530 Content-Digest)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -707,7 +707,8 @@ mod tests {
 
     #[test]
     fn test_parse_authorization() {
-        let challenge = test_challenge();
+        let mut challenge = test_challenge();
+        challenge.description = Some("OpenAI Responses WebSocket session".to_string());
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             "did:pkh:eip155:42431:0x123",
@@ -718,6 +719,10 @@ mod tests {
         let parsed = parse_authorization(&header).unwrap();
 
         assert_eq!(parsed.challenge.id, "abc123");
+        assert_eq!(
+            parsed.challenge.description.as_deref(),
+            Some("OpenAI Responses WebSocket session")
+        );
         assert_eq!(
             parsed.source,
             Some("did:pkh:eip155:42431:0x123".to_string())

--- a/src/protocol/traits/charge.rs
+++ b/src/protocol/traits/charge.rs
@@ -184,6 +184,7 @@ mod tests {
             intent: "charge".into(),
             request: crate::protocol::core::Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
+            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -150,6 +150,7 @@ mod tests {
             intent: "session".into(),
             request: crate::protocol::core::Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
+            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/server/compose.rs
+++ b/src/server/compose.rs
@@ -258,6 +258,7 @@ mod tests {
             intent: "charge".into(),
             request: Base64UrlJson::from_raw(request_raw),
             expires: Some(expires),
+            description: None,
             digest: None,
             opaque: None,
         };
@@ -326,6 +327,7 @@ mod tests {
             intent: "session".into(),
             request: Base64UrlJson::from_raw(request.raw()),
             expires: Some(expires),
+            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -1359,6 +1359,7 @@ mod tests {
             intent: "charge".into(),
             request: Base64UrlJson::from_raw(request),
             expires: Some(expires),
+            description: None,
             digest: None,
             opaque: None,
         };
@@ -1399,6 +1400,7 @@ mod tests {
             intent: "charge".into(),
             request: encoded,
             expires: Some(expires),
+            description: None,
             digest: Some(digest),
             opaque: None,
         };
@@ -1538,6 +1540,7 @@ mod tests {
                 intent: "charge".into(),
                 request: encoded,
                 expires: Some(expires),
+                description: None,
                 digest: None,
                 opaque: None,
             },
@@ -2638,6 +2641,7 @@ mod tests {
             intent: "session".into(),
             request: Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
+            description: None,
             digest: None,
             opaque: None,
         };
@@ -2875,6 +2879,7 @@ mod tests {
             intent: "charge".into(),
             request: encoded,
             expires: None,
+            description: None,
             digest: None,
             opaque: None,
         };
@@ -3125,6 +3130,7 @@ mod tests {
             intent: "session".into(),
             request: encoded,
             expires: None,
+            description: None,
             digest: None,
             opaque: None,
         };


### PR DESCRIPTION
## Summary
- top up native Tempo sessions before HTTP vouchers and application WebSocket authorization
- authorize application sockets without opening a throwaway billing WebSocket
- disconnect application sockets without settling reusable channels
- enforce the advertised deposit cap and preserve challenge descriptions on credentials

## Validation
- repository CI feature set: 1,050 unit tests, 11 Stripe integration tests, 5 WebSocket integration tests, 61 doctests
- Alloy transport: 14 unit tests, 2 application WebSocket tests, 23 canonical WebSocket integration tests
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

The opt-in `integration_charge` binary requires a Tempo node at localhost:8545; GitHub CI starts the repository Docker devnet for that job.