### PR TITLE
fix(client): top up concurrent HTTP sessions

### DIFF
--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -11,7 +11,7 @@ use super::events::{
     ChallengeReceivedContext, ClientEvent, ClientEvents, CredentialCreatedContext,
     PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
-use super::provider::PaymentProvider;
+use super::provider::{PaymentContext, PaymentProvider};
 use super::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::client::challenge_selection::{
     expired_payment_error, select_supported_challenge, ChallengeSelectionError,
@@ -281,7 +281,19 @@ impl PaymentExt for RequestBuilder {
 
             let credential = match override_credential {
                 Some(credential) => credential,
-                None => match provider.pay(&challenge).await {
+                None => match provider
+                    .pay_with_context(
+                        &challenge,
+                        PaymentContext {
+                            url: url.clone().ok_or(HttpError::CloneFailed)?,
+                            headers: peek
+                                .as_ref()
+                                .map(|request| request.headers().clone())
+                                .unwrap_or_default(),
+                        },
+                    )
+                    .await
+                {
                     Ok(credential) => credential,
                     Err(err) => {
                         let http_err = HttpError::Payment(err);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -39,7 +39,7 @@ mod fetch;
 mod middleware;
 
 pub use error::HttpError;
-pub use provider::{MultiProvider, PaymentProvider};
+pub use provider::{MultiProvider, PaymentContext, PaymentProvider};
 
 /// Default number of payment challenge retries after the initial 402 response.
 #[cfg(any(feature = "client", feature = "middleware"))]

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -6,7 +6,21 @@
 
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential};
+use reqwest::header::HeaderMap;
+use reqwest::Url;
 use std::future::Future;
+
+/// HTTP request context available while creating a payment credential.
+///
+/// Session providers use this to submit management credentials, such as a
+/// channel top-up, to the same resource before replaying the paid request.
+#[derive(Clone, Debug)]
+pub struct PaymentContext {
+    /// URL of the request that returned the payment challenge.
+    pub url: Url,
+    /// Caller-provided request headers to preserve for management requests.
+    pub headers: HeaderMap,
+}
 
 /// Trait for payment providers that can execute payments for challenges.
 ///
@@ -64,6 +78,20 @@ pub trait PaymentProvider: Clone + Send + Sync {
         &self,
         challenge: &PaymentChallenge,
     ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send;
+
+    /// Execute payment with access to the challenged HTTP request.
+    ///
+    /// Most providers only need the challenge and inherit this default. A
+    /// session provider may use the URL and headers to top up its channel via
+    /// the resource's management endpoint before returning a voucher.
+    fn pay_with_context(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send {
+        let _ = context;
+        self.pay(challenge)
+    }
 
     /// Build an `Accept-Payment` header value from this provider's supported methods.
     ///
@@ -151,6 +179,26 @@ impl PaymentProvider for MultiProvider {
         )))
     }
 
+    async fn pay_with_context(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentCredential, MppError> {
+        let method = challenge.method.as_str();
+        let intent = challenge.intent.as_str();
+
+        for provider in &self.providers {
+            if provider.dyn_supports(method, intent) {
+                return provider.dyn_pay_with_context(challenge, context).await;
+            }
+        }
+
+        Err(MppError::UnsupportedPaymentMethod(format!(
+            "no provider supports method={}, intent={}",
+            method, intent
+        )))
+    }
+
     fn accept_payment_header(&self) -> Option<String> {
         let headers: Vec<String> = self
             .providers
@@ -173,6 +221,11 @@ trait DynPaymentProvider: Send + Sync {
         &'a self,
         challenge: &'a PaymentChallenge,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>;
+    fn dyn_pay_with_context<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        context: PaymentContext,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>;
     fn dyn_accept_payment_header(&self) -> Option<String>;
     fn clone_box(&self) -> Box<dyn DynPaymentProvider>;
 }
@@ -188,6 +241,15 @@ impl<P: PaymentProvider + 'static> DynPaymentProvider for P {
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>
     {
         Box::pin(PaymentProvider::pay(self, challenge))
+    }
+
+    fn dyn_pay_with_context<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        context: PaymentContext,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>
+    {
+        Box::pin(PaymentProvider::pay_with_context(self, challenge, context))
     }
 
     fn dyn_accept_payment_header(&self) -> Option<String> {

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -38,7 +38,7 @@ use self::store::{
 };
 use super::autoswap::AutoswapConfig;
 use super::signing::TempoPrimitiveSigner;
-use crate::client::PaymentProvider;
+use crate::client::{PaymentContext, PaymentProvider};
 use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, Receipt};
 use crate::protocol::intents::{ChargeRequest, SessionRequest};
@@ -80,6 +80,8 @@ pub struct TempoSessionProvider {
     max_deposit: Option<u128>,
     /// Default deposit in atomic units when no suggestedDeposit is available.
     default_deposit: Option<u128>,
+    /// Preferred automatic top-up size. Exact shortfalls are used when unset.
+    top_up_amount: Option<u128>,
     /// Stablecoin used to acquire the session currency before open/top-up.
     autoswap: Option<AutoswapConfig>,
     /// Channel registry: key is `payee:currency:escrow` (lowercase).
@@ -92,6 +94,8 @@ pub struct TempoSessionProvider {
     on_channel_update: Option<Arc<dyn Fn(&ChannelEntry) + Send + Sync>>,
     /// Last challenge received from the server, used for `close()`.
     last_challenge: Arc<Mutex<Option<PaymentChallenge>>>,
+    /// Serializes channel recovery, cumulative advancement, and credential creation.
+    payment_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 struct ApplicationTopUp<'a> {
@@ -119,12 +123,14 @@ impl TempoSessionProvider {
             signing_mode: crate::client::tempo::signing::TempoSigningMode::Direct,
             max_deposit: None,
             default_deposit: None,
+            top_up_amount: None,
             autoswap: None,
             channels: Arc::new(Mutex::new(HashMap::new())),
             channel_store: Arc::new(MemoryChannelStore::default()),
             channel_id_to_key: Arc::new(Mutex::new(HashMap::new())),
             on_channel_update: None,
             last_challenge: Arc::new(Mutex::new(None)),
+            payment_lock: Arc::new(tokio::sync::Mutex::new(())),
         })
     }
 
@@ -160,6 +166,12 @@ impl TempoSessionProvider {
     /// Set the default deposit in atomic units.
     pub fn with_default_deposit(mut self, amount: u128) -> Self {
         self.default_deposit = Some(amount);
+        self
+    }
+
+    /// Set the preferred automatic top-up size in atomic units.
+    pub fn with_top_up_amount(mut self, amount: u128) -> Self {
+        self.top_up_amount = Some(amount);
         self
     }
 
@@ -273,7 +285,9 @@ impl TempoSessionProvider {
             .transpose()
             .mpp_config("invalid suggestedDeposit")?
             .unwrap_or_default();
-        let proposed = shortfall.max(suggested);
+        let proposed = shortfall
+            .max(suggested)
+            .max(self.top_up_amount.unwrap_or_default());
         let additional = match self.max_deposit {
             Some(max_deposit) => proposed.min(max_deposit - deposit),
             None => proposed,
@@ -1331,6 +1345,7 @@ impl TempoSessionProvider {
         challenge: &PaymentChallenge,
         top_up: Option<ApplicationTopUp<'_>>,
     ) -> Result<PaymentCredential, MppError> {
+        let _payment_guard = self.payment_lock.lock().await;
         use alloy::providers::ProviderBuilder;
         use tempo_alloy::TempoNetwork;
 
@@ -1600,6 +1615,21 @@ impl PaymentProvider for TempoSessionProvider {
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
         self.payment_credential(challenge, None).await
     }
+
+    async fn pay_with_context(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentCredential, MppError> {
+        let client = reqwest::Client::new();
+        self.application_websocket_credential_with_top_up(
+            &client,
+            context.url.as_str(),
+            context.headers,
+            challenge,
+        )
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -1757,6 +1787,24 @@ mod tests {
         assert!(provider
             .required_top_up(25_000, 20_000, Some("not-an-amount"))
             .is_err());
+    }
+
+    #[test]
+    fn configured_top_up_amount_batches_shortfalls() {
+        let provider = make_test_provider()
+            .with_max_deposit(10_000_000)
+            .with_top_up_amount(5_000_000);
+
+        assert_eq!(
+            provider.required_top_up(5_001, 5_000, None).unwrap(),
+            Some(5_000_000)
+        );
+        assert_eq!(
+            provider
+                .required_top_up(9_500_001, 9_500_000, None)
+                .unwrap(),
+            Some(500_000)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pass the challenged HTTP URL and caller headers to payment providers
- let `TempoSessionProvider` use that context for native TIP-1034 management top-ups before returning the voucher
- serialize session credential creation across provider clones so concurrent requests advance cumulative state monotonically
- add an optional `top_up_amount` refill quantum, matching wevm/mppx#698

## Demonstrated regression

On current `main`, a hydrated channel at `deposit=5000000`, `cumulative=4999615` failed every Nanocodex MPP egress request with:

```text
session cumulative amount exceeds channel deposit
```

The generic HTTP `PaymentProvider::pay` path passed no management endpoint context, even though the WebSocket-specific path could top up.

## Live validation

Using the patched crate through `nanocodex run --provider.tempo`, with the wallet access key from `store.json` and session state from `channels.db`:

- one RPC call triggered a native session top-up from 5,000,000 to 10,000,000 atomic units and returned HTTP 200
- a 2,048-request Code Mode batch completed all requests: 1,566 HTTP 200 and 482 upstream HTTP 429; zero 000/400/402/502
- all 2,048 terminal responses contained session receipts
- final accepted cumulative matched local state at 7,225,557

## Tests

- `cargo test --all-features client:: -- --test-threads=1` (288 passed)
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Follow-up observed under load

Sixteen concurrent request streams caused 17 replacement-challenge payments ($0.017 extra authorization across this batch) when lower cumulative vouchers raced higher ones. This PR makes local credential creation monotonic; preserving paid-replay order through the complete HTTP round trip should be handled separately rather than hidden in this patch.