### PR TITLE
feat: add generic MPP catalog client example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/alloy-transport-mpp",
   "examples/axum-extractor",
   "examples/basic",
+  "examples/catalog-client",
   "examples/session/multi-fetch",
   "examples/session/sse",
   "examples/stripe",

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,6 +7,7 @@ Standalone, runnable examples demonstrating the mpp HTTP 402 payment flow.
 | Example | Description |
 |---------|-------------|
 | [basic](./basic/) | Payment-gated Fortune Teller API (Tempo) |
+| [catalog-client](./catalog-client/) | Call arbitrary MPP service-catalog endpoints with Tempo Wallet state |
 | [stripe](./stripe/) | Payment-gated Fortune Teller API (Stripe SPT) |
 | [axum-extractor](./axum-extractor/) | Axum extractors with per-route pricing (`MppCharge<C>`) |
 | [session/multi-fetch](./session/multi-fetch/) | Multiple paid requests over a single payment channel |

--- a/examples/catalog-client/Cargo.toml
+++ b/examples/catalog-client/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "catalog-client-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "mpp-catalog-client"
+path = "src/main.rs"
+
+[dependencies]
+mpp = { path = "../..", default-features = false, features = ["client", "tempo", "stripe", "sqlite", "reqwest-rustls-tls"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/examples/catalog-client/README.md
+++ b/examples/catalog-client/README.md
@@ -1,0 +1,38 @@
+# MPP service catalog client
+
+Calls an arbitrary HTTP endpoint from the [MPP service catalog](https://mpp.dev/services).
+The client selects a payment provider from the server's `402 Payment Required`
+challenge, so it does not contain service-specific adapters.
+
+Tempo `charge` and `session` challenges use the active account and P-256 access
+key from Tempo Wallet's `~/.tempo/wallet/store.json`. Session channels persist
+in the MPPx-compatible `~/.tempo/wallet/channels.db`, scoped to the target
+service origin. A cold process can therefore continue an existing channel.
+
+```bash
+cargo run -p catalog-client-example -- \
+  GET 'https://stabletravel.dev/api/reference/locations?keyword=SFO&subType=AIRPORT%2CCITY'
+
+cargo run -p catalog-client-example -- \
+  POST https://rpc.mpp.tempo.xyz/ \
+  '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+```
+
+The optional third positional argument is sent as JSON when it parses as JSON,
+or as a raw request body otherwise. Set `MPP_REQUEST_HEADERS` to a JSON object
+for application-specific headers.
+
+Configuration:
+
+- `TEMPO_RPC_URL`: overrides the RPC selected from the wallet's active chain.
+- `MPP_CHANNEL_STORE`: overrides the shared channel database path.
+- `MPP_DEFAULT_DEPOSIT`: initial session deposit, default `20000` atomic units.
+- `MPP_MAX_DEPOSIT`: local session spending ceiling, default `1000000` atomic units.
+- `MPP_REQUEST_HEADERS`: JSON object of headers attached to the application request.
+- `STRIPE_SPT_ENDPOINT`: optional application endpoint that accepts the
+  `CreateTokenParams` JSON and returns `{ "spt": "...", "externalId": "..." }`.
+  This enables Stripe-only catalog services while leaving card authorization
+  and SPT issuance in the embedding application.
+
+This example pays real challenges. Inspect the target service's catalog price
+before running it.

--- a/examples/catalog-client/README.md
+++ b/examples/catalog-client/README.md
@@ -19,8 +19,11 @@ cargo run -p catalog-client-example -- \
 ```
 
 The optional third positional argument is sent as JSON when it parses as JSON,
-or as a raw request body otherwise. Set `MPP_REQUEST_HEADERS` to a JSON object
-for application-specific headers.
+or as a raw request body otherwise. Pass `-` to read raw bytes from stdin or
+`@PATH` to read them from a file. Set `MPP_REQUEST_HEADERS` to a JSON object for
+application-specific headers and content types. Together these cover the
+catalog's JSON, form, file, and authenticated application requests without
+service-specific payment adapters.
 
 Configuration:
 

--- a/examples/catalog-client/src/main.rs
+++ b/examples/catalog-client/src/main.rs
@@ -1,0 +1,146 @@
+use std::{env, sync::Arc};
+
+use mpp::{
+    client::{
+        stripe::StripeProvider,
+        tempo::{
+            session::store::{SqliteChannelStore, SqliteChannelStoreOptions},
+            signing::{KeychainVersion, TempoSigningMode},
+            wallet::TempoWallet,
+        },
+        Fetch, MultiProvider, TempoProvider, TempoSessionProvider,
+    },
+    protocol::methods::{stripe::CreateTokenResult, tempo::TempoNetwork},
+    MppError,
+};
+use reqwest::{
+    header::{HeaderMap, HeaderName},
+    Client, Method,
+};
+
+const DEFAULT_DEPOSIT: u128 = 20_000;
+const DEFAULT_MAX_DEPOSIT: u128 = 1_000_000;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args().skip(1);
+    let method = args
+        .next()
+        .ok_or("usage: mpp-catalog-client METHOD URL [BODY]")?
+        .parse::<Method>()?;
+    let url = args
+        .next()
+        .ok_or("usage: mpp-catalog-client METHOD URL [BODY]")?;
+    let body = args.next();
+    if args.next().is_some() {
+        return Err("usage: mpp-catalog-client METHOD URL [BODY]".into());
+    }
+
+    let target = reqwest::Url::parse(&url)?;
+    let wallet = TempoWallet::load_default()?;
+    let rpc_url = env::var("TEMPO_RPC_URL").unwrap_or_else(|_| {
+        TempoNetwork::from_chain_id(wallet.chain_id)
+            .map(TempoNetwork::default_rpc_url)
+            .unwrap_or("https://rpc.tempo.xyz")
+            .to_owned()
+    });
+    let signing_mode = TempoSigningMode::Keychain {
+        wallet: wallet.account,
+        key_authorization: None,
+        version: KeychainVersion::V2,
+    };
+
+    let charge = TempoProvider::new(wallet.signer.clone(), &rpc_url)?
+        .with_expected_chain_id(wallet.chain_id)
+        .with_signing_mode(signing_mode.clone());
+    let channel_store = SqliteChannelStore::open(SqliteChannelStoreOptions {
+        namespace: target.origin().ascii_serialization(),
+        path: env::var_os("MPP_CHANNEL_STORE").map(Into::into),
+        request_url: Some(url.clone()),
+    })?;
+    let session = TempoSessionProvider::new(wallet.signer, &rpc_url)?
+        .with_signing_mode(signing_mode)
+        .with_authorized_signer(wallet.access_key)
+        .with_channel_store(Arc::new(channel_store))
+        .with_default_deposit(read_u128("MPP_DEFAULT_DEPOSIT", DEFAULT_DEPOSIT)?)
+        .with_max_deposit(read_u128("MPP_MAX_DEPOSIT", DEFAULT_MAX_DEPOSIT)?);
+    let client = Client::new();
+    let request_headers = read_headers("MPP_REQUEST_HEADERS")?;
+    session
+        .bootstrap_with_headers(&client, &url, request_headers.clone())
+        .await?;
+    let mut providers = MultiProvider::new().with(charge).with(session);
+
+    if let Ok(endpoint) = env::var("STRIPE_SPT_ENDPOINT") {
+        let spt_client = client.clone();
+        providers.add(StripeProvider::new(move |params| {
+            let endpoint = endpoint.clone();
+            let client = spt_client.clone();
+            Box::pin(async move {
+                let response = client
+                    .post(endpoint)
+                    .json(&params)
+                    .send()
+                    .await
+                    .map_err(|error| MppError::Http(error.to_string()))?
+                    .error_for_status()
+                    .map_err(|error| MppError::Http(error.to_string()))?;
+                let value = response
+                    .json::<serde_json::Value>()
+                    .await
+                    .map_err(|error| MppError::Http(error.to_string()))?;
+                let spt = value
+                    .get("spt")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| MppError::Http("SPT response is missing spt".into()))?;
+                Ok(CreateTokenResult {
+                    spt: spt.to_owned(),
+                    external_id: value
+                        .get("externalId")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_owned),
+                })
+            })
+        }));
+    }
+
+    let request = client.request(method, target).headers(request_headers);
+    let request = match body {
+        Some(body) => match serde_json::from_str::<serde_json::Value>(&body) {
+            Ok(value) => request.json(&value),
+            Err(_) => request.body(body),
+        },
+        None => request,
+    };
+    let response = request.send_with_payment(&providers).await?;
+    let status = response.status();
+    let response_body = response.text().await?;
+    println!("status={status}");
+    println!("{response_body}");
+    Ok(())
+}
+
+fn read_u128(name: &str, default: u128) -> Result<u128, Box<dyn std::error::Error>> {
+    match env::var(name) {
+        Ok(value) => value
+            .parse()
+            .map_err(|error| format!("invalid {name}: {error}").into()),
+        Err(env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn read_headers(variable: &str) -> Result<HeaderMap, Box<dyn std::error::Error>> {
+    let mut output = HeaderMap::new();
+    let Ok(encoded) = env::var(variable) else {
+        return Ok(output);
+    };
+    let headers = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&encoded)?;
+    for (name, value) in headers {
+        let value = value
+            .as_str()
+            .ok_or_else(|| format!("{variable}.{name} must be a string"))?;
+        output.insert(name.parse::<HeaderName>()?, value.parse()?);
+    }
+    Ok(output)
+}

--- a/examples/catalog-client/src/main.rs
+++ b/examples/catalog-client/src/main.rs
@@ -1,4 +1,4 @@
-use std::{env, sync::Arc};
+use std::{env, io::Read, sync::Arc};
 
 use mpp::{
     client::{
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = args
         .next()
         .ok_or("usage: mpp-catalog-client METHOD URL [BODY]")?;
-    let body = args.next();
+    let body = read_body(args.next())?;
     if args.next().is_some() {
         return Err("usage: mpp-catalog-client METHOD URL [BODY]".into());
     }
@@ -106,10 +106,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let request = client.request(method, target).headers(request_headers);
     let request = match body {
-        Some(body) => match serde_json::from_str::<serde_json::Value>(&body) {
-            Ok(value) => request.json(&value),
-            Err(_) => request.body(body),
-        },
+        Some(RequestBody::Json(value)) => request.json(&value),
+        Some(RequestBody::Raw(bytes)) => request.body(bytes),
         None => request,
     };
     let response = request.send_with_payment(&providers).await?;
@@ -118,6 +116,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("status={status}");
     println!("{response_body}");
     Ok(())
+}
+
+enum RequestBody {
+    Json(serde_json::Value),
+    Raw(Vec<u8>),
+}
+
+fn read_body(argument: Option<String>) -> Result<Option<RequestBody>, Box<dyn std::error::Error>> {
+    let Some(argument) = argument else {
+        return Ok(None);
+    };
+    if argument == "-" {
+        let mut bytes = Vec::new();
+        std::io::stdin().read_to_end(&mut bytes)?;
+        return Ok(Some(RequestBody::Raw(bytes)));
+    }
+    if let Some(path) = argument.strip_prefix('@') {
+        return Ok(Some(RequestBody::Raw(std::fs::read(path)?)));
+    }
+    Ok(Some(
+        serde_json::from_str(&argument)
+            .map(RequestBody::Json)
+            .unwrap_or_else(|_| RequestBody::Raw(argument.into_bytes())),
+    ))
 }
 
 fn read_u128(name: &str, default: u128) -> Result<u128, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary
- add a generic request-driven MPP client example for services from `mpp.dev/services`
- compose Tempo charge/session and optional Stripe providers through the existing client boundary
- load the Tempo Wallet access key and MPPx-compatible `~/.tempo/channels.db`, including MPPx-style cold bootstrap
- accept JSON, raw, file, or stdin request bodies and caller-supplied headers

The example contains no service-specific payment logic: it follows each service's returned MPP challenge.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p catalog-client-example`
- full workspace tests and all-feature Clippy passed on the immediately preceding bootstrap branch
- `git diff --check`