### PR TITLE
fix(alloy): default MPP transport to Ring TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
         run: cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
         env:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+      - name: Check Ring transport dependency graph
+        run: |
+          tree=$(cargo tree -p alloy-transport-mpp --no-default-features --features ring --edges normal --prefix none)
+          if grep -q '^aws-lc-sys ' <<< "$tree"; then
+            echo "Ring-only transport unexpectedly includes aws-lc-sys"
+            exit 1
+          fi
       - run: cargo hack check --each-feature --no-dev-deps --skip integration,integration-stripe,integration-ws
       - name: Check examples
         run: cargo check --workspace --exclude mpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,15 @@ uuid = { version = "1", features = ["v4"], optional = true }
 tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
 futures-core = { version = "0.3", optional = true }
 async-stream = { version = "0.3", optional = true }
-alloy = { version = "2.1.0", features = ["full"], optional = true }
+alloy = { version = "2.1.0", default-features = false, features = [
+  "contract",
+  "provider-http",
+  "reqwest",
+  "rpc-types",
+  "signer-local",
+  "sol-types",
+  "std",
+], optional = true }
 
 # Tempo dependencies (optional)
 tempo-alloy = { version = "1.8.1", optional = true }

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -29,7 +29,7 @@ alloy-transport-ws = { version = "2.1.0", default-features = false }
 mpp = { path = "../..", default-features = false, features = ["ws"] }
 
 futures = "0.3"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+reqwest = { version = "0.13", default-features = false }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
@@ -53,8 +53,20 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync",
 tokio-tungstenite = "0.28"
 
 [features]
-default = ["aws-lc-rs"]
-aws-lc-rs = ["alloy-transport-ws/aws-lc-rs", "dep:rustls", "rustls?/aws-lc-rs"]
-ring = ["alloy-transport-ws/ring", "dep:rustls", "rustls?/ring"]
-native-tls = ["alloy-transport-ws/native-tls"]
-rustls-tls = ["alloy-transport-ws/rustls-tls"]
+# Ring is the lightweight default. Consumers that require a different TLS
+# backend should disable default features and select exactly one below.
+default = ["ring"]
+aws-lc-rs = [
+  "alloy-transport-ws/aws-lc-rs",
+  "dep:rustls",
+  "reqwest/rustls",
+  "rustls?/aws-lc-rs",
+]
+ring = [
+  "alloy-transport-ws/ring",
+  "dep:rustls",
+  "reqwest/rustls-no-provider",
+  "rustls?/ring",
+]
+native-tls = ["alloy-transport-ws/native-tls", "reqwest/native-tls"]
+rustls-tls = ["alloy-transport-ws/rustls-tls", "reqwest/rustls-no-provider"]

--- a/crates/alloy-transport-mpp/README.md
+++ b/crates/alloy-transport-mpp/README.md
@@ -12,6 +12,17 @@ internally via a user-supplied
 [`PaymentProvider`](https://docs.rs/mpp/latest/mpp/client/trait.PaymentProvider.html)
 (and a `VoucherProvider` for streaming/session intents).
 
+Ring is the default TLS backend. Select another backend explicitly and disable
+default features so Cargo does not compile more than one crypto provider:
+
+```toml
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", default-features = false, features = ["aws-lc-rs"] }
+```
+
+The available backend features are `ring`, `aws-lc-rs`, and `native-tls`.
+`rustls-tls` exposes the provider-neutral Rustls plumbing for applications that
+install their own process-wide Rustls crypto provider.
+
 ```rust,ignore
 use alloy_provider::ProviderBuilder;
 use alloy_transport_mpp::MppWsConnect;


### PR DESCRIPTION
## Summary

- replace the main `mpp` crate's broad Alloy `full` feature with the specific contract, HTTP provider, RPC type, signer, Solidity type, and std features it uses
- make Ring the default TLS backend for `alloy-transport-mpp`
- wire the HTTP bootstrap probe to the same selected TLS backend as the WebSocket transport
- guard the Ring-only dependency graph in CI and document explicit backend selection

## Why

Selecting `alloy-transport-mpp` with Ring still compiled `aws-lc-sys`. There were two independent causes:

1. `mpp` enabled Alloy's `full` feature, which includes Alloy's AWS-LC WebSocket transport even though `mpp` only uses an HTTP provider.
2. The application WebSocket bootstrap probe enabled Reqwest 0.13's generic `rustls` feature, which selects AWS-LC, independently of the transport crate's `ring` feature.

The transport crate is not currently published, so changing its default backend from AWS-LC to Ring does not alter a published crates.io default. AWS-LC and native TLS remain available explicitly with `default-features = false`.

## Dependency proof

Before this change:

```text
$ cargo tree -p alloy-transport-mpp --no-default-features --features ring -i aws-lc-sys -e features
aws-lc-sys v0.43.0
└── aws-lc-rs v1.17.3
    └── reqwest feature "rustls"
        └── alloy-transport-mpp v0.2.0
```

After this change, the same Ring-only graph contains no `aws-lc-sys`, and the main `mpp` Tempo/WebSocket graph contains no `alloy-transport-ws`. CI now asserts the first property.

One important boundary: enabling `mpp/tempo` still includes `aws-lc-sys` through `tempo-primitives`' direct cryptographic dependency. This PR removes the unintended TLS/Alloy WebSocket paths; it does not claim to remove Tempo's non-TLS cryptography dependency.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p alloy-transport-mpp` (39 tests)
- `cargo hack check -p alloy-transport-mpp --each-feature --no-dev-deps`
- `cargo hack check --each-feature --no-dev-deps --skip integration,integration-stripe,integration-ws`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws` (1,053 unit tests, 16 integration tests, and doc tests)
- explicit checks for the default, Ring, AWS-LC, native-TLS, and provider-neutral Rustls transport configurations
