### PR TITLE
fix(client): refuse duplicate charge retries

### DIFF
--- a/.changelog/charge-retry-safety.md
+++ b/.changelog/charge-retry-safety.md
@@ -1,0 +1,7 @@
+---
+"mpp": patch
+---
+
+Refuse a second, distinct charge challenge after a payment credential has been
+submitted for the same HTTP request, while preserving incremental session
+top-up retries.

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -24,6 +24,15 @@ pub enum HttpError {
     /// Payment provider error
     Payment(MppError),
 
+    /// A charge credential was already submitted for this logical request and
+    /// the server returned a distinct charge challenge.
+    IndeterminatePayment {
+        /// Challenge whose credential was already submitted.
+        paid_challenge_id: String,
+        /// Fresh challenge returned by the paid retry.
+        retry_challenge_id: String,
+    },
+
     /// HTTP request error
     #[cfg(feature = "client")]
     Request(reqwest::Error),
@@ -42,6 +51,15 @@ impl fmt::Display for HttpError {
             Self::InvalidCredential(msg) => write!(f, "invalid credential: {}", msg),
             Self::CloneFailed => write!(f, "request could not be cloned for retry"),
             Self::Payment(e) => write!(f, "payment failed: {}", e),
+            Self::IndeterminatePayment {
+                paid_challenge_id,
+                retry_challenge_id,
+            } => write!(
+                f,
+                "payment outcome is indeterminate: charge challenge {paid_challenge_id} was \
+                 submitted before the server returned distinct charge challenge \
+                 {retry_challenge_id}; refusing another payment"
+            ),
             #[cfg(feature = "client")]
             Self::Request(e) => write!(f, "HTTP request failed: {}", e),
         }

--- a/src/client/events.rs
+++ b/src/client/events.rs
@@ -104,6 +104,15 @@ pub enum PaymentFailureReason {
     /// Client refused before signing because the challenge was expired or had
     /// an unparseable `expires`. `provider.pay()` was not called.
     PreSigningExpired { expires: Option<String> },
+    /// A paid retry returned a distinct charge challenge. The first charge may
+    /// already have settled, so the client refused to create another
+    /// credential for the same logical request.
+    IndeterminateCharge {
+        /// Challenge whose credential was already submitted.
+        paid_challenge_id: String,
+        /// Fresh challenge returned by the paid retry.
+        retry_challenge_id: String,
+    },
 }
 
 /// Context for `payment.failed`.

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -199,6 +199,7 @@ impl PaymentExt for RequestBuilder {
         let ranking_accept = caller_accept.or(provider_accept);
 
         let mut paid_challenge_ids = std::collections::HashSet::new();
+        let mut submitted_charge_id: Option<String> = None;
         let mut resp = this.send().await?;
 
         for attempt in 0..max_payment_retries {
@@ -261,7 +262,7 @@ impl PaymentExt for RequestBuilder {
                 }
             };
 
-            if !paid_challenge_ids.insert(challenge.id.clone()) {
+            if paid_challenge_ids.contains(&challenge.id) {
                 events
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
@@ -271,6 +272,27 @@ impl PaymentExt for RequestBuilder {
                     .await;
                 return Ok(resp);
             }
+            if challenge.intent.as_str() == "charge" {
+                if let Some(paid_challenge_id) = &submitted_charge_id {
+                    let retry_challenge_id = challenge.id.clone();
+                    let err = HttpError::IndeterminatePayment {
+                        paid_challenge_id: paid_challenge_id.clone(),
+                        retry_challenge_id: retry_challenge_id.clone(),
+                    };
+                    events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: Some(challenge),
+                            error: err.to_string(),
+                            reason: Some(PaymentFailureReason::IndeterminateCharge {
+                                paid_challenge_id: paid_challenge_id.clone(),
+                                retry_challenge_id,
+                            }),
+                        }))
+                        .await;
+                    return Err(err);
+                }
+            }
+            paid_challenge_ids.insert(challenge.id.clone());
 
             let override_credential = events
                 .emit_challenge_received(ChallengeReceivedContext {
@@ -315,6 +337,9 @@ impl PaymentExt for RequestBuilder {
                     credential: credential.clone(),
                 }))
                 .await;
+            if challenge.intent.as_str() == "charge" {
+                submitted_charge_id = Some(challenge.id.clone());
+            }
 
             let auth_header = match format_authorization(&credential) {
                 Ok(auth_header) => auth_header,
@@ -488,10 +513,13 @@ mod tests {
         }
 
         fn test_challenge_with_id(id: &str) -> (PaymentChallenge, String) {
+            test_challenge_with_intent(id, "charge")
+        }
+
+        fn test_challenge_with_intent(id: &str, intent: &str) -> (PaymentChallenge, String) {
             let request =
                 Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
-            let challenge =
-                PaymentChallenge::new(id, "test.example.com", "tempo", "charge", request);
+            let challenge = PaymentChallenge::new(id, "test.example.com", "tempo", intent, request);
             let header = format_www_authenticate(&challenge).unwrap();
             (challenge, header)
         }
@@ -732,7 +760,7 @@ mod tests {
         async fn test_incremental_402_retries_stop_at_default_cap() {
             let headers = Arc::new(
                 (0..DEFAULT_MAX_PAYMENT_RETRIES)
-                    .map(|i| test_challenge_with_id(&format!("cap-{i}")).1)
+                    .map(|i| test_challenge_with_intent(&format!("cap-{i}"), "session").1)
                     .collect::<Vec<_>>(),
             );
             let request_count = Arc::new(AtomicU32::new(0));
@@ -876,10 +904,71 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_incremental_402_retries_pay_replacement_challenges() {
+        async fn test_distinct_charge_after_paid_retry_is_indeterminate() {
             let (_, first_header) = test_challenge_with_id("first");
             let (_, second_header) = test_challenge_with_id("second");
-            let (_, third_header) = test_challenge_with_id("third");
+            let headers = Arc::new([first_header, second_header]);
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, headers[index].clone())],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = MockProvider::new();
+            let client = reqwest::Client::new();
+            let events = ClientEvents::default();
+            let observed_reason = Arc::new(Mutex::new(None));
+            let _failed_sub = events.on_payment_failed({
+                let observed_reason = observed_reason.clone();
+                move |context| {
+                    *observed_reason.lock().unwrap() = context.reason;
+                    async {}
+                }
+            });
+
+            let error = client
+                .get(format!("{}/paid", base_url))
+                .send_with_payment_options(&provider, &AcceptPaymentPolicy::Always, events)
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                error,
+                HttpError::IndeterminatePayment {
+                    ref paid_challenge_id,
+                    ref retry_challenge_id,
+                } if paid_challenge_id == "first" && retry_challenge_id == "second"
+            ));
+            assert_eq!(
+                *observed_reason.lock().unwrap(),
+                Some(PaymentFailureReason::IndeterminateCharge {
+                    paid_challenge_id: "first".to_string(),
+                    retry_challenge_id: "second".to_string(),
+                })
+            );
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn test_incremental_402_retries_pay_replacement_challenges() {
+            let (_, first_header) = test_challenge_with_intent("first", "session");
+            let (_, second_header) = test_challenge_with_intent("second", "session");
+            let (_, third_header) = test_challenge_with_intent("third", "session");
             let headers = Arc::new([first_header, second_header, third_header]);
             let request_count = Arc::new(AtomicU32::new(0));
             let counter = request_count.clone();

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -12,6 +12,7 @@ use crate::client::accept_payment_policy::AcceptPaymentPolicy;
 use crate::client::challenge_selection::{
     expired_payment_error, select_supported_challenge, ChallengeSelectionError,
 };
+use crate::client::error::HttpError;
 use crate::client::events::{
     ChallengeReceivedContext, ClientEvent, ClientEventSubscription, ClientEvents,
     CredentialCreatedContext, PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
@@ -184,6 +185,7 @@ where
         };
 
         let mut paid_challenge_ids = std::collections::HashSet::new();
+        let mut submitted_charge_id: Option<String> = None;
 
         for attempt in 0..self.max_payment_retries {
             if resp.status() != StatusCode::PAYMENT_REQUIRED {
@@ -252,7 +254,7 @@ where
                 }
             };
 
-            if !paid_challenge_ids.insert(challenge.id.clone()) {
+            if paid_challenge_ids.contains(&challenge.id) {
                 self.events
                     .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                         challenge: Some(challenge),
@@ -262,6 +264,29 @@ where
                     .await;
                 return Ok(resp);
             }
+            if challenge.intent.as_str() == "charge" {
+                if let Some(paid_challenge_id) = &submitted_charge_id {
+                    let retry_challenge_id = challenge.id.clone();
+                    let error = HttpError::IndeterminatePayment {
+                        paid_challenge_id: paid_challenge_id.clone(),
+                        retry_challenge_id: retry_challenge_id.clone(),
+                    };
+                    self.events
+                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                            challenge: Some(challenge),
+                            error: error.to_string(),
+                            reason: Some(PaymentFailureReason::IndeterminateCharge {
+                                paid_challenge_id: paid_challenge_id.clone(),
+                                retry_challenge_id,
+                            }),
+                        }))
+                        .await;
+                    return Err(reqwest_middleware::Error::Middleware(anyhow::Error::new(
+                        error,
+                    )));
+                }
+            }
+            paid_challenge_ids.insert(challenge.id.clone());
 
             let override_credential = self
                 .events
@@ -295,6 +320,9 @@ where
                     credential: credential.clone(),
                 }))
                 .await;
