### PR TITLE
fix(tempo): match MPPx fee payer envelopes

### DIFF
--- a/.changelog/calm-echo-description.md
+++ b/.changelog/calm-echo-description.md
@@ -1,5 +1,0 @@
----
-"mpp": patch
----
-
-Preserve the server challenge description in credential echoes so applications can route out-of-band session management requests consistently with MPPx.

--- a/.changelog/fix-tempo-fee-payer-envelope.md
+++ b/.changelog/fix-tempo-fee-payer-envelope.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Match MPPx and Tempo fee sponsorship by encoding P-256 charge and TIP-1034 management credentials as sender-signed `0x78` envelopes.

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -38,7 +38,7 @@ use tempo_primitives::transaction::{Call, SignedKeyAuthorization, TempoTransacti
 use self::tx_builder::{build_charge_credential, build_tempo_tx, estimate_gas, TempoTxOptions};
 use crate::client::tempo::signing::{
     sign_and_encode_async, sign_and_encode_fee_payer_envelope_async,
-    sign_and_encode_fee_payer_request_primitive_async, sign_and_encode_primitive_async,
+    sign_and_encode_fee_payer_envelope_primitive_async, sign_and_encode_primitive_async,
     TempoPrimitiveSigner, TempoSigningMode,
 };
 use crate::error::{MppError, ResultExt};
@@ -447,7 +447,7 @@ impl PreparedTempoCharge {
             return Ok(self.proof(signature));
         };
         let tx_bytes = if self.fee_payer {
-            sign_and_encode_fee_payer_request_primitive_async(
+            sign_and_encode_fee_payer_envelope_primitive_async(
                 transaction,
                 signer,
                 &self.signing_mode,

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -449,9 +449,11 @@ mod tests {
         let payload = credential.charge_payload().unwrap();
 
         assert!(payload.is_transaction());
-        assert!(payload
-            .signed_tx()
-            .is_some_and(|transaction| transaction.len() > 4));
+        let transaction = payload.signed_tx().expect("missing signed transaction");
+        assert!(
+            transaction.starts_with("0x78"),
+            "charges use sponsorship envelopes"
+        );
         assert_eq!(
             credential.source,
             Some(PaymentCredential::evm_did(

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -959,7 +959,7 @@ where
     );
 
     let tx_bytes = if options.fee_payer {
-        crate::client::tempo::signing::sign_and_encode_fee_payer_request_primitive_async(
+        crate::client::tempo::signing::sign_and_encode_fee_payer_envelope_primitive_async(
             unsigned_tx,
             &primitive_signer,
             signing_mode,
@@ -1075,7 +1075,7 @@ where
         key_authorization: signing_mode.key_authorization().cloned(),
     });
     let tx_bytes = if options.fee_payer {
-        crate::client::tempo::signing::sign_and_encode_fee_payer_request_primitive_async(
+        crate::client::tempo::signing::sign_and_encode_fee_payer_envelope_primitive_async(
             unsigned_tx,
             &primitive_signer,
             signing_mode,

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -303,6 +303,49 @@ pub async fn sign_and_encode_fee_payer_request_primitive_async(
     Ok(out)
 }
 
+/// Primitive-signature version of [`sign_and_encode_fee_payer_envelope_async`].
+///
+/// This mirrors MPPx/Tempo's sender-only `signTransaction({ feePayer: true })`
+/// encoding for both charge credentials and TIP-1034 session management.
+pub async fn sign_and_encode_fee_payer_envelope_primitive_async(
+    mut tx: tempo_primitives::transaction::TempoTransaction,
+    signer: &impl alloy::signers::Signer<PrimitiveSignature>,
+    mode: &TempoSigningMode,
+) -> Result<Vec<u8>, MppError> {
+    let sender = mode.from_address(signer.address());
+    if tx.fee_payer_signature.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope requires fee_payer_signature placeholder; build tx with TempoTxOptions { fee_payer: true }"
+                .to_string(),
+        ));
+    }
+    if tx.fee_token.is_some() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must not include fee_token (server chooses)".to_string(),
+        ));
+    }
+    if tx.nonce_key != U256::MAX {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must use expiring nonce key (U256::MAX)".to_string(),
+        ));
+    }
+    if tx.valid_before.is_none() {
+        return Err(MppError::InvalidConfig(
+            "fee payer envelope must include valid_before".to_string(),
+        ));
+    }
+
+    tx.access_list = AccessList::default();
+    let sig_hash = tx.signature_hash();
+    let hash_to_sign = effective_signing_hash(sig_hash, mode);
+    let signature = signer
+        .sign_hash(&hash_to_sign)
+        .await
+        .mpp_http("failed to sign transaction")?;
+    let signature = build_tempo_signature_primitive(signature, mode);
+    Ok(FeePayerEnvelope78::from_signing_tx(tx, sender, signature).encoded_envelope())
+}
+
 /// Async version of [`sign_and_encode_fee_payer_envelope`].
 pub async fn sign_and_encode_fee_payer_envelope_async(
     mut tx: tempo_primitives::transaction::TempoTransaction,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -229,7 +229,6 @@ mod tests {
                 intent: "charge".into(),
                 request: Base64UrlJson::from_raw("eyJhbW91bnQiOiIxMDAwIn0"),
                 expires: None,
-                description: None,
                 digest: None,
                 opaque: None,
             },

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -260,7 +260,6 @@ impl PaymentChallenge {
             intent: self.intent.clone(),
             request: self.request.clone(),
             expires: self.expires.clone(),
-            description: self.description.clone(),
             digest: self.digest.clone(),
             opaque: self.opaque.clone(),
         }
@@ -518,13 +517,6 @@ pub struct ChallengeEcho {
     /// Challenge expiration time (ISO 8601)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires: Option<String>,
-
-    /// Human-readable description echoed from the server challenge.
-    ///
-    /// Some applications use this stable server-issued value to route
-    /// out-of-band session management credentials back to the paid resource.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
 
     /// Request body digest for body binding (RFC 9530 Content-Digest)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -707,8 +707,7 @@ mod tests {
 
     #[test]
     fn test_parse_authorization() {
-        let mut challenge = test_challenge();
-        challenge.description = Some("OpenAI Responses WebSocket session".to_string());
+        let challenge = test_challenge();
         let credential = PaymentCredential::with_source(
             challenge.to_echo(),
             "did:pkh:eip155:42431:0x123",
@@ -719,10 +718,6 @@ mod tests {
         let parsed = parse_authorization(&header).unwrap();
 
         assert_eq!(parsed.challenge.id, "abc123");
-        assert_eq!(
-            parsed.challenge.description.as_deref(),
-            Some("OpenAI Responses WebSocket session")
-        );
         assert_eq!(
             parsed.source,
             Some("did:pkh:eip155:42431:0x123".to_string())

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -1,19 +1,16 @@
 //! Fee payer envelope (magic byte 0x78).
 //!
-//! This is a helper encoding used for fee-sponsored transactions.
+//! This is the native sender-signed encoding used for fee-sponsored Tempo
+//! transactions before the sponsor completes them.
 //!
 //! It is **not** a broadcastable Tempo transaction type. Instead, clients send a
 //! `0x78 || rlp([...])` envelope to a sponsoring server, which validates the
 //! envelope, reconstitutes a normal 0x76 Tempo transaction, attaches a
 //! `fee_payer_signature`, and then broadcasts.
 //!
-//! Note: this envelope format is specific to mpp-rs. The TypeScript/Viem SDK
-//! (mppx) achieves fee sponsorship differently — the client sends a standard
-//! `0x76` transaction to a JSON-RPC sidecar (`Handler.feePayer()` in tempo-ts)
-//! via viem's `withFeePayer` transport, which cosigns using
-//! `signTransaction({ feePayer: account })` and returns a complete `0x76`.
-//! The `0x78` envelope exists in mpp-rs because it embeds the fee-payer flow
-//! inline in the MPP credential exchange rather than using a separate RPC hop.
+//! This mirrors MPPx/Tempo's `signTransaction({ feePayer: true })` behavior:
+//! the client submits a pre-cosign `0x78` envelope, and the server or hosted
+//! fee-payer transport validates it before producing the completed transaction.
 
 use std::num::NonZeroU64;
 

--- a/src/protocol/traits/charge.rs
+++ b/src/protocol/traits/charge.rs
@@ -184,7 +184,6 @@ mod tests {
             intent: "charge".into(),
             request: crate::protocol::core::Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
-            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -150,7 +150,6 @@ mod tests {
             intent: "session".into(),
             request: crate::protocol::core::Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
-            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/server/compose.rs
+++ b/src/server/compose.rs
@@ -258,7 +258,6 @@ mod tests {
             intent: "charge".into(),
             request: Base64UrlJson::from_raw(request_raw),
             expires: Some(expires),
-            description: None,
             digest: None,
             opaque: None,
         };
@@ -327,7 +326,6 @@ mod tests {
             intent: "session".into(),
             request: Base64UrlJson::from_raw(request.raw()),
             expires: Some(expires),
-            description: None,
             digest: None,
             opaque: None,
         };

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -1359,7 +1359,6 @@ mod tests {
             intent: "charge".into(),
             request: Base64UrlJson::from_raw(request),
             expires: Some(expires),
-            description: None,
             digest: None,
             opaque: None,
         };
@@ -1400,7 +1399,6 @@ mod tests {
             intent: "charge".into(),
             request: encoded,
             expires: Some(expires),
-            description: None,
             digest: Some(digest),
             opaque: None,
         };
@@ -1540,7 +1538,6 @@ mod tests {
                 intent: "charge".into(),
                 request: encoded,
                 expires: Some(expires),
-                description: None,
                 digest: None,
                 opaque: None,
             },
@@ -2641,7 +2638,6 @@ mod tests {
             intent: "session".into(),
             request: Base64UrlJson::from_raw("eyJ0ZXN0IjoidmFsdWUifQ"),
             expires: None,
-            description: None,
             digest: None,
             opaque: None,
         };
@@ -2879,7 +2875,6 @@ mod tests {
             intent: "charge".into(),
             request: encoded,
             expires: None,
-            description: None,
             digest: None,
             opaque: None,
         };
@@ -3130,7 +3125,6 @@ mod tests {
             intent: "session".into(),
             request: encoded,
             expires: None,
-            description: None,
             digest: None,
             opaque: None,
         };


### PR DESCRIPTION
## Summary
- restore the compatible `ChallengeEcho` shape after conformance caught the added public field
- encode P-256 charges and TIP-1034 open/top-up management credentials as the same sender-signed `0x78` envelope emitted by current MPPx/Tempo `signTransaction({ feePayer: true })`
- correct the stale docs that claimed the TypeScript client used a different sponsorship wire path

## Regression proof
Current merged main returned 402 in 10 of the 22 live Tempo charge tests and failed the external Rust conformance adapter build.

With this branch:
- all 22 `integration_charge` tests pass against a real local Tempo 1.10.2 dev node
- repository CI feature set passes (1,050 unit tests, 11 Stripe tests, 5 WebSocket tests, 61 doctests)
- Alloy MPP transport passes 14 unit, 2 application WebSocket, and 23 canonical WebSocket tests
- all-features Clippy and rustfmt pass

Reference behavior: current `wevm/mppx@92c7b6e` charge and TIP-1034 channel clients sign `feePayer: true` transactions; MPPx charge tests explicitly identify the pre-cosign result as `0x78`.