### PR TITLE
fix(transport): refresh websocket session challenges

### DIFF
--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.13", default-features = false }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+time = { version = "0.3", features = ["formatting", "parsing"] }
 tracing = "0.1"
 url = "2"
 

--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -5,7 +5,7 @@
 //! initial credential, authorizes the upgraded socket in-band, and services
 //! session voucher requests while exposing only application payloads.
 
-use std::{fmt, time::Duration};
+use std::{fmt, future::Future, pin::Pin, sync::Arc, time::Duration};
 
 use futures::{SinkExt, StreamExt};
 use http::{HeaderMap, HeaderName, HeaderValue};
@@ -15,6 +15,7 @@ use mpp::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::net::TcpStream;
 use tokio::sync::{broadcast, watch};
 use tokio::time::timeout;
@@ -31,6 +32,7 @@ type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_EVENTS_CAPACITY: usize = 64;
+const CHALLENGE_REFRESH_WINDOW: TimeDuration = TimeDuration::seconds(5);
 
 /// Errors produced by the canonical paid WebSocket transport.
 #[derive(Debug, thiserror::Error)]
@@ -182,35 +184,17 @@ where
                 })?,
             );
         }
-        let response = reqwest::Client::new()
-            .get(probe_url.clone())
-            .headers(probe_headers.clone())
-            .send()
-            .await
-            .map_err(MppWsError::Probe)?;
-        if response.status() != reqwest::StatusCode::PAYMENT_REQUIRED {
-            return Err(MppWsError::ProbeStatus {
-                status: response.status().as_u16(),
-            });
-        }
-
-        let challenge = PaymentChallenge::from_headers(
-            response
-                .headers()
-                .get_all(reqwest::header::WWW_AUTHENTICATE)
-                .iter()
-                .filter_map(|value| value.to_str().ok()),
+        let http_client = reqwest::Client::new();
+        let challenge = probe_challenge(
+            &http_client,
+            &probe_url,
+            &probe_headers,
+            &self.payment_provider,
         )
-        .into_iter()
-        .filter_map(Result::ok)
-        .find(|challenge| {
-            self.payment_provider
-                .supports(challenge.method.as_str(), challenge.intent.as_str())
-        })
-        .ok_or(MppWsError::UnsupportedChallenge)?;
+        .await?;
         let payment_context = PaymentContext {
-            url: probe_url,
-            headers: probe_headers,
+            url: probe_url.clone(),
+            headers: probe_headers.clone(),
         };
         let challenge = self
             .payment_provider
@@ -233,6 +217,12 @@ where
         let mut client = MppApplicationWs {
             socket,
             challenge,
+            challenge_refresher: Arc::new(PaymentProbe {
+                client: http_client,
+                provider: self.payment_provider.clone(),
+                url: probe_url,
+                headers: probe_headers,
+            }),
             voucher_provider: self.voucher_provider.clone(),
             receipt_tx: self.receipt_tx.clone(),
             events_tx: self.events_tx.clone(),
@@ -246,6 +236,7 @@ where
 pub struct MppApplicationWs<V> {
     socket: Socket,
     challenge: PaymentChallenge,
+    challenge_refresher: Arc<dyn ChallengeRefresher>,
     voucher_provider: V,
     receipt_tx: watch::Sender<Option<Value>>,
     events_tx: broadcast::Sender<MppApplicationEvent>,
@@ -270,6 +261,7 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
                     let _ = self
                         .events_tx
                         .send(MppApplicationEvent::NeedVoucher(data.clone()));
+                    self.refresh_challenge_if_expiring(&data.channel_id).await?;
                     let voucher = self
                         .voucher_provider
                         .next_voucher_for_challenge(&self.challenge, &data)
@@ -332,6 +324,7 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
                     }
                 }
                 ServerFrame::NeedVoucher { data } => {
+                    self.refresh_challenge_if_expiring(&data.channel_id).await?;
                     let voucher = self
                         .voucher_provider
                         .next_voucher_for_challenge(&self.challenge, &data)
@@ -384,6 +377,17 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
         }
     }
 
