### PR TITLE
fix(client): retry transient Tempo RPC limits

### DIFF
--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -33,6 +33,7 @@ pub mod tx_builder;
 use std::num::NonZeroU64;
 
 use alloy::primitives::{Address, TxKind, U256};
+use alloy::providers::Provider;
 use tempo_primitives::transaction::{
     Call, SignatureType, SignedKeyAuthorization, TempoTransaction,
 };
@@ -47,7 +48,7 @@ use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, PaymentPayload};
 use crate::protocol::intents::ChargeRequest;
 use crate::protocol::methods::tempo::charge::{parse_memo_bytes_checked, TempoChargeExt};
-use crate::protocol::methods::tempo::network::TempoNetwork;
+use crate::protocol::methods::tempo::network::TempoNetwork as TempoChain;
 use crate::protocol::methods::tempo::proof;
 use crate::protocol::methods::tempo::transfers::get_transfers;
 use crate::protocol::methods::tempo::types::Split;
@@ -288,11 +289,59 @@ impl TempoCharge {
         .await
     }
 
+    pub(crate) async fn sign_with_primitive_provider_options(
+        self,
+        signer: &TempoPrimitiveSigner,
+        provider: &impl Provider<tempo_alloy::TempoNetwork>,
+        options: SignOptions,
+    ) -> Result<SignedTempoCharge, MppError> {
+        let signature_type = match signer {
+            TempoPrimitiveSigner::Secp256k1(_) => SignatureType::Secp256k1,
+            TempoPrimitiveSigner::P256(_) => SignatureType::P256,
+        };
+        self.prepare_with_provider(
+            alloy::signers::Signer::address(signer),
+            signature_type,
+            options,
+            provider,
+        )
+        .await?
+        .sign_primitive(signer)
+        .await
+    }
+
     async fn prepare(
         self,
         signer_address: Address,
         signature_type: SignatureType,
         options: SignOptions,
+    ) -> Result<PreparedTempoCharge, MppError> {
+        let rpc_url = match options.rpc_url.as_deref() {
+            Some(url) => url.parse().mpp_config("invalid RPC URL")?,
+            None => {
+                let network = TempoChain::from_chain_id(self.chain_id).ok_or_else(|| {
+                    MppError::InvalidConfig(format!(
+                        "unknown chain ID {}: provide rpc_url in SignOptions",
+                        self.chain_id
+                    ))
+                })?;
+                network
+                    .default_rpc_url()
+                    .parse()
+                    .mpp_config("invalid RPC URL")?
+            }
+        };
+        let provider = super::rpc_provider(rpc_url);
+        self.prepare_with_provider(signer_address, signature_type, options, &provider)
+            .await
+    }
+
+    async fn prepare_with_provider(
+        self,
+        signer_address: Address,
+        signature_type: SignatureType,
+        options: SignOptions,
+        provider: &impl Provider<tempo_alloy::TempoNetwork>,
     ) -> Result<PreparedTempoCharge, MppError> {
         let signing_mode = options.signing_mode.unwrap_or_default();
         let from = signing_mode.from_address(signer_address);
@@ -308,28 +357,9 @@ impl TempoCharge {
             });
         }
 
