### PR TITLE
feat(client): autoswap session deposits

### DIFF
--- a/.changelog/session-autoswap.md
+++ b/.changelog/session-autoswap.md
@@ -1,0 +1,6 @@
+---
+"mpp": minor
+---
+
+Add atomic stablecoin auto-swaps for native TIP-1034 session opens and top-ups,
+including the required Stablecoin DEX approval for charge and session payments.

--- a/src/client/tempo/autoswap.rs
+++ b/src/client/tempo/autoswap.rs
@@ -8,8 +8,8 @@
 //!
 //! 1. Check the client's balance of the challenge currency
 //! 2. If balance >= amount, no swap needed — proceed normally
-//! 3. If balance < amount, compute the deficit and query the DEX for a quote
-//! 4. Prepend a `swapExactAmountOut` call to the transaction's call list
+//! 3. If balance < amount, query the DEX for an exact-output quote
+//! 4. Prepend `approve` and `swapExactAmountOut` calls to the transaction
 //!    so the swap and transfer execute atomically in a single AA transaction
 //!
 //! # Example
@@ -99,6 +99,17 @@ pub async fn quote_swap<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>
     Ok(amount_in)
 }
 
+/// Build the approval required by the Stablecoin DEX.
+pub fn build_approve_call(token_in: Address, max_amount_in: u128) -> Call {
+    Call {
+        to: TxKind::Call(token_in),
+        value: U256::ZERO,
+        input: Bytes::from(
+            ITIP20::approveCall::new((DEX_ADDRESS, U256::from(max_amount_in))).abi_encode(),
+        ),
+    }
+}
+
 /// Build the swap call to prepend to the transaction.
 ///
 /// Applies slippage tolerance to the quoted `amount_in` to compute `max_amount_in`.
@@ -129,20 +140,20 @@ pub fn build_swap_call(
     }
 }
 
-/// Resolve autoswap: check balance, quote, and return the swap call if needed.
+/// Resolve autoswap: check balance, quote, and return the approval + swap calls if needed.
 ///
-/// Returns `Ok(Some(call))` if a swap is needed, `Ok(None)` if balance is sufficient.
+/// Returns `Ok(Some(calls))` if a swap is needed, `Ok(None)` if balance is sufficient.
 ///
 /// Validates that:
 /// 1. The slippage tolerance is within bounds
 /// 2. The user has sufficient `token_in` balance to cover `max_amount_in`
-pub async fn resolve_autoswap<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
+pub async fn resolve_autoswap_calls<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
     provider: &P,
     owner: Address,
     currency: Address,
     amount: U256,
     config: &AutoswapConfig,
-) -> Result<Option<Call>, MppError> {
+) -> Result<Option<Vec<Call>>, MppError> {
     if config.slippage_bps > MAX_SLIPPAGE_BPS {
         return Err(MppError::InvalidConfig(format!(
             "autoswap slippage {}bps exceeds maximum {}bps",
@@ -155,17 +166,18 @@ pub async fn resolve_autoswap<P: alloy::providers::Provider<tempo_alloy::TempoNe
         return Ok(None);
     }
 
-    let deficit = match check_balance_deficit(provider, owner, currency, amount).await? {
-        Some(d) => d,
+    match check_balance_deficit(provider, owner, currency, amount).await? {
+        Some(_) => {}
         None => return Ok(None),
-    };
+    }
 
-    // Convert deficit to u128 for the DEX call (TIP-20 tokens use u128 amounts).
-    let deficit_u128: u128 = deficit
+    // Match MPPx: acquire the full requested output amount when the target
+    // balance is insufficient, leaving any pre-existing dust untouched.
+    let amount_out: u128 = amount
         .try_into()
-        .map_err(|_| MppError::InvalidAmount(format!("deficit {} exceeds u128", deficit)))?;
+        .map_err(|_| MppError::InvalidAmount(format!("amount {amount} exceeds u128")))?;
 
-    let quoted_amount_in = quote_swap(provider, config.token_in, currency, deficit_u128).await?;
+    let quoted_amount_in = quote_swap(provider, config.token_in, currency, amount_out).await?;
 
     // Compute max_amount_in with slippage and verify the user can cover it.
     let max_amount_in =
@@ -182,13 +194,35 @@ pub async fn resolve_autoswap<P: alloy::providers::Provider<tempo_alloy::TempoNe
         ));
     }
 
-    Ok(Some(build_swap_call(
-        config.token_in,
-        currency,
-        deficit_u128,
-        quoted_amount_in,
-        config.slippage_bps,
-    )))
+    Ok(Some(vec![
+        build_approve_call(config.token_in, max_amount_in),
+        build_swap_call(
+            config.token_in,
+            currency,
+            amount_out,
+            quoted_amount_in,
+            config.slippage_bps,
+        ),
+    ]))
+}
+
+/// Resolve the DEX swap call without its approval call.
+///
+/// This compatibility helper preserves the original API. Transaction builders
+/// should use [`resolve_autoswap_calls`] so the DEX approval and swap execute
+/// atomically in the correct order.
+pub async fn resolve_autoswap<P: alloy::providers::Provider<tempo_alloy::TempoNetwork>>(
+    provider: &P,
+    owner: Address,
+    currency: Address,
+    amount: U256,
+    config: &AutoswapConfig,
+) -> Result<Option<Call>, MppError> {
+    Ok(
+        resolve_autoswap_calls(provider, owner, currency, amount, config)
+            .await?
+            .and_then(|mut calls| calls.pop()),
+    )
 }
 
 #[cfg(test)]
