### PR TITLE
fix(client): make charge autoswap payable from input token

### DIFF
--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -33,7 +33,9 @@ pub mod tx_builder;
 use std::num::NonZeroU64;
 
 use alloy::primitives::{Address, TxKind, U256};
-use tempo_primitives::transaction::{Call, SignedKeyAuthorization, TempoTransaction};
+use tempo_primitives::transaction::{
+    Call, SignatureType, SignedKeyAuthorization, TempoTransaction,
+};
 
 use self::tx_builder::{build_charge_credential, build_tempo_tx, estimate_gas, TempoTxOptions};
 use crate::client::tempo::signing::{
@@ -83,6 +85,18 @@ fn encode_transfer(
             }
             .abi_encode(),
         )
+    }
+}
+
+fn apply_estimation_signer_hints(
+    request: &mut TempoTransactionRequest,
+    signing_mode: &TempoSigningMode,
+    signer_address: Address,
+    signature_type: SignatureType,
+) {
+    request.key_type = Some(signature_type);
+    if matches!(signing_mode, TempoSigningMode::Keychain { .. }) {
+        request.key_id = Some(signer_address);
     }
 }
 
@@ -244,7 +258,7 @@ impl TempoCharge {
         signer: &(impl alloy::signers::Signer + Clone),
         options: SignOptions,
     ) -> Result<SignedTempoCharge, MppError> {
-        self.prepare(signer.address(), options)
+        self.prepare(signer.address(), SignatureType::Secp256k1, options)
             .await?
             .sign_secp256k1(signer)
             .await
@@ -260,15 +274,24 @@ impl TempoCharge {
         signer: &TempoPrimitiveSigner,
         options: SignOptions,
     ) -> Result<SignedTempoCharge, MppError> {
-        self.prepare(alloy::signers::Signer::address(signer), options)
-            .await?
-            .sign_primitive(signer)
-            .await
+        let signature_type = match signer {
+            TempoPrimitiveSigner::Secp256k1(_) => SignatureType::Secp256k1,
+            TempoPrimitiveSigner::P256(_) => SignatureType::P256,
+        };
+        self.prepare(
+            alloy::signers::Signer::address(signer),
+            signature_type,
+            options,
+        )
+        .await?
+        .sign_primitive(signer)
+        .await
     }
 
     async fn prepare(
         self,
         signer_address: Address,
+        signature_type: SignatureType,
         options: SignOptions,
     ) -> Result<PreparedTempoCharge, MppError> {
         let signing_mode = options.signing_mode.unwrap_or_default();
@@ -372,6 +395,7 @@ impl TempoCharge {
             req.inner.nonce = Some(nonce);
             req.inner.max_fee_per_gas = Some(max_fee_per_gas);
             req.inner.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
+            apply_estimation_signer_hints(&mut req, &signing_mode, signer_address, signature_type);
 
             estimate_gas(&provider, req).await?
         };
@@ -670,6 +694,41 @@ mod tests {
         assert!(opts.key_authorization.is_none());
         assert!(opts.valid_before.is_none());
         assert!(opts.nonce_key.is_none());
+    }
+
+    #[test]
+    fn estimation_hints_direct_signature_type_without_key_id() {
+        let signer = Address::repeat_byte(0x11);
+        let mut request = TempoTransactionRequest::default();
+
+        apply_estimation_signer_hints(
+            &mut request,
+            &TempoSigningMode::Direct,
+            signer,
+            SignatureType::Secp256k1,
+        );
+
+        assert_eq!(request.key_type, Some(SignatureType::Secp256k1));
+        assert_eq!(request.key_id, None);
+    }
+
+    #[test]
+    fn estimation_hints_keychain_p256_access_key() {
+        use crate::client::tempo::signing::KeychainVersion;
+
+        let signer = Address::repeat_byte(0x11);
+        let wallet = Address::repeat_byte(0x22);
+        let mode = TempoSigningMode::Keychain {
+            wallet,
+            version: KeychainVersion::V2,
+            key_authorization: None,
+        };
+        let mut request = TempoTransactionRequest::default();
+
+        apply_estimation_signer_hints(&mut request, &mode, signer, SignatureType::P256);
+
+        assert_eq!(request.key_type, Some(SignatureType::P256));
+        assert_eq!(request.key_id, Some(signer));
     }
 
     #[test]

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -104,6 +104,10 @@ impl TempoProvider {
         self.autoswap.as_ref()
     }
 
+    fn fee_token(&self) -> Option<alloy::primitives::Address> {
+        self.autoswap.as_ref().map(|config| config.token_in)
+    }
+
     /// Pin the chain ID this provider will pay on. When set, [`pay`] rejects any
     /// challenge whose `methodDetails.chainId` differs, before signing.
     ///
@@ -172,7 +176,10 @@ impl PaymentProvider for TempoProvider {
             charge = charge.with_memo(memo);
         }
 
-        // If autoswap is enabled, check balance and prepend a swap call if needed.
+        // If autoswap is configured, keep gas payable in the funded input token
+        // even when the output-token balance already covers the charge itself.
+        // Otherwise the transfer can leave too little output token for gas.
+        let fee_token = self.fee_token();
         if let Some(autoswap_config) = &self.autoswap {
             let from = self
                 .signing_mode
@@ -201,6 +208,7 @@ impl PaymentProvider for TempoProvider {
         let options = SignOptions {
             rpc_url: Some(self.rpc_url.to_string()),
             signing_mode: Some(self.signing_mode.clone()),
+            fee_token,
             ..Default::default()
         };
         let signed = charge
@@ -268,6 +276,17 @@ mod tests {
             provider.signing_mode(),
             TempoSigningMode::Keychain { .. }
         ));
+    }
+
+    #[test]
+    fn autoswap_input_token_is_always_used_for_fees() {
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let token_in = alloy::primitives::Address::repeat_byte(0x11);
+        let provider = TempoProvider::new(signer, "https://rpc.example.com")
+            .unwrap()
+            .with_autoswap(AutoswapConfig::new(token_in, 100));
+
+        assert_eq!(provider.fee_token(), Some(token_in));
     }
 
     #[test]

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -1520,6 +1520,13 @@ async fn test_keychain_source_did_consistent_across_proof_and_paid() {
     // Fund the wallet address (access key signs on its behalf).
     fund_account(&rpc, server_signer.address()).await;
     fund_account(&rpc, wallet_signer.address()).await;
+    wallet_authorize_access_key(
+        &rpc,
+        &wallet_signer,
+        access_key_signer.address(),
+        U256::from(1_000_000u64),
+    )
+    .await;
 
     let mpp = Mpp::create(
         tempo(TempoConfig {


### PR DESCRIPTION
## Summary

- pay charge auto-swap gas from the configured input token, whether or not the current output-token balance requires swap calls
- include the primitive signature type and access-key ID in Tempo gas estimation
- authorize the keychain integration fixture now that estimation accurately exercises the access key

## Why

A P-256 access-key client with only 0.003278 USDC.e available and sufficient PathUSD could not reliably pay USDC.e charges. Two related cases failed:

1. When a swap was required, selecting the not-yet-produced USDC.e as the fee token made verification fail before the atomic swap could execute.
2. When the existing USDC.e covered the payment but not payment plus gas, skipping the swap and keeping USDC.e as the fee token left no fee headroom.

MPPx pays from the configured auto-swap input token. This patch matches that behavior and supplies the Tempo key metadata required for accurate P-256 access-key gas estimation.

## Live validation

- StableEnrich search ($0.01): HTTP 200 with insufficient USDC.e and PathUSD auto-swap
- StableEnrich contents ($0.002): reproduced HTTP 500 before the fee-headroom fix, then HTTP 200 with the same wallet state after it
- Nanocodex Code Mode: 14 paid calls launched together across charge and session services; all seven charge credentials decoded as Tempo type 0x76 with nonce 0, nonceKey MAX, and short validBefore

## Local validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
- TEMPO_RPC_URL=http://localhost:8545 cargo test --features integration --test integration_charge test_keychain_source_did_consistent_across_proof_and_paid -- --nocapture