### PR TITLE
fix(tempo): align TIP-1034 client scope with MPPx

### DIFF
--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -29,7 +29,7 @@ use crate::protocol::methods::tempo::session::{
     ChannelDescriptor, SessionCredentialPayload, TempoSessionExt,
 };
 use crate::protocol::methods::tempo::voucher::{compute_channel_id, sign_voucher};
-use crate::protocol::methods::tempo::MODERATO_CHAIN_ID;
+use crate::protocol::methods::tempo::CHAIN_ID;
 
 #[cfg(feature = "tempo")]
 const FEE_PAYER_VALID_BEFORE_SECS: u64 = 25;
@@ -75,33 +75,38 @@ pub struct ChannelEntry {
 /// Resolve chain ID from a session challenge's methodDetails.
 pub fn resolve_chain_id(challenge: &PaymentChallenge) -> u64 {
     let session: Result<SessionRequest, _> = challenge.request.decode();
-    session
-        .ok()
-        .and_then(|r| r.chain_id())
-        .unwrap_or(MODERATO_CHAIN_ID)
+    session.ok().and_then(|r| r.chain_id()).unwrap_or(CHAIN_ID)
 }
 
-/// Resolve escrow contract address from challenge methodDetails, an override, or defaults.
+/// Resolve escrow contract address from an override, challenge hints, or defaults.
 pub fn resolve_escrow(
     challenge: &PaymentChallenge,
     chain_id: u64,
     escrow_override: Option<Address>,
 ) -> Result<Address, MppError> {
-    // Try challenge methodDetails first
-    if let Ok(req) = challenge.request.decode::<SessionRequest>() {
-        if let Ok(addr_str) = req.escrow_contract() {
-            if let Ok(addr) = addr_str.parse::<Address>() {
-                return Ok(addr);
-            }
-        }
-    }
-
-    // Then override
+    // Match MPPx: an explicit client override wins over server hints.
     if let Some(addr) = escrow_override {
         return Ok(addr);
     }
 
-    // Then defaults
+    if let Ok(req) = challenge.request.decode::<SessionRequest>() {
+        if let Some(details) = req.method_details.as_ref() {
+            for key in ["escrowContract", "escrow"] {
+                if let Some(addr) = details
+                    .get(key)
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|value| value.parse::<Address>().ok())
+                {
+                    return Ok(addr);
+                }
+            }
+        }
+        if req.is_tip1034_session() {
+            return Ok(TIP20_CHANNEL_RESERVE_ADDRESS);
+        }
+    }
+
+    // Legacy sessions retain their chain-specific escrow fallback.
     default_escrow_contract(chain_id).ok_or_else(|| {
         MppError::InvalidConfig(
             "No escrowContract available. Provide it in parameters or ensure the server challenge includes it.".to_string(),
@@ -661,6 +666,35 @@ fn precompile_open_tx_nonce_fields(fee_payer: bool, nonce: u64) -> (u64, U256, O
     )
 }
 
+/// Returns a random past timestamp for a sponsored repeatable transaction.
+///
+/// MPPx adds `validAfter` to sponsored top-ups so two otherwise identical
+/// top-up calls do not serialize to the same transaction.
+#[cfg(feature = "tempo")]
+fn random_past_valid_after() -> Option<std::num::NonZeroU64> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let latest = now.saturating_sub(60);
+    if latest == 0 {
+        return None;
+    }
+
+    let random = B256::random();
+    let mut prefix = [0u8; 8];
+    prefix.copy_from_slice(&random[..8]);
+    let timestamp = (u64::from_be_bytes(prefix) % latest).max(1);
+    std::num::NonZeroU64::new(timestamp)
+}
+
+#[cfg(feature = "tempo")]
+fn add_sponsored_top_up_entropy(transaction: &mut TempoTransaction, fee_payer: bool) {
+    if fee_payer {
+        transaction.valid_after = random_past_valid_after();
+    }
+}
+
 /// Convert a JSON wire descriptor into the generated precompile ABI tuple.
 #[cfg(feature = "tempo")]
 pub fn precompile_descriptor_from_wire(
@@ -930,7 +964,6 @@ where
         valid_before,
         key_authorization: signing_mode.key_authorization().cloned(),
     });
-
     // Derive id from the unsigned tx before signing; expiringNonceHash binds
     // the signing-payload bytes.
     let expiring_nonce_hash = if options.fee_payer {
@@ -1057,7 +1090,7 @@ where
         .mpp_http("failed to get gas price")?;
     let (nonce, nonce_key, valid_before) =
         precompile_open_tx_nonce_fields(options.fee_payer, nonce);
-    let unsigned_tx = build_tempo_tx(TempoTxOptions {
+    let mut unsigned_tx = build_tempo_tx(TempoTxOptions {
         calls,
         chain_id: options.chain_id,
         fee_token: options
@@ -1074,6 +1107,7 @@ where
         valid_before,
         key_authorization: signing_mode.key_authorization().cloned(),
     });
+    add_sponsored_top_up_entropy(&mut unsigned_tx, options.fee_payer);
     let tx_bytes = if options.fee_payer {
         crate::client::tempo::signing::sign_and_encode_fee_payer_envelope_primitive_async(
             unsigned_tx,
@@ -1322,6 +1356,35 @@ mod tests {
     }
 
     #[cfg(feature = "tempo")]
+    #[test]
+    fn sponsored_repeatable_transactions_get_past_valid_after_entropy() {
+        let mut transaction = build_tempo_tx(TempoTxOptions {
+            calls: vec![],
+            chain_id: 4217,
+            fee_token: Address::repeat_byte(0x22),
+            nonce: 0,
+            nonce_key: U256::MAX,
+            gas_limit: 500_000,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 100_000_000,
+            fee_payer: true,
+            valid_before: None,
+            key_authorization: None,
+        });
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        add_sponsored_top_up_entropy(&mut transaction, true);
+        let valid_after = transaction
+            .valid_after
+            .expect("sponsored top-ups get transaction entropy");
+
+        assert!(valid_after.get() <= now.saturating_sub(60));
+    }
+
+    #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn test_create_precompile_open_payload_rejects_uint96_overflow() {
         use crate::protocol::methods::tempo::precompile_voucher::PRECOMPILE_MAX_CUMULATIVE_AMOUNT;
@@ -1447,6 +1510,59 @@ mod tests {
 
         let result = resolve_escrow(&challenge, 42431, None).unwrap();
         assert_eq!(result, escrow_addr.parse::<Address>().unwrap());
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn tip1034_challenge_without_escrow_uses_canonical_precompile() {
+        use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
+
+        let challenge = PaymentChallenge {
+            id: "test".to_string(),
+            realm: "test".to_string(),
+            method: "tempo".into(),
+            intent: "session".into(),
+            request: Base64UrlJson::from_value(&serde_json::json!({
+                "amount": "1000",
+                "currency": Address::repeat_byte(0x44).to_string(),
+                "methodDetails": { "sessionProtocol": "v2" }
+            }))
+            .unwrap(),
+            expires: None,
+            description: None,
+            digest: None,
+            opaque: None,
+        };
+
+        assert_eq!(
+            resolve_escrow(&challenge, 4217, None).unwrap(),
+            TIP20_CHANNEL_RESERVE_ADDRESS
+        );
+    }
+
+    #[test]
+    fn test_resolve_escrow_accepts_legacy_alias_hint() {
+        use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
+
+        let hinted = Address::repeat_byte(0x22);
+        let challenge = PaymentChallenge {
+            id: "test".to_string(),
+            realm: "test".to_string(),
+            method: "tempo".into(),
+            intent: "session".into(),
+            request: Base64UrlJson::from_value(&serde_json::json!({
+                "amount": "1000",
+                "currency": Address::repeat_byte(0x44).to_string(),
+                "methodDetails": { "escrow": hinted.to_string() }
+            }))
+            .unwrap(),
+            expires: None,
+            description: None,
+            digest: None,
+            opaque: None,
+        };
+
+        assert_eq!(resolve_escrow(&challenge, 4217, None).unwrap(), hinted);
     }
 
     #[test]
@@ -1647,7 +1763,7 @@ mod tests {
             opaque: None,
         };
 
-        assert_eq!(resolve_chain_id(&challenge), MODERATO_CHAIN_ID);
+        assert_eq!(resolve_chain_id(&challenge), CHAIN_ID);
     }
 
     #[test]
@@ -1669,8 +1785,8 @@ mod tests {
             opaque: None,
         };
 
-        // Should fall back to MODERATO_CHAIN_ID on decode failure
-        assert_eq!(resolve_chain_id(&challenge), MODERATO_CHAIN_ID);
+        // Match MPPx's default Tempo client: mainnet when no chain is advertised.
+        assert_eq!(resolve_chain_id(&challenge), CHAIN_ID);
     }
 
     #[test]
@@ -1891,11 +2007,10 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_escrow_challenge_priority_order() {
+    fn test_resolve_escrow_override_priority_order() {
         use crate::protocol::core::{Base64UrlJson, PaymentChallenge};
 
-        // Challenge has a valid escrow, override is also present.
-        // Challenge should take priority.
+        // Match MPPx: an explicit caller override wins over a challenge hint.
         let escrow_addr = "0x2222222222222222222222222222222222222222";
         let override_addr: Address = "0x3333333333333333333333333333333333333333"
             .parse()
@@ -1922,9 +2037,8 @@ mod tests {
 
         let result = resolve_escrow(&challenge, 42431, Some(override_addr)).unwrap();
         assert_eq!(
-            result,
-            escrow_addr.parse::<Address>().unwrap(),
-            "challenge escrow should take priority over override"
+            result, override_addr,
+            "override should take priority over challenge escrow"
         );
     }
 

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -271,31 +271,12 @@ impl TempoSessionProvider {
         })
     }
 
-    /// Cache key identifying a channel. Precompile channel ids bind `operator`,
-    /// so it is appended for precompile channels; legacy keys are unchanged.
-    fn channel_key(
-        payee: &Address,
-        currency: &Address,
-        escrow: &Address,
-        operator: Option<Address>,
-    ) -> String {
-        match operator {
-            Some(op) => format!("{:#x}:{:#x}:{:#x}:{:#x}", payee, currency, escrow, op),
-            None => format!("{:#x}:{:#x}:{:#x}", payee, currency, escrow),
-        }
-    }
-
-    /// Operator identity for the cache key: the parsed operator for precompile
-    /// escrow, `None` for legacy escrow.
-    fn key_operator(
-        escrow: &Address,
-        session_req: &SessionRequest,
-    ) -> Result<Option<Address>, MppError> {
-        if is_precompile_escrow(*escrow) {
-            Ok(Some(Self::parse_operator(session_req)?))
-        } else {
-            Ok(None)
-        }
+    /// Cache key identifying the reusable payment scope.
+    ///
+    /// This intentionally matches MPPx: operator is channel identity, not
+    /// payment scope, while chain ID must prevent cross-network reuse.
+    fn channel_key(payee: &Address, currency: &Address, escrow: &Address, chain_id: u64) -> String {
+        format!("{:#x}:{:#x}:{:#x}:{chain_id}", payee, currency, escrow)
     }
 
     /// Parse `methodDetails.operator` from a precompile session request.
@@ -340,10 +321,8 @@ impl TempoSessionProvider {
             .parse()
             .map_err(|_| MppError::InvalidConfig("invalid currency address".to_string()))?;
 
-        let operator = Self::key_operator(&escrow_contract, &session_req)?;
-
         Ok((
-            Self::channel_key(&payee, &currency, &escrow_contract, operator),
+            Self::channel_key(&payee, &currency, &escrow_contract, chain_id),
             chain_id,
         ))
     }
@@ -561,11 +540,6 @@ impl TempoSessionProvider {
             .token
             .parse()
             .mpp_config("invalid snapshot token")?;
-        let operator = snapshot
-            .descriptor
-            .operator
-            .parse()
-            .mpp_config("invalid snapshot operator")?;
         let escrow = snapshot
             .escrow
             .parse()
@@ -595,7 +569,7 @@ impl TempoSessionProvider {
             .map_err(Self::store_error)?;
 
         let entry = Self::channel_entry(recovered.clone())?;
-        let key = Self::channel_key(&payee, &token, &escrow, Some(operator));
+        let key = Self::channel_key(&payee, &token, &escrow, snapshot.chain_id);
         self.channel_id_to_key
             .lock()
             .unwrap()
@@ -1293,8 +1267,12 @@ impl TempoSessionProvider {
         let payer = self.signing_mode.from_address(self.signer.address());
         let authorized_signer = self.authorized_signer.unwrap_or(self.signer.address());
         let precompile = is_precompile_escrow(escrow_contract);
-        let operator = Self::key_operator(&escrow_contract, &session_req)?;
-        let key = Self::channel_key(&payee, &currency, &escrow_contract, operator);
+        let operator = if precompile {
+            Some(Self::parse_operator(&session_req)?)
+        } else {
+            None
+        };
+        let key = Self::channel_key(&payee, &currency, &escrow_contract, chain_id);
         let session_snapshot = session_req.session_snapshot();
 
         let provider =
@@ -1657,19 +1635,12 @@ mod tests {
             .parse()
             .unwrap();
 
-        // Legacy: no operator → 3 fields.
-        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, None);
+        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, 4217);
         assert_eq!(key, key.to_lowercase());
-        assert_eq!(key.matches(':').count(), 2);
+        assert_eq!(key.matches(':').count(), 3);
 
-        // Precompile: operator appended → 4 fields, distinct per operator.
-        let op_a = Address::repeat_byte(0x01);
-        let op_b = Address::repeat_byte(0x02);
-        let key_a = TempoSessionProvider::channel_key(&payee, &currency, &escrow, Some(op_a));
-        let key_b = TempoSessionProvider::channel_key(&payee, &currency, &escrow, Some(op_b));
-        assert_eq!(key_a.matches(':').count(), 3);
-        assert_ne!(key_a, key_b);
-        assert_ne!(key_a, key);
+        let other_chain = TempoSessionProvider::channel_key(&payee, &currency, &escrow, 42431);
+        assert_ne!(key, other_chain);
     }
 
     #[test]
@@ -2002,7 +1973,7 @@ mod tests {
 
         *provider.last_challenge.lock().unwrap() =
             Some(make_scoped_challenge(payee, currency, escrow));
-        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, None);
+        let key = TempoSessionProvider::channel_key(&payee, &currency, &escrow, 42431);
         provider
             .channel_id_to_key
             .lock()
@@ -2086,7 +2057,7 @@ mod tests {
         *provider.last_challenge.lock().unwrap() =
             Some(make_scoped_challenge(expected_payee, currency, escrow));
 
-        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, None);
+        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, 42431);
         provider
             .channel_id_to_key
             .lock()
@@ -2154,7 +2125,7 @@ mod tests {
         *provider.last_challenge.lock().unwrap() =
             Some(make_scoped_challenge(expected_payee, currency, escrow));
 
-        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, None);
+        let other_key = TempoSessionProvider::channel_key(&other_payee, &currency, &escrow, 42431);
         provider.channels.lock().unwrap().insert(
             other_key,
             ChannelEntry {
@@ -2291,31 +2262,6 @@ mod tests {
     }
 
     #[cfg(feature = "tempo")]
-    #[test]
-    fn key_operator_only_applies_to_precompile_escrow() {
-        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
-
-        let op = Address::repeat_byte(0x42);
-        let req = SessionRequest {
-            method_details: Some(serde_json::json!({ "operator": op.to_string() })),
-            ..Default::default()
-        };
-
-        // Legacy escrow ignores operator → None (keeps legacy key shape).
-        let legacy = Address::repeat_byte(0x44);
-        assert_eq!(
-            TempoSessionProvider::key_operator(&legacy, &req).unwrap(),
-            None
-        );
-
-        // Precompile escrow binds operator → Some.
-        assert_eq!(
-            TempoSessionProvider::key_operator(&TIP20_CHANNEL_RESERVE_ADDRESS, &req).unwrap(),
-            Some(op)
-        );
-    }
-
-    #[cfg(feature = "tempo")]
     #[tokio::test]
     async fn pay_branches_to_precompile_voucher_for_existing_precompile_channel() {
         use alloy::signers::local::PrivateKeySigner;
@@ -2365,7 +2311,7 @@ mod tests {
             &payee,
             &currency,
             &TIP20_CHANNEL_RESERVE_ADDRESS,
-            Some(operator),
+            chain_id,
         );
         provider.channels.lock().unwrap().insert(
             key.clone(),
@@ -2565,7 +2511,7 @@ mod tests {
             &payee,
             &currency,
             &TIP20_CHANNEL_RESERVE_ADDRESS,
-            Some(operator),
+            chain_id,
         );
         provider.channels.lock().unwrap().insert(
             key,


### PR DESCRIPTION
## What changed

- key reusable channels by the same payment scope as MPPx: payee, token, escrow, and chain
- give explicit escrow overrides precedence, accept both escrow hints, and default v2 sessions to the canonical TIP-1034 precompile
- match the MPPx mainnet chain default when a challenge omits chainId
- add random past validAfter entropy to sponsored repeated top-ups

## Why

The deployed OpenAI flow supplies explicit chain and escrow fields, so the existing path worked, but the Rust client still diverged from the current MPPx TIP-1034 lifecycle in fallback, cross-chain scope, and repeated sponsored top-up behavior.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
- focused TIP-1034 channel operation and provider tests

The feature-complete test run passed 1,053 library tests plus Stripe and WebSocket integration suites.