### PR TITLE
perf(client): resume WebSocket sessions with channel hints

### DIFF
--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -10,7 +10,8 @@ use std::{fmt, time::Duration};
 use futures::{SinkExt, StreamExt};
 use http::{HeaderMap, HeaderName, HeaderValue};
 use mpp::{
-    client::PaymentProvider, format_authorization, MppError, PaymentChallenge, PaymentCredential,
+    client::{PaymentContext, PaymentProvider},
+    format_authorization, MppError, PaymentChallenge, PaymentCredential,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -172,13 +173,21 @@ where
     async fn connect_inner(&self) -> Result<MppApplicationWs<V>, MppWsError> {
         install_default_crypto_provider();
         let probe_url = probe_url(&self.url)?;
-        let mut probe = reqwest::Client::new()
-            .get(probe_url)
-            .headers(self.headers.clone());
+        let mut probe_headers = self.headers.clone();
         if let Some(accept) = self.payment_provider.accept_payment_header() {
-            probe = probe.header("Accept-Payment", accept);
+            probe_headers.insert(
+                HeaderName::from_static("accept-payment"),
+                accept.parse().map_err(|error| {
+                    MppError::InvalidConfig(format!("invalid Accept-Payment header: {error}"))
+                })?,
+            );
         }
-        let response = probe.send().await.map_err(MppWsError::Probe)?;
+        let response = reqwest::Client::new()
+            .get(probe_url.clone())
+            .headers(probe_headers.clone())
+            .send()
+            .await
+            .map_err(MppWsError::Probe)?;
         if response.status() != reqwest::StatusCode::PAYMENT_REQUIRED {
             return Err(MppWsError::ProbeStatus {
                 status: response.status().as_u16(),
@@ -199,10 +208,21 @@ where
                 .supports(challenge.method.as_str(), challenge.intent.as_str())
         })
         .ok_or(MppWsError::UnsupportedChallenge)?;
+        let payment_context = PaymentContext {
+            url: probe_url,
+            headers: probe_headers,
+        };
+        let challenge = self
+            .payment_provider
+            .prepare_application_websocket_challenge(&challenge, payment_context.clone())
+            .await?;
         let _ = self
             .events_tx
             .send(MppApplicationEvent::Challenge(challenge.clone()));
-        let credential = self.payment_provider.pay(&challenge).await?;
+        let credential = self
+            .payment_provider
+            .pay_with_context(&challenge, payment_context)
+            .await?;
 
         let mut request = self.url.as_str().into_client_request()?;
         request.headers_mut().extend(self.headers.clone());

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -13,8 +13,9 @@ use axum::{
 };
 use futures::StreamExt;
 use mpp::{
-    client::PaymentProvider, protocol::core::Base64UrlJson, MppError, PaymentChallenge,
-    PaymentCredential, PaymentPayload,
+    client::{PaymentContext, PaymentProvider},
+    protocol::core::Base64UrlJson,
+    MppError, PaymentChallenge, PaymentCredential, PaymentPayload,
 };
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
@@ -35,6 +36,57 @@ impl PaymentProvider for StubProvider {
             challenge.to_echo(),
             PaymentPayload::hash("0xopen"),
         ))
+    }
+}
+
+#[derive(Clone)]
+struct ContextProvider {
+    observed: Arc<Mutex<Option<PaymentContext>>>,
+}
+
+impl PaymentProvider for ContextProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "tempo" && intent == "session"
+    }
+
+    async fn pay(&self, _: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        panic!("application transport must call pay_with_context")
+    }
+
+    async fn pay_with_context(
+        &self,
+        challenge: &PaymentChallenge,
+        _: PaymentContext,
+    ) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("0xopen"),
+        ))
+    }
+
+    async fn prepare_application_websocket_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentChallenge, MppError> {
+        *self.observed.lock().await = Some(context);
+        Ok(challenge.clone())
+    }
+
+    fn accept_payment_header(&self) -> Option<String> {
+        Some("tempo/session".into())
+    }
+}
+
+impl VoucherProvider for ContextProvider {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request("unexpected voucher request"))
+    }
+}
+
+impl CloseProvider for ContextProvider {
+    async fn close_credential(&self, _: &CloseRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request("unexpected close request"))
     }
 }
 
