### PR TITLE
fix(client): load wallet key authorization

### DIFF
--- a/.changelog/wallet-key-authorization.md
+++ b/.changelog/wallet-key-authorization.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Load pending Accounts SDK key authorizations from the shared Tempo Wallet store so native Rust clients can provision a fresh access key with their first transaction. Open a fresh session after access-key rotation instead of trying to reuse a channel bound to the previous voucher signer.

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -30,7 +30,8 @@ use self::channel_ops::{
     OpenPayloadOptions, OpenPrecompilePayloadOptions, TopUpPrecompilePayloadOptions,
 };
 use self::recovery::{
-    hydrate_session_snapshot, read_on_chain_channel_state, recover_stored_channel, RecoveryScope,
+    can_sign_descriptor, hydrate_session_snapshot, read_on_chain_channel_state,
+    recover_stored_channel, RecoveryScope,
 };
 use self::store::{
     channel_key as persistent_channel_key, ChannelStore, MemoryChannelStore, StoredChannelEntry,
@@ -403,6 +404,12 @@ impl TempoSessionProvider {
             .await
             .map_err(Self::store_error)?;
 
+        let snapshot = if let Some(snapshot) = snapshot {
+            can_sign_descriptor(&snapshot.descriptor, scope.payer, scope.authorized_signer)?
+                .then_some(snapshot)
+        } else {
+            None
+        };
         if let Some(snapshot) = snapshot {
             let snapshot_channel_id = snapshot.channel_id.parse().map_err(|error| {
                 MppError::InvalidConfig(format!("invalid snapshot channelId: {error}"))
@@ -442,6 +449,9 @@ impl TempoSessionProvider {
         let Some(stored) = stored else {
             return Ok(None);
         };
+        if !can_sign_descriptor(&stored.descriptor, scope.payer, scope.authorized_signer)? {
+            return Ok(None);
+        }
 
         let state = read_on_chain_channel_state(provider, stored.channel_id).await?;
         if state.deposit == 0 || state.close_requested_at != 0 {

--- a/src/client/tempo/session/recovery.rs
+++ b/src/client/tempo/session/recovery.rs
@@ -78,6 +78,21 @@ pub struct RecoveryScope {
     pub chain_id: u64,
 }
 
+/// Return whether this client controls the voucher authority bound into a descriptor.
+///
+/// A different authority is expected after access-key rotation and makes the old
+/// channel non-reusable; it is not a malformed snapshot.
+pub fn can_sign_descriptor(
+    descriptor: &ChannelDescriptor,
+    payer: Address,
+    authorized_signer: Address,
+) -> Result<bool, MppError> {
+    Ok(
+        parse_address("descriptor payer", &descriptor.payer)? == payer
+            && descriptor_authority(descriptor)? == authorized_signer,
+    )
+}
+
 /// Reconcile a locally stored entry with its descriptor and on-chain state.
 pub fn recover_stored_channel(
     mut entry: StoredChannelEntry,
@@ -353,6 +368,18 @@ mod tests {
         .unwrap();
         assert_eq!(recovered.cumulative_amount, 300);
         assert_eq!(recovered.deposit, 1_000);
+    }
+
+    #[test]
+    fn rotated_access_key_cannot_reuse_old_descriptor() {
+        let old_authority = Address::repeat_byte(0x60);
+        let new_authority = Address::repeat_byte(0x70);
+        assert!(!can_sign_descriptor(
+            &descriptor(old_authority),
+            Address::repeat_byte(0x10),
+            new_authority,
+        )
+        .unwrap());
     }
 
     #[tokio::test]

--- a/src/client/tempo/wallet.rs
+++ b/src/client/tempo/wallet.rs
@@ -6,9 +6,13 @@ use std::{
     str::FromStr,
 };
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, Bytes, Signature, B256, U256};
 use alloy::signers::Signer;
-use serde::Deserialize;
+use serde::{de::Error as _, Deserialize, Deserializer};
+use tempo_primitives::transaction::{
+    tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
+    KeyAuthorization, PrimitiveSignature, SignatureType, SignedKeyAuthorization, TokenLimit,
+};
 
 use super::signing::{P256Jwk, TempoP256Signer};
 
@@ -23,6 +27,8 @@ pub struct TempoWallet {
     pub chain_id: u64,
     /// Native signer reconstructed from the persisted WebCrypto JWK.
     pub signer: TempoP256Signer,
+    /// Signed authorization attached while the active access key is not yet on-chain.
+    pub key_authorization: Option<Box<SignedKeyAuthorization>>,
 }
 
 /// Errors returned while loading Tempo Wallet state.
@@ -96,6 +102,7 @@ impl TempoWallet {
             access_key: access_key.address,
             chain_id: state.chain_id,
             signer,
+            key_authorization: access_key.key_authorization.map(Box::new),
         })
     }
 
@@ -145,12 +152,241 @@ struct TempoAccessKey {
     chain_id: u64,
     key_type: String,
     handle: TempoAccessKeyHandle,
+    #[serde(default, deserialize_with = "deserialize_key_authorization")]
+    key_authorization: Option<SignedKeyAuthorization>,
 }
 
 #[derive(Deserialize)]
 struct TempoAccessKeyHandle {
     kind: String,
     jwk: P256Jwk,
+}
+
+fn deserialize_key_authorization<'de, D>(
+    deserializer: D,
+) -> Result<Option<SignedKeyAuthorization>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    value
+        .as_ref()
+        .map(parse_key_authorization)
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
+fn parse_key_authorization(value: &serde_json::Value) -> Result<SignedKeyAuthorization, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Tempo Wallet keyAuthorization must be an object".to_owned())?;
+    if object.contains_key("scopes") {
+        return Err("Tempo Wallet keyAuthorization scopes are not yet supported".to_owned());
+    }
+    let key_type = match string_field(object, "type")? {
+        "secp256k1" => SignatureType::Secp256k1,
+        "p256" => SignatureType::P256,
+        "webAuthn" => SignatureType::WebAuthn,
+        value => return Err(format!("unsupported Tempo Wallet key type {value}")),
+    };
+    let key_id = string_field(object, "address")?
+        .parse()
+        .map_err(|error| format!("invalid Tempo Wallet access-key address: {error}"))?;
+    let chain_id = tagged_u256(value_field(object, "chainId")?, "chainId")?
+        .try_into()
+        .map_err(|_| "Tempo Wallet keyAuthorization chainId exceeds u64".to_owned())?;
+    let expiry = object
+        .get("expiry")
+        .filter(|value| !value.is_null())
+        .map(|value| tagged_u256(value, "expiry"))
+        .transpose()?
+        .map(|value| {
+            u64::try_from(value)
+                .map_err(|_| "Tempo Wallet keyAuthorization expiry exceeds u64".to_owned())
+        })
+        .transpose()?
+        .and_then(std::num::NonZeroU64::new);
+    let limits = object
+        .get("limits")
+        .map(|value| {
+            value
+                .as_array()
+                .ok_or_else(|| "Tempo Wallet keyAuthorization limits must be an array".to_owned())?
+                .iter()
+                .map(parse_token_limit)
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+    let witness = object
+        .get("witness")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| "Tempo Wallet keyAuthorization witness must be hex".to_owned())?
+                .parse()
+                .map_err(|error| format!("invalid Tempo Wallet keyAuthorization witness: {error}"))
+        })
+        .transpose()?;
+    let account = object
+        .get("account")
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| {
+                    "Tempo Wallet keyAuthorization account must be an address".to_owned()
+                })?
+                .parse()
+                .map_err(|error| format!("invalid Tempo Wallet keyAuthorization account: {error}"))
+        })
+        .transpose()?;
+    let authorization = KeyAuthorization {
+        chain_id,
+        key_type,
+        key_id,
+        expiry,
+        limits,
+        allowed_calls: None,
+        witness,
+        is_admin: object
+            .get("isAdmin")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        account,
+    };
+    let signature = parse_primitive_signature(value_field(object, "signature")?)?;
+    Ok(SignedKeyAuthorization::new(authorization, signature))
+}
+
+fn parse_token_limit(value: &serde_json::Value) -> Result<TokenLimit, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Tempo Wallet token limit must be an object".to_owned())?;
+    Ok(TokenLimit {
+        token: string_field(object, "token")?
+            .parse()
+            .map_err(|error| format!("invalid Tempo Wallet token-limit address: {error}"))?,
+        limit: tagged_u256(value_field(object, "limit")?, "limit")?,
+        period: object
+            .get("period")
+            .map(|value| tagged_u256(value, "period"))
+            .transpose()?
+            .map(u64::try_from)
+            .transpose()
+            .map_err(|_| "Tempo Wallet token-limit period exceeds u64".to_owned())?
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_primitive_signature(value: &serde_json::Value) -> Result<PrimitiveSignature, String> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| "Tempo Wallet keyAuthorization signature must be an object".to_owned())?;
+    match string_field(object, "type")? {
+        "secp256k1" => {
+            let signature = object
+                .get("signature")
+                .and_then(serde_json::Value::as_object)
+                .unwrap_or(object);
+            Ok(PrimitiveSignature::Secp256k1(Signature::new(
+                tagged_u256(value_field(signature, "r")?, "signature.r")?,
+                tagged_u256(value_field(signature, "s")?, "signature.s")?,
+                tagged_u256(value_field(signature, "yParity")?, "signature.yParity")? != U256::ZERO,
+            )))
+        }
+        "p256" => {
+            let (r, s, x, y) = signature_components(object)?;
+            Ok(PrimitiveSignature::P256(P256SignatureWithPreHash {
+                r,
+                s,
+                pub_key_x: x,
+                pub_key_y: y,
+                pre_hash: object
+                    .get("prehash")
+                    .or_else(|| object.get("preHash"))
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+            }))
+        }
+        "webAuthn" => {
+            let (r, s, x, y) = signature_components(object)?;
+            let metadata = value_field(object, "metadata")?
+                .as_object()
+                .ok_or_else(|| "Tempo Wallet WebAuthn metadata must be an object".to_owned())?;
+            let mut webauthn_data = hex_bytes(string_field(metadata, "authenticatorData")?)?;
+            webauthn_data.extend_from_slice(string_field(metadata, "clientDataJSON")?.as_bytes());
+            Ok(PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                r,
+                s,
+                pub_key_x: x,
+                pub_key_y: y,
+                webauthn_data: Bytes::from(webauthn_data),
+            }))
+        }
+        value => Err(format!(
+            "unsupported Tempo Wallet key-authorization signature type {value}"
+        )),
+    }
+}
+
+fn signature_components(
+    object: &serde_json::Map<String, serde_json::Value>,
+) -> Result<(B256, B256, B256, B256), String> {
+    let signature = value_field(object, "signature")?
+        .as_object()
+        .ok_or_else(|| "Tempo Wallet signature coordinates must be an object".to_owned())?;
+    let public_key = value_field(object, "publicKey")?
+        .as_object()
+        .ok_or_else(|| "Tempo Wallet public key must be an object".to_owned())?;
+    Ok((
+        tagged_b256(value_field(signature, "r")?, "signature.r")?,
+        tagged_b256(value_field(signature, "s")?, "signature.s")?,
+        tagged_b256(value_field(public_key, "x")?, "publicKey.x")?,
+        tagged_b256(value_field(public_key, "y")?, "publicKey.y")?,
+    ))
+}
+
+fn tagged_b256(value: &serde_json::Value, field: &str) -> Result<B256, String> {
+    Ok(B256::from(tagged_u256(value, field)?.to_be_bytes::<32>()))
+}
+
+fn tagged_u256(value: &serde_json::Value, field: &str) -> Result<U256, String> {
+    if let Some(value) = value.as_u64() {
+        return Ok(U256::from(value));
+    }
+    let value = value
+        .as_str()
+        .ok_or_else(|| format!("Tempo Wallet {field} must be an integer"))?;
+    let value = value.strip_suffix("#__bigint").unwrap_or(value);
+    if let Some(value) = value.strip_prefix("0x") {
+        U256::from_str_radix(value, 16)
+    } else {
+        U256::from_str_radix(value, 10)
+    }
+    .map_err(|error| format!("invalid Tempo Wallet {field}: {error}"))
+}
+
+fn value_field<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<&'a serde_json::Value, String> {
+    object
+        .get(field)
+        .ok_or_else(|| format!("Tempo Wallet keyAuthorization is missing {field}"))
+}
+
+fn string_field<'a>(
+    object: &'a serde_json::Map<String, serde_json::Value>,
+    field: &str,
+) -> Result<&'a str, String> {
+    value_field(object, field)?
+        .as_str()
+        .ok_or_else(|| format!("Tempo Wallet keyAuthorization {field} must be a string"))
+}
+
+fn hex_bytes(value: &str) -> Result<Vec<u8>, String> {
+    alloy::hex::decode(value).map_err(|error| format!("invalid Tempo Wallet hex bytes: {error}"))
 }
 
 fn active_account(state: &TempoWalletState) -> Result<Address, TempoWalletError> {
@@ -218,7 +454,23 @@ mod tests {
                   "x":"OtOGGpViE5JRa7WT7wVYPtLlhm9ctiYKMBcjf9ibkK8",
                   "y":"0JYcfjcHWmeRo5xh9WKVsCttJlZ7YV5gqkHuHI6DOI0",
                   "d":"QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI"
-                }}
+                }},
+                "keyAuthorization": {
+                  "address":"0xf0159a522607cd6ab1097204c9fafb7bbe6afb6c",
+                  "chainId":"4217#__bigint",
+                  "expiry":4102444800,
+                  "limits":[{
+                    "token":"0x20c0000000000000000000000000000000000000",
+                    "limit":"100000000#__bigint"
+                  }],
+                  "type":"p256",
+                  "signature":{
+                    "metadata":{"authenticatorData":"0x010203","clientDataJSON":"{}"},
+                    "publicKey":{"prefix":4,"x":"3#__bigint","y":"4#__bigint"},
+                    "signature":{"r":"1#__bigint","s":"2#__bigint"},
+                    "type":"webAuthn"
+                  }
+                }
               }]
             }
           }
@@ -239,5 +491,16 @@ mod tests {
                 .parse::<Address>()
                 .unwrap()
         );
+        let authorization = wallet.key_authorization.unwrap();
+        assert_eq!(authorization.chain_id, 4217);
+        assert_eq!(authorization.key_id, wallet.access_key);
+        assert_eq!(
+            authorization.limits.as_ref().unwrap()[0].limit,
+            U256::from(100_000_000)
+        );
+        let PrimitiveSignature::WebAuthn(signature) = &authorization.signature else {
+            panic!("expected WebAuthn root authorization")
+        };
+        assert_eq!(signature.webauthn_data.as_ref(), b"\x01\x02\x03{}");
     }
 }


### PR DESCRIPTION
Load pending Accounts SDK key authorizations from the shared Tempo Wallet store and expose them with the reconstructed access-key signer.

This lets Rust CLI consumers attach the signed authorization to the first native transaction for a freshly issued wallet access key. It supports the persisted secp256k1, P-256, and WebAuthn signature envelopes and rejects scoped authorizations instead of silently broadening them.

Validation:
- `cargo test --all-features client::tempo::wallet --lib`
- `cargo clippy --all-features --all-targets -- -D warnings`