### PR TITLE
docs: fix broken config.toml link in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -102,7 +102,7 @@ Bump types: `major`, `minor`, `patch`
 
 ## Configuration
 
-See [config.toml](./config.toml) for changelog settings:
+See [config.toml](./.changelog/config.toml) for changelog settings:
 
 - `dependent_bump` - How to bump dependents (default: `patch`)
 - `changelog.format` - `root` for single CHANGELOG.md or `per-crate`


### PR DESCRIPTION
RELEASE.md's Configuration section links to `./config.toml`, which doesn't exist — the changelog config lives at `.changelog/config.toml`. This corrects the link path.

I checked the rest of that section while I was there: the documented settings (`dependent_bump`, `changelog.format`, `ignore`) all match `.changelog/config.toml`, and both referenced workflows (`changelog.yml`, `release.yml`) exist. Only the path was wrong, so this is a one-line change.