@@ -263,6 +315,48 @@ async fn probes_then_authorizes_and_translates_application_messages() {
     socket.send("hello").await.unwrap();
     assert_eq!(socket.next().await.unwrap(), "world");
     assert_eq!(socket.close().await.unwrap()["channelId"], "0xchannel");
+}
+
+#[tokio::test]
+async fn payment_provider_receives_probe_url_and_headers() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let (signal_tx, signal_rx) = oneshot::channel();
+    let signal = Arc::new(Mutex::new(Some(signal_tx)));
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new()
+                .route("/", get(disconnect_route))
+                .with_state(signal),
+        )
+        .await
+        .unwrap();
+    });
+
+    let observed = Arc::new(Mutex::new(None));
+    let provider = ContextProvider {
+        observed: Arc::clone(&observed),
+    };
+    let connector =
+        MppApplicationWsConnect::new(format!("ws://{address}/"), provider.clone(), provider)
+            .with_header(
+                "x-test-routing".parse().unwrap(),
+                HeaderValue::from_static("preserved"),
+            );
+    connector
+        .connect()
+        .await
+        .unwrap()
+        .disconnect()
+        .await
+        .unwrap();
+
+    assert!(signal_rx.await.unwrap());
+    let context = observed.lock().await.take().unwrap();
+    assert_eq!(context.url.as_str(), format!("http://{address}/"));
+    assert_eq!(context.headers["x-test-routing"], "preserved");
+    assert_eq!(context.headers["accept-payment"], "tempo/session");
 }
 
 #[tokio::test]

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -93,6 +93,23 @@ pub trait PaymentProvider: Clone + Send + Sync {
         self.pay(challenge)
     }
 
+    /// Reconcile a challenge before opening an application WebSocket.
+    ///
+    /// Session providers may use this hook to refresh persisted state from the
+    /// server before creating the socket-bound credential. Other providers
+    /// inherit the challenge unchanged.
+    fn prepare_application_websocket_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> impl Future<Output = Result<PaymentChallenge, MppError>> + Send {
+        let challenge = challenge.clone();
+        async move {
+            let _ = context;
+            Ok(challenge)
+        }
+    }
+
     /// Build an `Accept-Payment` header value from this provider's supported methods.
     ///
     /// Returns `None` if the provider does not advertise specific methods.
@@ -199,6 +216,28 @@ impl PaymentProvider for MultiProvider {
         )))
     }
 