+            if challenge.intent.as_str() == "charge" {
+                submitted_charge_id = Some(challenge.id.clone());
+            }
 
             let auth_header =
                 match format_authorization(&credential).context("failed to format credential") {
@@ -489,6 +517,14 @@ mod tests {
 
         fn test_challenge_with_id(id: &str) -> (PaymentChallenge, String) {
             test_challenge_with_id_and_expires(id, None)
+        }
+
+        fn test_challenge_with_intent(id: &str, intent: &str) -> (PaymentChallenge, String) {
+            let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "500"})).unwrap();
+            let challenge =
+                PaymentChallenge::new(id, "middleware.example.com", "tempo", intent, request);
+            let header = format_www_authenticate(&challenge).unwrap();
+            (challenge, header)
         }
 
         fn test_challenge_with_id_and_expires(
@@ -700,7 +736,7 @@ mod tests {
         async fn test_middleware_incremental_402_retries_stop_at_default_cap() {
             let headers = Arc::new(
                 (0..DEFAULT_MAX_PAYMENT_RETRIES)
-                    .map(|i| test_challenge_with_id(&format!("cap-{i}")).1)
+                    .map(|i| test_challenge_with_intent(&format!("cap-{i}"), "session").1)
                     .collect::<Vec<_>>(),
             );
             let request_count = Arc::new(AtomicU32::new(0));
@@ -850,10 +886,69 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_middleware_incremental_402_retries_pay_replacement_challenges() {
+        async fn test_middleware_distinct_charge_after_paid_retry_is_indeterminate() {
             let (_, first_header) = test_challenge_with_id("first");
             let (_, second_header) = test_challenge_with_id("second");
-            let (_, third_header) = test_challenge_with_id("third");
+            let headers = Arc::new([first_header, second_header]);
+            let request_count = Arc::new(AtomicU32::new(0));
+            let counter = request_count.clone();
+
+            let app = Router::new().route(
+                "/paid",
+                get(move || {
+                    let headers = headers.clone();
+                    let counter = counter.clone();
+                    async move {
+                        let index = counter.fetch_add(1, Ordering::SeqCst) as usize;
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [(WWW_AUTH_NAME, headers[index].clone())],
+                            "pay up",
+                        )
+                    }
+                }),
+            );
+
+            let base_url = spawn_server(app).await;
+            let provider = TestProvider::new();
+            let events = ClientEvents::default();
+            let observed_reason = Arc::new(Mutex::new(None));
+            let _failed_sub = events.on_payment_failed({
+                let observed_reason = observed_reason.clone();
+                move |context| {
+                    *observed_reason.lock().unwrap() = context.reason;
+                    async {}
+                }
+            });
+            let client = ClientBuilder::new(reqwest::Client::new())
+                .with(PaymentMiddleware::new(provider.clone()).with_events(events))
+                .build();
+
+            let error = client
+                .get(format!("{}/paid", base_url))
+                .send()
+                .await
+                .unwrap_err();
+
+            assert!(error
+                .to_string()
+                .contains("payment outcome is indeterminate"));
+            assert_eq!(
+                *observed_reason.lock().unwrap(),
+                Some(PaymentFailureReason::IndeterminateCharge {
+                    paid_challenge_id: "first".to_string(),
+                    retry_challenge_id: "second".to_string(),
+                })
+            );
+            assert_eq!(provider.call_count(), 1);
+            assert_eq!(request_count.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test]
+        async fn test_middleware_incremental_402_retries_pay_replacement_challenges() {
+            let (_, first_header) = test_challenge_with_intent("first", "session");
+            let (_, second_header) = test_challenge_with_intent("second", "session");
+            let (_, third_header) = test_challenge_with_intent("third", "session");
             let headers = Arc::new([first_header, second_header, third_header]);
             let request_count = Arc::new(AtomicU32::new(0));
             let counter = request_count.clone();

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -24,7 +24,7 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::SignerSync;
 use alloy::sol_types::SolCall;
 use axum::{routing::get, Json, Router};
-use mpp::client::{Fetch, PaymentProvider, TempoProvider};
+use mpp::client::{Fetch, HttpError, PaymentProvider, TempoProvider};
 use mpp::server::axum::{ChargeChallenger, ChargeConfig, MppCharge, WithReceipt};
 use mpp::server::{tempo, Mpp, TempoConfig};
 use reqwest::Client;
@@ -1101,9 +1101,10 @@ async fn test_e2e_charge_with_fee_payer() {
     let _ = handle.await;
 }
 
-/// Fee payer requested but server has no signer configured → 402.
+/// Fee payer requested but server has no signer configured → indeterminate
+/// after the paid retry returns a fresh charge challenge.
 #[tokio::test]
-async fn test_fee_payer_requested_but_no_signer_returns_402() {
+async fn test_fee_payer_requested_but_no_signer_is_indeterminate() {
     let rpc = rpc_url();
     let chain_id = get_chain_id(&rpc).await;
 
@@ -1129,20 +1130,21 @@ async fn test_fee_payer_requested_but_no_signer_returns_402() {
 
     let provider = TempoProvider::new(client_signer, &rpc).expect("failed to create TempoProvider");
 
-    let resp = Client::new()
+    let error = Client::new()
         .get(format!("{url}/paid"))
         .send_with_payment(&provider)
         .await
-        .expect("request failed");
+        .expect_err("fresh charge challenge after payment should be indeterminate");
 
-    assert_eq!(
-        resp.status(),
-        402,
-        "fee payer requested without signer should return 402"
-    );
     assert!(
-        resp.headers().contains_key("www-authenticate"),
-        "should return a fresh challenge for retry"
+        matches!(
+            error,
+            HttpError::IndeterminatePayment {
+                ref paid_challenge_id,
+                ref retry_challenge_id,
+            } if paid_challenge_id != retry_challenge_id
+        ),
+        "fee payer requested without a signer should refuse a second charge: {error}"
     );
 
     handle.abort();


### PR DESCRIPTION
A charge credential may already have settled when its paid retry receives another 402. Creating a credential for a fresh charge challenge in the same logical HTTP call can therefore double-pay.

This makes charge retries fail closed after one submitted credential with a typed `IndeterminatePayment` error and event reason. Session retries remain incremental because replacement challenges are required for opens, top-ups, and vouchers.

The production reproduction was a 36-request concurrent Nanocodex egress run: every HTTP call returned 200, but 73 credentials were created and the wallet was debited for 54 charges. The server-side sponsor reservation race is fixed separately by wevm/mppx#707; this PR adds defense in depth at the reusable Rust client boundary.

Validation:
- `cargo test --features client,middleware,utils` (360 unit tests and 30 doctests passed)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`