-        // Resolve RPC provider + build calls
-        let rpc_url = match options.rpc_url {
-            Some(url) => url.parse().mpp_config("invalid RPC URL")?,
-            None => {
-                let network = TempoNetwork::from_chain_id(self.chain_id).ok_or_else(|| {
-                    MppError::InvalidConfig(format!(
-                        "unknown chain ID {}: provide rpc_url in SignOptions",
-                        self.chain_id
-                    ))
-                })?;
-                network
-                    .default_rpc_url()
-                    .parse()
-                    .mpp_config("invalid RPC URL")?
-            }
-        };
-        let provider =
-            alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
-
         let managed_key_authorization = if options.key_authorization.is_none() {
             crate::client::tempo::signing::keychain::resolve_key_authorization(
-                &provider,
+                provider,
                 &signing_mode,
                 signer_address,
             )
@@ -397,7 +427,7 @@ impl TempoCharge {
             req.inner.max_priority_fee_per_gas = Some(max_priority_fee_per_gas);
             apply_estimation_signer_hints(&mut req, &signing_mode, signer_address, signature_type);
 
-            estimate_gas(&provider, req).await?
+            estimate_gas(provider, req).await?
         };
 
         // Build the key_authorization for the transaction

--- a/src/client/tempo/mod.rs
+++ b/src/client/tempo/mod.rs
@@ -35,6 +35,27 @@ fn default_wallet_directory() -> Option<std::path::PathBuf> {
 }
 pub use provider::TempoProvider;
 
+/// Build the RPC provider used while preparing Tempo payments.
+///
+/// Tempo RPC reports transient overloads as JSON-RPC error `-32005` and
+/// includes a millisecond retry hint. Alloy's rate-limit layer recognizes both
+/// the code and the hint, so keep that policy at the transport boundary rather
+/// than duplicating retries around every balance, quote, and gas-estimation
+/// call.
+pub(crate) fn rpc_provider(
+    rpc_url: reqwest::Url,
+) -> alloy::providers::RootProvider<tempo_alloy::TempoNetwork> {
+    // Pace retrying bursts at 50 RPC/s (Alloy's default 20 compute units per
+    // request against a 1,000 CU/s budget) so concurrent payment preparation
+    // does not immediately exhaust the server-provided retry window again.
+    let retry = alloy::transports::layers::RetryBackoffLayer::new(20, 10, 1_000);
+    let client = alloy::rpc::client::ClientBuilder::default()
+        .layer(retry)
+        .http(rpc_url);
+    alloy::providers::ProviderBuilder::<_, _, tempo_alloy::TempoNetwork>::default()
+        .connect_client(client)
+}
+
 /// Static max fee per gas: 41 gwei (`base_fee * 2 + priority_fee`).
 ///
 /// Tempo networks use a fixed 20 gwei base fee. Using 2× base fee
@@ -43,3 +64,56 @@ pub const MAX_FEE_PER_GAS: u128 = 20_000_000_000 * 2 + 1_000_000_000; // 41 gwei
 
 /// Static max priority fee per gas: 1 gwei.
 pub const MAX_PRIORITY_FEE_PER_GAS: u128 = 1_000_000_000;
+
+#[cfg(test)]
+mod tests {
+    use super::rpc_provider;
+    use alloy::providers::Provider;
+    use axum::{extract::State, routing::post, Json, Router};
+    use serde_json::{json, Value};
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[tokio::test]
+    async fn rpc_provider_retries_tempo_rate_limits() {
+        async fn rpc(
+            State(attempts): State<Arc<AtomicUsize>>,
+            Json(request): Json<Value>,
+        ) -> Json<Value> {
+            let attempt = attempts.fetch_add(1, Ordering::SeqCst);
+            let id = request.get("id").cloned().unwrap_or(Value::Null);
+            if attempt < 2 {
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32005,
+                        "message": "rate limited, try again in 1ms"
+                    }
+                }))
+            } else {
+                Json(json!({"jsonrpc": "2.0", "id": id, "result": "0x1079"}))
+            }
+        }
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/", post(rpc))
+            .with_state(attempts.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let chain_id = rpc_provider(url).get_chain_id().await.unwrap();
+
+        assert_eq!(chain_id, 4217);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        server.abort();
+    }
+}

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -39,6 +39,7 @@ use crate::client::PaymentProvider;
 pub struct TempoProvider {
     signer: TempoPrimitiveSigner,
     rpc_url: reqwest::Url,
+    rpc_provider: alloy::providers::RootProvider<tempo_alloy::TempoNetwork>,
     client_id: Option<String>,
     signing_mode: TempoSigningMode,
     autoswap: Option<AutoswapConfig>,
@@ -55,10 +56,12 @@ impl TempoProvider {
         signer: impl Into<TempoPrimitiveSigner>,
         rpc_url: impl AsRef<str>,
     ) -> Result<Self, MppError> {
-        let url = rpc_url.as_ref().parse().mpp_config("invalid RPC URL")?;
+        let url: reqwest::Url = rpc_url.as_ref().parse().mpp_config("invalid RPC URL")?;
+        let rpc_provider = super::rpc_provider(url.clone());
         Ok(Self {
             signer: signer.into(),
             rpc_url: url,
+            rpc_provider,
             client_id: None,
             signing_mode: TempoSigningMode::Direct,
             autoswap: None,
@@ -184,12 +187,9 @@ impl PaymentProvider for TempoProvider {
             let from = self
                 .signing_mode
                 .from_address(alloy::signers::Signer::address(&self.signer));
-            let rpc_url: reqwest::Url = self.rpc_url.clone();
-            let provider =
-                alloy::providers::RootProvider::<tempo_alloy::TempoNetwork>::new_http(rpc_url);
 
             if let Some(swap_calls) = super::autoswap::resolve_autoswap_calls(
-                &provider,
+                &self.rpc_provider,
                 from,
                 charge.currency(),
                 charge.amount(),
@@ -206,13 +206,12 @@ impl PaymentProvider for TempoProvider {
         }
 
         let options = SignOptions {
-            rpc_url: Some(self.rpc_url.to_string()),
             signing_mode: Some(self.signing_mode.clone()),
             fee_token,
             ..Default::default()
         };
         let signed = charge
-            .sign_with_primitive_options(&self.signer, options)
+            .sign_with_primitive_provider_options(&self.signer, &self.rpc_provider, options)
             .await?;
         Ok(signed.into_credential())
     }
@@ -221,6 +220,7 @@ impl PaymentProvider for TempoProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy::providers::Provider;
     use alloy::signers::Signer;
 
     #[test]
@@ -230,6 +230,21 @@ mod tests {
 
         assert_eq!(provider.rpc_url().as_str(), "https://rpc.example.com/");
         assert_eq!(provider.signer().address(), signer.address());
+    }
+
+    #[test]
+    fn test_tempo_provider_clones_share_rpc_client() {
+        let provider = TempoProvider::new(
+            alloy::signers::local::PrivateKeySigner::random(),
+            "https://rpc.example.com",
+        )
+        .unwrap();
+        let cloned = provider.clone();
+
+        assert!(std::ptr::eq(
+            provider.rpc_provider.client(),
+            cloned.rpc_provider.client()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- build Tempo payment RPC clients with Alloy's `RetryBackoffLayer`
- reuse one layered `RootProvider` across `TempoProvider` clones and concurrent charge/autoswap preparation
- pace retrying bursts at 50 RPC/s through Alloy's shared transport queue
- keep provider injection internal to the charge signing pipeline

## Why

A 4,029-request Nanocodex MPP stress run reproduced 143 Tempo RPC `-32005` responses while preparing payments. The previous bare `RootProvider::new_http` clients surfaced those transient rate limits as payment failures even though Alloy already recognizes `-32005` and parses the node's `try again in Nms` hint.

## Validation

- `cargo test --lib --features tempo,client,ws` — 959 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --no-run`
- deterministic RPC test returns `-32005` twice, then succeeds on Alloy's third attempt
- clone test proves `TempoProvider` clones share the same Alloy RPC client
- real mainnet RPC comparison, 400 concurrent credential preparations:
  - 500 RPC/s retry budget: 117 succeeded, 283 exhausted retries, 4.9s
  - 50 RPC/s shared retry budget: 400 succeeded, 0 failed, 19.1s

No signed credentials were submitted by the comparison, so it incurred no charge payments. The localnet-backed integration tests require a Tempo node on `localhost:8545`; without one, their execution fails at connection setup before exercising this change.