+    async fn prepare_application_websocket_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentChallenge, MppError> {
+        let method = challenge.method.as_str();
+        let intent = challenge.intent.as_str();
+
+        for provider in &self.providers {
+            if provider.dyn_supports(method, intent) {
+                return provider
+                    .dyn_prepare_application_websocket_challenge(challenge, context)
+                    .await;
+            }
+        }
+
+        Err(MppError::UnsupportedPaymentMethod(format!(
+            "no provider supports method={}, intent={}",
+            method, intent
+        )))
+    }
+
     fn accept_payment_header(&self) -> Option<String> {
         let headers: Vec<String> = self
             .providers
@@ -226,6 +265,11 @@ trait DynPaymentProvider: Send + Sync {
         challenge: &'a PaymentChallenge,
         context: PaymentContext,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>;
+    fn dyn_prepare_application_websocket_challenge<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        context: PaymentContext,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentChallenge, MppError>> + Send + 'a>>;
     fn dyn_accept_payment_header(&self) -> Option<String>;
     fn clone_box(&self) -> Box<dyn DynPaymentProvider>;
 }
@@ -250,6 +294,17 @@ impl<P: PaymentProvider + 'static> DynPaymentProvider for P {
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentCredential, MppError>> + Send + 'a>>
     {
         Box::pin(PaymentProvider::pay_with_context(self, challenge, context))
+    }
+
+    fn dyn_prepare_application_websocket_challenge<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        context: PaymentContext,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentChallenge, MppError>> + Send + 'a>>
+    {
+        Box::pin(PaymentProvider::prepare_application_websocket_challenge(
+            self, challenge, context,
+        ))
     }
 
     fn dyn_accept_payment_header(&self) -> Option<String> {

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -517,6 +517,104 @@ impl TempoSessionProvider {
             .unwrap_or(None))
     }
 
+    /// Reconcile an application WebSocket challenge with reusable client state.
+    ///
+    /// When the challenged scope already exists locally, this re-probes with a
+    /// `Payment-Session` channel hint so the server can include its latest
+    /// signed snapshot without the authenticated `HEAD` bootstrap flow. A
+    /// missing local scope, unsupported hint, or missing snapshot falls back to
+    /// bootstrap so fresh and stale clients remain recoverable.
+    pub async fn recover_application_websocket_challenge_with_headers(
+        &self,
+        client: &reqwest::Client,
+        url: &str,
+        mut headers: reqwest::header::HeaderMap,
+        challenge: &PaymentChallenge,
+    ) -> Result<PaymentChallenge, MppError> {
+        use reqwest::header::{HeaderValue, AUTHORIZATION, WWW_AUTHENTICATE};
+
+        let bootstrap_headers = headers.clone();
+        let (key, _) = self.expected_channel_key(challenge)?;
+        let payer = self.signing_mode.from_address(self.signer.address());
+        let authorized_signer = self.authorized_signer.unwrap_or(self.signer.address());
+
+        let cached_in_memory = self
+            .channels
+            .lock()
+            .unwrap()
+            .get(&key)
+            .filter(|entry| entry.opened)
+            .map(|entry| {
+                let descriptor = entry.descriptor.as_ref().ok_or_else(|| {
+                    MppError::InvalidConfig(
+                        "cached native MPP channel is missing its descriptor".into(),
+                    )
+                })?;
+                can_sign_descriptor(descriptor, payer, authorized_signer)
+                    .map(|controlled| controlled.then_some(entry.channel_id))
+            })
+            .transpose()?
+            .flatten();
+        let cached_channel_id = match cached_in_memory {
+            Some(channel_id) => Some(channel_id),
+            None => self
+                .channel_store
+                .get(&key)
+                .await
+                .map_err(Self::store_error)?
+                .filter(|entry| entry.opened && entry.key() == key)
+                .map(|entry| {
+                    can_sign_descriptor(&entry.descriptor, payer, authorized_signer)
+                        .map(|controlled| controlled.then_some(entry.channel_id))
+                })
+                .transpose()?
+                .flatten(),
+        };
+
+        if let Some(channel_id) = cached_channel_id {
+            headers.insert(
+                crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER,
+                HeaderValue::from_static("tempo/session"),
+            );
+            headers.insert(
+                reqwest::header::HeaderName::from_static("payment-session"),
+                channel_id
+                    .to_string()
+                    .parse()
+                    .mpp_config("invalid Payment-Session header")?,
+            );
+            headers.remove(AUTHORIZATION);
+            if let Ok(response) = client.get(url).headers(headers.clone()).send().await {
+                if response.status() == reqwest::StatusCode::PAYMENT_REQUIRED {
+                    let refreshed = PaymentChallenge::from_headers(
+                        response
+                            .headers()
+                            .get_all(WWW_AUTHENTICATE)
+                            .iter()
+                            .filter_map(|value| value.to_str().ok()),
+                    )
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .find(|candidate| {
+                        candidate.method.as_str() == crate::protocol::methods::tempo::METHOD_NAME
+                            && candidate.intent.as_str()
+                                == crate::protocol::methods::tempo::INTENT_SESSION
+                    });
+                    if let Some(refreshed) = refreshed {
+                        let request: SessionRequest = refreshed.request.decode()?;
+                        if request.session_snapshot().is_some() {
+                            return Ok(refreshed);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.bootstrap_with_headers(client, url, bootstrap_headers)
+            .await?;
+        Ok(challenge.clone())
+    }
+
     async fn try_bootstrap_with_headers(
         &self,
         client: &reqwest::Client,
@@ -1624,6 +1722,20 @@ impl PaymentProvider for TempoSessionProvider {
         let client = reqwest::Client::new();
         self.application_websocket_credential_with_top_up(
             &client,
+            context.url.as_str(),
+            context.headers,
+            challenge,
+        )
+        .await
+    }
+
+    async fn prepare_application_websocket_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentChallenge, MppError> {
+        self.recover_application_websocket_challenge_with_headers(
+            &reqwest::Client::new(),
             context.url.as_str(),
             context.headers,
             challenge,
@@ -2752,6 +2864,158 @@ mod tests {
             chain_id,
         )
         .unwrap());
+    }
+
+    #[cfg(feature = "axum")]
+    #[tokio::test]
+    async fn challenge_recovery_uses_channel_hint_before_identity_bootstrap() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use axum::{
+            http::{HeaderMap, StatusCode},
+            response::IntoResponse,
+            routing::get,
+            Router,
+        };
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        use crate::protocol::methods::tempo::session::{
+            ChannelDescriptor, SessionSnapshot, TempoSessionMethodDetails,
+        };
+
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let challenge = make_scoped_challenge(payee, currency, TIP20_CHANNEL_RESERVE_ADDRESS);
+        let store = Arc::new(MemoryChannelStore::default());
+        let provider = make_test_provider().with_channel_store(store.clone());
+        let payer = provider.signer.address();
+        let channel_id = B256::repeat_byte(0x33);
+        let descriptor = ChannelDescriptor {
+            authorized_signer: payer.to_string(),
+            expiring_nonce_hash: B256::repeat_byte(0x44).to_string(),
+            operator: Address::ZERO.to_string(),
+            payee: payee.to_string(),
+            payer: payer.to_string(),
+            salt: B256::repeat_byte(0x55).to_string(),
+            token: currency.to_string(),
+        };
+        store
+            .set(&StoredChannelEntry {
+                channel_id,
+                cumulative_amount: 1_000,
+                deposit: 10_000,
+                descriptor: descriptor.clone(),
+                escrow: TIP20_CHANNEL_RESERVE_ADDRESS,
+                chain_id: 42431,
+                opened: true,
+            })
+            .await
+            .unwrap();
+
+        let mut refreshed_request: SessionRequest = challenge.request.decode().unwrap();
+        refreshed_request.method_details = Some(
+            serde_json::to_value(TempoSessionMethodDetails {
+                escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS.to_string(),
+                channel_id: Some(channel_id.to_string()),
+                min_voucher_delta: None,
+                chain_id: Some(42431),
+                fee_payer: Some(true),
+                operator: Some(Address::ZERO.to_string()),
+                session_protocol: Some("v2".into()),
+                session_snapshot: Some(SessionSnapshot {
+                    accepted_cumulative: "2000".into(),
+                    chain_id: 42431,
+                    channel_id: channel_id.to_string(),
+                    close_requested_at: None,
+                    deposit: "10000".into(),
+                    descriptor,
+                    escrow: TIP20_CHANNEL_RESERVE_ADDRESS.to_string(),
+                    highest_voucher: None,
+                    required_cumulative: "3000".into(),
+                    settled: "0".into(),
+                    spent: "2000".into(),
+                    units: Some(2),
+                }),
+            })
+            .unwrap(),
+        );
+        let refreshed_challenge = PaymentChallenge::new(
+            "refreshed-id",
+            challenge.realm.clone(),
+            crate::protocol::methods::tempo::METHOD_NAME,
+            crate::protocol::methods::tempo::INTENT_SESSION,
+            crate::protocol::core::Base64UrlJson::from_typed(&refreshed_request).unwrap(),
+        );
+        let refreshed_header = refreshed_challenge.to_header().unwrap();
+        let get_calls = Arc::new(AtomicUsize::new(0));
+        let head_calls = Arc::new(AtomicUsize::new(0));
+        let app = Router::new().route(
+            "/v1/responses",
+            get({
+                let get_calls = Arc::clone(&get_calls);
+                move |headers: HeaderMap| {
+                    let get_calls = Arc::clone(&get_calls);
+                    let refreshed_header = refreshed_header.clone();
+                    async move {
+                        get_calls.fetch_add(1, Ordering::SeqCst);
+                        assert_eq!(
+                            headers
+                                .get("payment-session")
+                                .and_then(|value| value.to_str().ok()),
+                            Some(channel_id.to_string().as_str())
+                        );
+                        (
+                            StatusCode::PAYMENT_REQUIRED,
+                            [("www-authenticate", refreshed_header)],
+                        )
+                            .into_response()
+                    }
+                }
+            })
+            .head({
+                let head_calls = Arc::clone(&head_calls);
+                move || {
+                    let head_calls = Arc::clone(&head_calls);
+                    async move {
+                        head_calls.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::NO_CONTENT
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let url = format!("http://{address}/v1/responses");
+
+        let result = provider
+            .recover_application_websocket_challenge_with_headers(
+                &reqwest::Client::new(),
+                &url,
+                reqwest::header::HeaderMap::new(),
+                &challenge,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, "refreshed-id");
+        assert_eq!(get_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(head_calls.load(Ordering::SeqCst), 0);
+
+        let empty_provider = make_test_provider();
+        let result = empty_provider
+            .recover_application_websocket_challenge_with_headers(
+                &reqwest::Client::new(),
+                &url,
+                reqwest::header::HeaderMap::new(),
+                &challenge,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.id, "test-id");
+        assert_eq!(get_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(head_calls.load(Ordering::SeqCst), 1);
     }
 
     #[cfg(feature = "axum")]


### PR DESCRIPTION
## Summary
- let the application WebSocket transport give payment providers the challenged URL and headers before credential creation
- have Tempo sessions re-probe with `Payment-Session` when a matching channel exists in memory or `ChannelStore`
- require the server latest signed session snapshot before using that fast path
- retain authenticated zero-amount HEAD bootstrap for genuinely empty stores or servers without hint support

## Why
Nanocodex cold processes with a populated `channels.db` were paying for a two-request identity bootstrap even though they already knew the channel ID. The live Worker trace measured the authorized bootstrap at 2.739s.

The original shortcut in this PR only checked local storage. A live cross-client test exposed that as unsafe: another client advanced the server voucher from 7,925,489 to 7,966,536, and the stale client was rejected. The revised path sends the channel ID as a hint and hydrates from the server signed highest-voucher snapshot, matching MPPx behavior while avoiding identity recovery.

## Validation
- deterministic test: populated store sends one hinted GET and zero HEADs; empty store falls back to one HEAD
- transport test: provider receives the exact probe URL, routing headers, and Accept-Payment header
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- focused Rust tests passed
- live Nanocodex stale-store run succeeds and advances the cumulative voucher instead of receiving the prior `must be strictly greater` rejection

The matching proxy change is tempoxyz/mpp-proxy#255. The commit is SSH-signed and GitHub reports it as verified.