@@ -245,5 +279,59 @@ mod tests {
         let decoded =
             IStablecoinDEX::swapExactAmountOutCall::abi_decode_raw(&call.input[4..]).unwrap();
         assert_eq!(decoded.maxAmountIn, 1_050_000);
+    }
+
+    #[test]
+    fn test_build_approve_call() {
+        let token_in = address!("0x20c0000000000000000000000000000000000000");
+        let call = build_approve_call(token_in, 5_050_500);
+
+        assert_eq!(call.to, TxKind::Call(token_in));
+        let decoded = ITIP20::approveCall::abi_decode_raw(&call.input[4..]).unwrap();
+        assert_eq!(decoded.spender, DEX_ADDRESS);
+        assert_eq!(decoded.amount, U256::from(5_050_500));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_autoswap_returns_approve_then_swap() {
+        use alloy::{
+            primitives::Bytes,
+            providers::{mock::Asserter, ProviderBuilder},
+        };
+
+        let token_in = address!("0x20c0000000000000000000000000000000000000");
+        let token_out = address!("0x20C000000000000000000000b9537d11c60E8b50");
+        let asserter = Asserter::new();
+        asserter.push_success(&Bytes::from(ITIP20::balanceOfCall::abi_encode_returns(
+            &U256::from(52_906),
+        )));
+        asserter.push_success(&Bytes::from(
+            IStablecoinDEX::quoteSwapExactAmountOutCall::abi_encode_returns(&5_000_500u128),
+        ));
+        asserter.push_success(&Bytes::from(ITIP20::balanceOfCall::abi_encode_returns(
+            &U256::from(16_852_785),
+        )));
+        let provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+            .connect_mocked_client(asserter);
+
+        let calls = resolve_autoswap_calls(
+            &provider,
+            Address::repeat_byte(0x11),
+            token_out,
+            U256::from(5_000_000),
+            &AutoswapConfig::new(token_in, 100),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(calls.len(), 2);
+        let approve = ITIP20::approveCall::abi_decode_raw(&calls[0].input[4..]).unwrap();
+        assert_eq!(approve.spender, DEX_ADDRESS);
+        assert_eq!(approve.amount, U256::from(5_050_505));
+        let swap =
+            IStablecoinDEX::swapExactAmountOutCall::abi_decode_raw(&calls[1].input[4..]).unwrap();
+        assert_eq!(swap.amountOut, 5_000_000);
+        assert_eq!(swap.maxAmountIn, 5_050_505);
     }
 }

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -181,7 +181,7 @@ impl PaymentProvider for TempoProvider {
             let provider =
                 alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
 
-            if let Some(swap_call) = super::autoswap::resolve_autoswap(
+            if let Some(swap_calls) = super::autoswap::resolve_autoswap_calls(
                 &provider,
                 from,
                 charge.currency(),
@@ -190,7 +190,11 @@ impl PaymentProvider for TempoProvider {
             )
             .await?
             {
-                charge = charge.with_prepended_call(swap_call)?;
+                // `with_prepended_call` inserts at index zero, so walk the
+                // sequence backwards to retain approve -> swap -> transfer.
+                for call in swap_calls.into_iter().rev() {
+                    charge = charge.with_prepended_call(call)?;
+                }
             }
         }
 

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -859,6 +859,8 @@ pub fn create_precompile_top_up_payload(
 /// (always the precompile) with `operator`. `deposit` and `initial_amount`
 /// must fit `uint96`.
 pub struct OpenPrecompilePayloadOptions {
+    /// Calls executed atomically before the channel open.
+    pub prefix_calls: Vec<Call>,
     /// Optional relayer for `settle`/`close`; `Address::ZERO` = payee-only.
     pub operator: Address,
     /// Voucher signer; defaults to `payer` if `None`.
@@ -873,6 +875,8 @@ pub struct OpenPrecompilePayloadOptions {
 
 /// Options for a descriptor-backed TIP-1034 top-up transaction.
 pub struct TopUpPrecompilePayloadOptions<'a> {
+    /// Calls executed atomically before the channel top-up.
+    pub prefix_calls: Vec<Call>,
     /// Existing channel descriptor.
     pub descriptor: &'a ChannelDescriptor,
     /// Amount added to the existing channel deposit.
@@ -883,9 +887,10 @@ pub struct TopUpPrecompilePayloadOptions<'a> {
     pub fee_payer: bool,
 }
 
-/// Open payload targeting the TIP-1034 reserve precompile. Single-call tx
-/// (no `approve` needed: precompile is on the TIP-1035 implicit approvals
-/// list). Channel id is derived against the unsigned tx's `expiringNonceHash`.
+/// Open payload targeting the TIP-1034 reserve precompile. The escrow open
+/// itself needs no approval because the precompile is on the TIP-1035 implicit
+/// approvals list; optional prefix calls may acquire the deposit currency.
+/// Channel id is derived against the complete unsigned tx's `expiringNonceHash`.
 #[cfg(feature = "tempo")]
 pub async fn create_precompile_open_payload<P, S>(
     provider: &P,
@@ -928,11 +933,12 @@ where
     ))
     .abi_encode();
 
-    let calls = vec![Call {
+    let mut calls = options.prefix_calls;
+    calls.push(Call {
         to: TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS),
         value: U256::ZERO,
         input: Bytes::from(open_data),
-    }];
+    });
 
     let nonce = if options.fee_payer {
         0
@@ -1069,13 +1075,14 @@ where
     let signing_mode = signing_mode.unwrap_or(&default_mode);
     let primitive_signer = signer.clone().into();
     let descriptor = precompile_descriptor_from_wire(options.descriptor)?;
-    let calls = vec![Call {
+    let mut calls = options.prefix_calls;
+    calls.push(Call {
         to: TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS),
         value: U256::ZERO,
         input: Bytes::from(
             ITIP20ChannelReserve::topUpCall::new((descriptor, additional_deposit)).abi_encode(),
         ),
-    }];
+    });
     let nonce = if options.fee_payer {
         0
     } else {
@@ -1398,6 +1405,7 @@ mod tests {
             .connect_http("http://localhost:1".parse().unwrap());
 
         let opts = OpenPrecompilePayloadOptions {
+            prefix_calls: Vec::new(),
             operator: Address::ZERO,
             authorized_signer: None,
             payee: Address::repeat_byte(0x11),

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -13,10 +13,13 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use alloy::{
-    primitives::{Address, B256},
+    primitives::{Address, B256, U256},
+    providers::Provider,
     signers::Signer,
 };
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use tempo_alloy::TempoNetwork;
+use tempo_primitives::transaction::Call;
 
 use self::channel_ops::{
     build_credential, create_close_payload, create_open_payload,
@@ -32,6 +35,7 @@ use self::recovery::{
 use self::store::{
     channel_key as persistent_channel_key, ChannelStore, MemoryChannelStore, StoredChannelEntry,
 };
+use super::autoswap::AutoswapConfig;
 use super::signing::TempoPrimitiveSigner;
 use crate::client::PaymentProvider;
 use crate::error::{MppError, ResultExt};
@@ -75,6 +79,8 @@ pub struct TempoSessionProvider {
     max_deposit: Option<u128>,
     /// Default deposit in atomic units when no suggestedDeposit is available.
     default_deposit: Option<u128>,
+    /// Stablecoin used to acquire the session currency before open/top-up.
+    autoswap: Option<AutoswapConfig>,
     /// Channel registry: key is `payee:currency:escrow` (lowercase).
     channels: Arc<Mutex<HashMap<String, ChannelEntry>>>,
     /// Durable channel view. Recovery policy remains owned by this provider.
@@ -112,6 +118,7 @@ impl TempoSessionProvider {
             signing_mode: crate::client::tempo::signing::TempoSigningMode::Direct,
             max_deposit: None,
             default_deposit: None,
+            autoswap: None,
             channels: Arc::new(Mutex::new(HashMap::new())),
             channel_store: Arc::new(MemoryChannelStore::default()),
             channel_id_to_key: Arc::new(Mutex::new(HashMap::new())),
@@ -153,6 +160,17 @@ impl TempoSessionProvider {
     pub fn with_default_deposit(mut self, amount: u128) -> Self {
         self.default_deposit = Some(amount);
         self
+    }
+
+    /// Enable atomic stablecoin swaps before native session opens and top-ups.
+    pub fn with_autoswap(mut self, config: AutoswapConfig) -> Self {
+        self.autoswap = Some(config);
+        self
+    }
+
+    /// Get the autoswap configuration, if set.
+    pub fn autoswap(&self) -> Option<&AutoswapConfig> {
+        self.autoswap.as_ref()
     }
 
     /// Persist reusable native MPP channels in `store`.
@@ -213,6 +231,27 @@ impl TempoSessionProvider {
             }
         }
         Ok(())
+    }
+
+    async fn autoswap_calls<P: Provider<TempoNetwork>>(
+        &self,
+        provider: &P,
+        payer: Address,
+        currency: Address,
+        amount: u128,
+    ) -> Result<Vec<Call>, MppError> {
+        let Some(config) = &self.autoswap else {
+            return Ok(Vec::new());
+        };
+        Ok(super::autoswap::resolve_autoswap_calls(
+            provider,
+            payer,
+            currency,
+            U256::from(amount),
+            config,
+        )
+        .await?
+        .unwrap_or_default())
     }
 
     fn required_top_up(
@@ -737,12 +776,24 @@ impl TempoSessionProvider {
         let payer = self.signing_mode.from_address(self.signer.address());
         let provider =
             ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(self.rpc_url.clone());
+        let prefix_calls = self
+            .autoswap_calls(
+                &provider,
+                payer,
+                descriptor
+                    .token
+                    .parse()
+                    .mpp_config("invalid TIP-1034 descriptor token")?,
+                additional_deposit,
+            )
+            .await?;
         let payload = create_precompile_top_up_transaction_payload(
             &provider,
             &self.signer,
             Some(&self.signing_mode),
             payer,
             TopUpPrecompilePayloadOptions {
+                prefix_calls,
                 descriptor,
                 additional_deposit,
                 chain_id: entry.chain_id,
@@ -1477,12 +1528,16 @@ impl TempoSessionProvider {
         }
 
         let (entry, payload) = if precompile {
+            let prefix_calls = self
+                .autoswap_calls(&provider, payer, currency, deposit)
+                .await?;
             create_precompile_open_payload(
                 &provider,
                 &self.signer,
                 Some(&self.signing_mode),
                 payer,
                 OpenPrecompilePayloadOptions {
+                    prefix_calls,
                     operator: operator.unwrap_or(Address::ZERO),
                     authorized_signer: Some(authorized_signer),
                     payee,
@@ -1593,18 +1648,22 @@ mod tests {
         let auth_signer: Address = "0x2222222222222222222222222222222222222222"
             .parse()
             .unwrap();
+        let swap_token = Address::repeat_byte(0x33);
+        let autoswap = AutoswapConfig::new(swap_token, 100);
 
         let provider = TempoSessionProvider::new(signer, "https://rpc.example.com")
             .unwrap()
             .with_escrow_contract(escrow)
             .with_authorized_signer(auth_signer)
             .with_max_deposit(1_000_000)
-            .with_default_deposit(500_000);
+            .with_default_deposit(500_000)
+            .with_autoswap(autoswap);
 
         assert_eq!(provider.escrow_contract, Some(escrow));
         assert_eq!(provider.authorized_signer, Some(auth_signer));
         assert_eq!(provider.max_deposit, Some(1_000_000));
         assert_eq!(provider.default_deposit, Some(500_000));
+        assert_eq!(provider.autoswap().unwrap().token_in, swap_token);
     }
 
     #[test]


### PR DESCRIPTION
Mirrors MPPx native-session autoswap semantics for TIP-1034 channel funding.

- adds `TempoSessionProvider::with_autoswap`
- atomically prepends approve + exact-output DEX swap calls before open/top-up
- fixes the existing charge path to include the DEX approval while preserving the legacy single-call helper
- signs the complete call batch so channel identity remains transaction-bound

Validation:
- `cargo test --features "client,tempo" "client::tempo::autoswap" --lib` (6 passed)
- `cargo test --features "client,tempo" "client::tempo::session" --lib` (80 passed)
- `cargo clippy --all-features --all-targets -- -D warnings`