### PR TITLE
fix(client): avoid replaying key authorizations

### DIFF
--- a/.changelog/resolve-key-authorization.md
+++ b/.changelog/resolve-key-authorization.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Resolve persisted Tempo Wallet key authorizations against the Account Keychain before signing. Already-authorized access keys now omit the one-time authorization instead of failing fresh charge or session transactions with `KeyAlreadyExists`.

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -304,6 +304,22 @@ impl TempoCharge {
         let provider =
             alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
 
+        let managed_key_authorization = if options.key_authorization.is_none() {
+            crate::client::tempo::signing::keychain::resolve_key_authorization(
+                &provider,
+                &signing_mode,
+                signer_address,
+            )
+            .await?
+        } else {
+            None
+        };
+        let key_authorization = options
+            .key_authorization
+            .as_deref()
+            .cloned()
+            .or(managed_key_authorization);
+
         let calls = match self.calls {
             Some(c) => c,
             None => self.build_transfer_calls()?,
@@ -339,14 +355,9 @@ impl TempoCharge {
             // co-signs and pays for gas.
             1_000_000
         } else {
-            let key_auth = options
-                .key_authorization
-                .as_deref()
-                .or_else(|| signing_mode.key_authorization());
-
             let mut req = TempoTransactionRequest {
                 calls: calls.clone(),
-                key_authorization: key_auth.cloned(),
+                key_authorization: key_authorization.clone(),
                 ..Default::default()
             }
             .with_fee_token(fee_token)
@@ -366,12 +377,6 @@ impl TempoCharge {
         };
 
         // Build the key_authorization for the transaction
-        let tx_key_authorization = options
-            .key_authorization
-            .as_deref()
-            .or_else(|| signing_mode.key_authorization())
-            .cloned();
-
         let tx = build_tempo_tx(TempoTxOptions {
             calls,
             chain_id: self.chain_id,
@@ -383,7 +388,7 @@ impl TempoCharge {
             max_priority_fee_per_gas,
             fee_payer: self.fee_payer,
             valid_before,
-            key_authorization: tx_key_authorization,
+            key_authorization,
         });
 
         Ok(PreparedTempoCharge {

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -527,6 +527,13 @@ where
         .await
         .mpp_http("failed to get gas price")?;
 
+    let key_authorization = crate::client::tempo::signing::keychain::resolve_key_authorization(
+        provider,
+        signing_mode,
+        signer.address(),
+    )
+    .await?;
+
     let tempo_tx = build_tempo_tx(TempoTxOptions {
         calls,
         chain_id: options.chain_id,
@@ -538,7 +545,7 @@ where
         max_priority_fee_per_gas: gas_price,
         fee_payer: options.fee_payer,
         valid_before: None,
-        key_authorization: signing_mode.key_authorization().cloned(),
+        key_authorization,
     });
 
     let tx_bytes =
@@ -957,6 +964,13 @@ where
     let (nonce, nonce_key, valid_before) =
         precompile_open_tx_nonce_fields(options.fee_payer, nonce);
 
+    let key_authorization = crate::client::tempo::signing::keychain::resolve_key_authorization(
+        provider,
+        signing_mode,
+        primitive_signer.address(),
+    )
+    .await?;
+
     let unsigned_tx = build_tempo_tx(TempoTxOptions {
         calls,
         chain_id: options.chain_id,
@@ -968,7 +982,7 @@ where
         max_priority_fee_per_gas: gas_price,
         fee_payer: options.fee_payer,
         valid_before,
-        key_authorization: signing_mode.key_authorization().cloned(),
+        key_authorization,
     });
     // Derive id from the unsigned tx before signing; expiringNonceHash binds
     // the signing-payload bytes.
@@ -1097,6 +1111,13 @@ where
         .mpp_http("failed to get gas price")?;
     let (nonce, nonce_key, valid_before) =
         precompile_open_tx_nonce_fields(options.fee_payer, nonce);
+
+    let key_authorization = crate::client::tempo::signing::keychain::resolve_key_authorization(
+        provider,
+        signing_mode,
+        primitive_signer.address(),
+    )
+    .await?;
     let mut unsigned_tx = build_tempo_tx(TempoTxOptions {
         calls,
         chain_id: options.chain_id,
@@ -1112,7 +1133,7 @@ where
         max_priority_fee_per_gas: gas_price,
         fee_payer: options.fee_payer,
         valid_before,
-        key_authorization: signing_mode.key_authorization().cloned(),
+        key_authorization,
     });
     add_sponsored_top_up_entropy(&mut unsigned_tx, options.fee_payer);
     let tx_bytes = if options.fee_payer {

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -6,10 +6,13 @@
 
 use alloy::primitives::{Address, U256};
 use tempo_alloy::contracts::precompiles::{IAccountKeychain, ACCOUNT_KEYCHAIN_ADDRESS};
+use tempo_alloy::TempoNetwork;
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
 use crate::client::tempo::TempoClientError;
 use crate::error::{MppError, ResultExt};
+
+use super::TempoSigningMode;
 
 /// Validate key info returned from the keychain precompile.
 ///
@@ -32,6 +35,74 @@ fn validate_key_info(
     Ok(key_info.enforceLimits)
 }
 
+/// Resolve a stored one-time key authorization against authoritative chain state.
+///
+/// Tempo Wallet persists the signed authorization so a newly created access key
+/// can provision itself with its first transaction. Once the key exists on-chain,
+/// replaying that authorization fails with `KeyAlreadyExists`. Match viem's Tempo
+/// transaction preparation: attach the stored authorization only while the access
+/// key is not currently active on the wallet's keychain.
+pub(crate) async fn resolve_key_authorization<P: alloy::providers::Provider<TempoNetwork>>(
+    provider: &P,
+    signing_mode: &TempoSigningMode,
+    key_address: Address,
+) -> Result<Option<SignedKeyAuthorization>, MppError> {
+    let TempoSigningMode::Keychain {
+        wallet,
+        key_authorization: Some(key_authorization),
+        ..
+    } = signing_mode
+    else {
+        return Ok(None);
+    };
+
+    let now_secs = unix_time_secs();
+    if key_authorization
+        .authorization
+        .expiry
+        .is_some_and(|expiry| expiry.get() <= now_secs)
+    {
+        return Ok(None);
+    }
+
+    let keychain = IAccountKeychain::new(ACCOUNT_KEYCHAIN_ADDRESS, provider);
+    let key_info = keychain
+        .getKey(*wallet, key_address)
+        .call()
+        .await
+        .mpp_http("failed to query key authorization state")?;
+
+    if should_attach_key_authorization(key_authorization, &key_info, key_address, now_secs) {
+        Ok(Some(key_authorization.as_ref().clone()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn should_attach_key_authorization(
+    key_authorization: &SignedKeyAuthorization,
+    key_info: &IAccountKeychain::KeyInfo,
+    key_address: Address,
+    now_secs: u64,
+) -> bool {
+    if key_authorization
+        .authorization
+        .expiry
+        .is_some_and(|expiry| expiry.get() <= now_secs)
+    {
+        return false;
+    }
+
+    key_info.keyId != key_address || key_info.isRevoked || key_info.expiry <= now_secs
+}
+
+fn unix_time_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 /// Query the key's remaining spending limit for a token.
 ///
 /// Returns `Ok(None)` if the key doesn't enforce limits (unlimited spending),
@@ -47,10 +118,7 @@ pub async fn query_key_spending_limit<P: alloy::providers::Provider>(
 ) -> Result<Option<U256>, MppError> {
     let keychain = IAccountKeychain::new(ACCOUNT_KEYCHAIN_ADDRESS, provider);
 
-    let now_secs = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let now_secs = unix_time_secs();
 
     let key_info = keychain
         .getKey(wallet_address, key_address)
@@ -277,6 +345,63 @@ mod tests {
             format!("{:#x}", ACCOUNT_KEYCHAIN_ADDRESS),
             "0xaaaaaaaa00000000000000000000000000000000"
         );
+    }
+
+    #[test]
+    fn test_pending_authorization_is_dropped_for_active_on_chain_key() {
+        let signer = test_signer();
+        let key_authorization = make_signed_auth(&signer, None);
+        let mut key_info = make_key_info(9_999_999_999, false, false);
+        key_info.keyId = signer.address();
+
+        assert!(!should_attach_key_authorization(
+            &key_authorization,
+            &key_info,
+            signer.address(),
+            1_000,
+        ));
+    }
+
+    #[test]
+    fn test_pending_authorization_is_kept_for_missing_on_chain_key() {
+        let signer = test_signer();
+        let key_authorization = make_signed_auth(&signer, None);
+        let key_info = make_key_info(0, false, false);
+
+        assert!(should_attach_key_authorization(
+            &key_authorization,
+            &key_info,
+            signer.address(),
+            1_000,
+        ));
+    }
+
+    #[test]
+    fn test_expired_pending_authorization_is_dropped() {
+        let signer = test_signer();
+        let authorization = KeyAuthorization {
+            chain_id: 42431,
+            key_type: SignatureType::Secp256k1,
+            key_id: signer.address(),
+            expiry: NonZeroU64::new(1_000),
+            limits: None,
+            allowed_calls: None,
+            witness: None,
+            is_admin: false,
+            account: None,
+        };
+        let signature = signer
+            .sign_hash_sync(&authorization.signature_hash())
+            .unwrap();
+        let key_authorization = authorization.into_signed(PrimitiveSignature::Secp256k1(signature));
+        let key_info = make_key_info(0, false, false);
+
+        assert!(!should_attach_key_authorization(
+            &key_authorization,
+            &key_info,
+            signer.address(),
+            1_000,
+        ));
     }
 
     // --- validate_key_info tests ---


### PR DESCRIPTION
## Summary

- resolve persisted Tempo Wallet key authorizations against the Account Keychain before signing
- attach a pending authorization only when the access key is not already active on-chain
- apply the viem/MPPx behavior to native charges, session opens, and session top-ups

## Regression

A fresh client/channel store reused an already-provisioned access key whose wallet store still retained `keyAuthorization`. mpp-rs replayed the one-time authorization and mainnet rejected the sponsored session open with `KeyAlreadyExists`.

## Validation

- `cargo test -p mpp --all-features pending_authorization --lib`
- `cargo clippy -p mpp --all-features --all-targets -- -D warnings`
- live Tempo mainnet: fresh SQLite store, sponsored PathUSD→USDC exact-output session open, OpenAI Responses WebSocket, `gpt-5.6-sol` returned `OK`
- successful open transaction: `0x4a3b90f40ac3b6dfe1953a30049b70232a5398329bf3bcb9a91a6827e6d6301e`
- channel: `0xc8c29a5756322f413c81d09836e3a6948f9c20a484fc19711c5f94a7711bcd53`