### PR TITLE
fix(client): preserve application error responses

### DIFF
--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -378,14 +378,10 @@ impl PaymentExt for RequestBuilder {
                 return Ok(resp);
             }
 
+            // A completed HTTP response is the application's answer, not a
+            // payment flow error. Match MPPx by returning non-402 responses
+            // and the final 402 without emitting `payment.failed`.
             if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == max_payment_retries {
-                events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: Some(challenge),
-                        error: format!("payment retry returned unsuccessful status: {status}"),
-                        reason: None,
-                    }))
-                    .await;
                 return Ok(resp);
             }
         }
@@ -669,7 +665,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_unsuccessful_paid_retry_emits_payment_failed() {
+        async fn test_unsuccessful_paid_retry_emits_no_payment_outcome() {
             let (_, www_auth) = test_challenge();
 
             let app = Router::new().route(
@@ -707,12 +703,9 @@ mod tests {
             });
             let _failed_sub = events.on_payment_failed({
                 let failed_count = failed_count.clone();
-                move |ctx| {
+                move |_| {
                     failed_count.fetch_add(1, Ordering::SeqCst);
-                    async move {
-                        assert!(ctx.challenge.is_some());
-                        assert!(ctx.error.contains("403 Forbidden"));
-                    }
+                    async {}
                 }
             });
 
@@ -725,7 +718,7 @@ mod tests {
             assert_eq!(resp.status(), StatusCode::FORBIDDEN);
             assert_eq!(provider.call_count(), 1);
             assert_eq!(response_count.load(Ordering::SeqCst), 0);
-            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }
 
         #[tokio::test]
@@ -784,7 +777,7 @@ mod tests {
                 request_count.load(Ordering::SeqCst),
                 DEFAULT_MAX_PAYMENT_RETRIES as u32 + 1
             );
-            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }
 
         #[tokio::test]

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -360,14 +360,10 @@ where
                 return Ok(resp);
             }
 
+            // A completed HTTP response is the application's answer, not a
+            // payment flow error. Match MPPx by returning non-402 responses
+            // and the final 402 without emitting `payment.failed`.
             if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == self.max_payment_retries {
-                self.events
-                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                        challenge: Some(challenge),
-                        error: format!("payment retry returned unsuccessful status: {status}"),
-                        reason: None,
-                    }))
-                    .await;
                 return Ok(resp);
             }
         }
@@ -635,7 +631,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_middleware_unsuccessful_paid_retry_emits_payment_failed() {
+        async fn test_middleware_unsuccessful_paid_retry_emits_no_payment_outcome() {
             let (_, www_auth) = test_challenge();
 
             let app = Router::new().route(
@@ -672,12 +668,9 @@ mod tests {
             });
             let _failed_sub = events.on_payment_failed({
                 let failed_count = failed_count.clone();
-                move |ctx| {
+                move |_| {
                     failed_count.fetch_add(1, Ordering::SeqCst);
-                    async move {
-                        assert!(ctx.challenge.is_some());
-                        assert!(ctx.error.contains("403 Forbidden"));
-                    }
+                    async {}
                 }
             });
             let client = ClientBuilder::new(reqwest::Client::new())
@@ -693,7 +686,7 @@ mod tests {
             assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
             assert_eq!(provider.call_count(), 1);
             assert_eq!(response_count.load(Ordering::SeqCst), 0);
-            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }
 
         #[tokio::test]
@@ -754,7 +747,7 @@ mod tests {
                 request_count.load(Ordering::SeqCst),
                 DEFAULT_MAX_PAYMENT_RETRIES as u32 + 1
             );
-            assert_eq!(failed_count.load(Ordering::SeqCst), 1);
+            assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
- return paid non-402 application responses without emitting `payment.failed`
- return the final 402 at the retry cap without misclassifying it as a payment-handler failure
- align both the reqwest extension and reqwest middleware event behavior with MPPx

## Why
A live Nanocodex stress run paid Alchemy successfully and received a payment receipt, after which the application returned HTTP 500. mpp-rs emitted `payment.failed`, making a successful payment look like a protocol failure. MPPx returns this application response without emitting either payment outcome event.

## Validation
- Negative control on `main`: both existing paid-403 tests emitted `payment.failed`
- Focused replacement tests pass for fetch and middleware
- Retry-cap tests pass and assert no false `payment.failed`
- 1,072 all-feature library tests pass
- Alloy transport unit/integration suites pass
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`

The live integration targets in the unfiltered all-feature command require a Tempo node at `127.0.0.1:8545`; with no node running, those environment-dependent tests fail before exercising this code.