+    async fn refresh_challenge_if_expiring(&mut self, channel_id: &str) -> Result<(), MppWsError> {
+        if !challenge_needs_refresh(&self.challenge) {
+            return Ok(());
+        }
+        self.challenge = self.challenge_refresher.refresh(channel_id).await?;
+        let _ = self
+            .events_tx
+            .send(MppApplicationEvent::Challenge(self.challenge.clone()));
+        Ok(())
+    }
+
     fn accept_receipt(&self, receipt: Value, close_ready: bool) {
         let _ = self.receipt_tx.send(Some(receipt.clone()));
         let event = if close_ready {
@@ -393,6 +397,78 @@ impl<V: VoucherProvider> MppApplicationWs<V> {
         };
         let _ = self.events_tx.send(event);
     }
+}
+
+trait ChallengeRefresher: Send + Sync {
+    fn refresh<'a>(
+        &'a self,
+        channel_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<PaymentChallenge, MppWsError>> + Send + 'a>>;
+}
+
+struct PaymentProbe<P> {
+    client: reqwest::Client,
+    provider: P,
+    url: Url,
+    headers: HeaderMap,
+}
+
+impl<P: PaymentProvider> ChallengeRefresher for PaymentProbe<P> {
+    fn refresh<'a>(
+        &'a self,
+        channel_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<PaymentChallenge, MppWsError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut headers = self.headers.clone();
+            headers.insert(
+                HeaderName::from_static("payment-session"),
+                channel_id.parse().map_err(|error| {
+                    MppError::InvalidConfig(format!(
+                        "invalid Payment-Session channel ID header: {error}"
+                    ))
+                })?,
+            );
+            probe_challenge(&self.client, &self.url, &headers, &self.provider).await
+        })
+    }
+}
+
+async fn probe_challenge<P: PaymentProvider>(
+    client: &reqwest::Client,
+    url: &Url,
+    headers: &HeaderMap,
+    provider: &P,
+) -> Result<PaymentChallenge, MppWsError> {
+    let response = client
+        .get(url.clone())
+        .headers(headers.clone())
+        .send()
+        .await
+        .map_err(MppWsError::Probe)?;
+    if response.status() != reqwest::StatusCode::PAYMENT_REQUIRED {
+        return Err(MppWsError::ProbeStatus {
+            status: response.status().as_u16(),
+        });
+    }
+    PaymentChallenge::from_headers(
+        response
+            .headers()
+            .get_all(reqwest::header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|value| value.to_str().ok()),
+    )
+    .into_iter()
+    .filter_map(Result::ok)
+    .find(|challenge| provider.supports(challenge.method.as_str(), challenge.intent.as_str()))
+    .ok_or(MppWsError::UnsupportedChallenge)
+}
+
+fn challenge_needs_refresh(challenge: &PaymentChallenge) -> bool {
+    challenge
+        .expires
+        .as_deref()
+        .and_then(|expires| OffsetDateTime::parse(expires, &Rfc3339).ok())
+        .is_some_and(|expires| expires <= OffsetDateTime::now_utc() + CHALLENGE_REFRESH_WINDOW)
 }
 
 fn close_request(receipt: &Value) -> Result<CloseRequest, MppWsError> {

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -6,7 +6,7 @@ use axum::{
         ws::{rejection::WebSocketUpgradeRejection, Message, WebSocketUpgrade},
         State,
     },
-    http::{header::WWW_AUTHENTICATE, HeaderValue, StatusCode},
+    http::{header::WWW_AUTHENTICATE, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Router,
@@ -14,14 +14,19 @@ use axum::{
 use futures::StreamExt;
 use mpp::{
     client::{PaymentContext, PaymentProvider},
+    parse_authorization,
     protocol::core::Base64UrlJson,
     MppError, PaymentChallenge, PaymentCredential, PaymentPayload,
 };
 use serde_json::{json, Value};
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
 use tokio::net::TcpListener;
 use tokio::sync::{oneshot, Mutex};
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 
 #[derive(Clone)]
 struct StubProvider;
@@ -133,8 +138,12 @@ impl CloseProvider for StubProvider {
 }
 
 fn challenge() -> PaymentChallenge {
+    challenge_with_id("challenge-1")
+}
+
+fn challenge_with_id(id: &str) -> PaymentChallenge {
     PaymentChallenge::new(
-        "challenge-1",
+        id,
         "application-test",
         "tempo",
         "session",
@@ -145,6 +154,127 @@ fn challenge() -> PaymentChallenge {
         }))
         .unwrap(),
     )
+}
+
+#[derive(Clone)]
+struct RefreshProvider {
+    voucher_challenges: Arc<Mutex<Vec<String>>>,
+}
+
+impl PaymentProvider for RefreshProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "tempo" && intent == "session"
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("0xopen"),
+        ))
+    }
+}
+
+impl VoucherProvider for RefreshProvider {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request(
+            "socket-bound voucher challenge was not forwarded",
+        ))
+    }
+
+    async fn next_voucher_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        _: &VoucherRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        self.voucher_challenges
+            .lock()
+            .await
+            .push(challenge.id.clone());
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("0xvoucher"),
+        ))
+    }
+}
+
+#[derive(Clone, Default)]
+struct RefreshState {
+    challenge_requests: Arc<AtomicUsize>,
+}
+
+async fn refresh_route(
+    State(state): State<RefreshState>,
+    headers: HeaderMap,
+    upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>,
+) -> Response {
+    let Ok(upgrade) = upgrade else {
+        let request = state.challenge_requests.fetch_add(1, Ordering::SeqCst) + 1;
+        if request > 1 {
+            assert_eq!(headers["payment-session"], "0xchannel");
+        }
+        let expires = (OffsetDateTime::now_utc() + Duration::seconds(2))
+            .format(&Rfc3339)
+            .unwrap();
+        let header = HeaderValue::from_str(
+            &challenge_with_id(&format!("challenge-{request}"))
+                .with_expires(expires)
+                .to_header()
+                .unwrap(),
+        )
+        .unwrap();
+        return (StatusCode::PAYMENT_REQUIRED, [(WWW_AUTHENTICATE, header)]).into_response();
+    };
+
+    upgrade
+        .on_upgrade(|mut socket| async move {
+            let opening = socket.next().await.unwrap().unwrap();
+            assert!(matches!(opening, Message::Text(_)));
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "payment-receipt", "data": receipt() })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+
+            tokio::time::sleep(std::time::Duration::from_millis(2_200)).await;
+            socket
+                .send(Message::Text(
+                    json!({
+                        "mpp": "payment-need-voucher",
+                        "data": {
+                            "channelId": "0xchannel",
+                            "requiredCumulative": "100",
+                            "acceptedCumulative": "0",
+                            "deposit": "100"
+                        }
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+
+            let voucher = socket.next().await.unwrap().unwrap();
+            let Message::Text(voucher) = voucher else {
+                panic!("expected voucher authorization text frame")
+            };
+            let voucher: Value = serde_json::from_str(&voucher).unwrap();
+            let credential =
+                parse_authorization(voucher["authorization"].as_str().unwrap()).unwrap();
+            assert_eq!(credential.challenge.id, "challenge-2");
+
+            socket
+                .send(Message::Text(
+                    json!({ "mpp": "message", "data": "after-refresh" })
+                        .to_string()
+                        .into(),
+                ))
+                .await
+                .unwrap();
+        })
+        .into_response()
 }
 
 fn receipt() -> Value {
@@ -315,6 +445,36 @@ async fn probes_then_authorizes_and_translates_application_messages() {
     socket.send("hello").await.unwrap();
     assert_eq!(socket.next().await.unwrap(), "world");
     assert_eq!(socket.close().await.unwrap()["channelId"], "0xchannel");
+}
+
+#[tokio::test]
+async fn refreshes_expiring_challenge_before_later_voucher() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let state = RefreshState::default();
+    let server_state = state.clone();
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            Router::new()
+                .route("/", get(refresh_route))
+                .with_state(server_state),
+        )
+        .await
+        .unwrap();
+    });
+
+    let voucher_challenges = Arc::new(Mutex::new(Vec::new()));
+    let provider = RefreshProvider {
+        voucher_challenges: Arc::clone(&voucher_challenges),
+    };
+    let connector =
+        MppApplicationWsConnect::new(format!("ws://{address}/"), provider.clone(), provider);
+    let mut socket = connector.connect().await.unwrap();
+
+    assert_eq!(socket.next().await.unwrap(), "after-refresh");
+    assert_eq!(state.challenge_requests.load(Ordering::SeqCst), 2);
+    assert_eq!(*voucher_challenges.lock().await, ["challenge-2"]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- re-probe an application WebSocket's HTTP endpoint when its session challenge is expired or within five seconds of expiry
- preserve the active `Payment-Session` channel hint and original routing headers on that probe
- bind subsequent vouchers to the refreshed challenge without changing the public Alloy transport type

This mirrors the client behavior in wevm/mppx#709. A long-running Nanocodex/OpenAI MPP session exposed the bug after its initial five-minute challenge expired: a later voucher remained bound to the opening challenge and the live service rejected it with `payment-expired`.

## Regression proof

The deterministic harness gives each probe a fresh two-second challenge, opens the socket, idles for 2.2 seconds, and requests another voucher.

- untouched `main` fails: the voucher echoes `challenge-1` instead of `challenge-2`, then the socket resets
- this branch passes: the client issues a second probe with `Payment-Session: 0xchannel`, echoes `challenge-2`, and receives the next application message

## Validation

- `cargo test -p alloy-transport-mpp`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
