### PR TITLE
fix(client): roll back rejected session opens

### DIFF
--- a/crates/alloy-transport-mpp/src/application.rs
+++ b/crates/alloy-transport-mpp/src/application.rs
@@ -208,27 +208,45 @@ where
             .pay_with_context(&challenge, payment_context)
             .await?;
 
-        let mut request = self.url.as_str().into_client_request()?;
-        request.headers_mut().extend(self.headers.clone());
-        let (mut socket, _) = connect_async_with_config(request, None, false).await?;
-        send_authorization(&mut socket, &credential).await?;
-        let _ = self.events_tx.send(MppApplicationEvent::CredentialSent);
+        let result = async {
+            let mut request = self.url.as_str().into_client_request()?;
+            request.headers_mut().extend(self.headers.clone());
+            let (mut socket, _) = connect_async_with_config(request, None, false).await?;
+            send_authorization(&mut socket, &credential).await?;
+            let _ = self.events_tx.send(MppApplicationEvent::CredentialSent);
 
-        let mut client = MppApplicationWs {
-            socket,
-            challenge,
-            challenge_refresher: Arc::new(PaymentProbe {
-                client: http_client,
-                provider: self.payment_provider.clone(),
-                url: probe_url,
-                headers: probe_headers,
-            }),
-            voucher_provider: self.voucher_provider.clone(),
-            receipt_tx: self.receipt_tx.clone(),
-            events_tx: self.events_tx.clone(),
-        };
-        client.wait_for_receipt().await?;
-        Ok(client)
+            let mut client = MppApplicationWs {
+                socket,
+                challenge: challenge.clone(),
+                challenge_refresher: Arc::new(PaymentProbe {
+                    client: http_client,
+                    provider: self.payment_provider.clone(),
+                    url: probe_url,
+                    headers: probe_headers,
+                }),
+                voucher_provider: self.voucher_provider.clone(),
+                receipt_tx: self.receipt_tx.clone(),
+                events_tx: self.events_tx.clone(),
+            };
+            client.wait_for_receipt().await?;
+            Ok(client)
+        }
+        .await;
+
+        match result {
+            Ok(client) => {
+                self.payment_provider
+                    .commit_payment(&challenge, &credential)
+                    .await?;
+                Ok(client)
+            }
+            Err(error) => {
+                self.payment_provider
+                    .rollback_payment(&challenge, &credential)
+                    .await?;
+                Err(error)
+            }
+        }
     }
 }
 

--- a/crates/alloy-transport-mpp/tests/application_ws.rs
+++ b/crates/alloy-transport-mpp/tests/application_ws.rs
@@ -137,6 +137,49 @@ impl CloseProvider for StubProvider {
     }
 }
 
+#[derive(Clone, Default)]
+struct TrackingProvider {
+    commits: Arc<AtomicUsize>,
+    rollbacks: Arc<AtomicUsize>,
+}
+
+impl PaymentProvider for TrackingProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "tempo" && intent == "session"
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("0xopen"),
+        ))
+    }
+
+    async fn commit_payment(
+        &self,
+        _: &PaymentChallenge,
+        _: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.commits.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn rollback_payment(
+        &self,
+        _: &PaymentChallenge,
+        _: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.rollbacks.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+impl VoucherProvider for TrackingProvider {
+    async fn next_voucher(&self, _: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        Err(MppError::bad_request("unexpected voucher request"))
+    }
+}
+
 fn challenge() -> PaymentChallenge {
     challenge_with_id("challenge-1")
 }
@@ -429,6 +472,32 @@ async fn disconnect_route(
         .into_response()
 }
 
+async fn rejection_route(upgrade: Result<WebSocketUpgrade, WebSocketUpgradeRejection>) -> Response {
+    let Ok(upgrade) = upgrade else {
+        let header = HeaderValue::from_str(&challenge().to_header().unwrap()).unwrap();
+        return (StatusCode::PAYMENT_REQUIRED, [(WWW_AUTHENTICATE, header)]).into_response();
+    };
+
+    upgrade
+        .on_upgrade(|mut socket| async move {
+            let authorization = socket.next().await.unwrap().unwrap();
+            assert!(matches!(authorization, Message::Text(_)));
+            socket
+                .send(Message::Text(
+                    json!({
+                        "mpp": "payment-error",
+                        "status": 410,
+                        "message": "session/channel-not-found"
+                    })
+                    .to_string()
+                    .into(),
+                ))
+                .await
+                .unwrap();
+        })
+        .into_response()
+}
+
 #[tokio::test]
 async fn probes_then_authorizes_and_translates_application_messages() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -547,4 +616,27 @@ async fn disconnect_closes_transport_without_requesting_session_settlement() {
         .unwrap();
 
     assert!(signal_rx.await.unwrap());
+}
+
+#[tokio::test]
+async fn rejected_initial_credential_rolls_back_provider_state() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, Router::new().route("/", get(rejection_route)))
+            .await
+            .unwrap();
+    });
+
+    let provider = TrackingProvider::default();
+    let connector = MppApplicationWsConnect::new(
+        format!("ws://{address}/"),
+        provider.clone(),
+        provider.clone(),
+    );
+    let error = connector.connect().await.err().unwrap();
+
+    assert!(error.to_string().contains("session/channel-not-found"));
+    assert_eq!(provider.commits.load(Ordering::SeqCst), 0);
+    assert_eq!(provider.rollbacks.load(Ordering::SeqCst), 1);
 }

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -11,13 +11,15 @@ use super::events::{
     ChallengeReceivedContext, ClientEvent, ClientEvents, CredentialCreatedContext,
     PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
-use super::provider::{PaymentContext, PaymentProvider};
+use super::provider::{commit_payments, rollback_payments, PaymentContext, PaymentProvider};
 use super::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::client::challenge_selection::{
     expired_payment_error, select_supported_challenge, ChallengeSelectionError,
 };
 use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
-use crate::protocol::core::{format_authorization, parse_www_authenticate_all};
+use crate::protocol::core::{
+    format_authorization, parse_www_authenticate_all, PaymentChallenge, PaymentCredential,
+};
 
 /// Extension trait for `reqwest::RequestBuilder` with payment support.
 ///
@@ -199,6 +201,7 @@ impl PaymentExt for RequestBuilder {
         let ranking_accept = caller_accept.or(provider_accept);
 
         let mut paid_challenge_ids = std::collections::HashSet::new();
+        let mut pending_payments: Vec<(PaymentChallenge, PaymentCredential)> = Vec::new();
         let mut resp = this.send().await?;
 
         for attempt in 0..max_payment_retries {
@@ -221,6 +224,9 @@ impl PaymentExt for RequestBuilder {
                         reason: None,
                     }))
                     .await;
+                rollback_payments(provider, &pending_payments)
+                    .await
+                    .map_err(HttpError::Payment)?;
                 return Err(HttpError::MissingChallenge);
             }
 
@@ -246,6 +252,9 @@ impl PaymentExt for RequestBuilder {
                             reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
                         }))
                         .await;
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
                     return Err(err);
                 }
                 Err(ChallengeSelectionError::NoSupportedChallenge(message)) => {
@@ -257,6 +266,9 @@ impl PaymentExt for RequestBuilder {
                             reason: None,
                         }))
                         .await;
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
                     return Err(err);
                 }
             };
@@ -269,6 +281,9 @@ impl PaymentExt for RequestBuilder {
                         reason: None,
                     }))
                     .await;
+                rollback_payments(provider, &pending_payments)
+                    .await
+                    .map_err(HttpError::Payment)?;
                 return Ok(resp);
             }
 
@@ -281,33 +296,46 @@ impl PaymentExt for RequestBuilder {
 
             let credential = match override_credential {
                 Some(credential) => credential,
-                None => match provider
-                    .pay_with_context(
-                        &challenge,
-                        PaymentContext {
-                            url: url.clone().ok_or(HttpError::CloneFailed)?,
-                            headers: peek
-                                .as_ref()
-                                .map(|request| request.headers().clone())
-                                .unwrap_or_default(),
-                        },
-                    )
-                    .await
-                {
-                    Ok(credential) => credential,
-                    Err(err) => {
-                        let http_err = HttpError::Payment(err);
-                        events
-                            .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                                challenge: Some(challenge),
-                                error: http_err.to_string(),
-                                reason: None,
-                            }))
-                            .await;
-                        return Err(http_err);
+                None => {
+                    let Some(url) = url.clone() else {
+                        rollback_payments(provider, &pending_payments)
+                            .await
+                            .map_err(HttpError::Payment)?;
+                        return Err(HttpError::CloneFailed);
+                    };
+                    match provider
+                        .pay_with_context(
+                            &challenge,
+                            PaymentContext {
+                                url,
+                                headers: peek
+                                    .as_ref()
+                                    .map(|request| request.headers().clone())
+                                    .unwrap_or_default(),
+                            },
+                        )
+                        .await
+                    {
+                        Ok(credential) => credential,
+                        Err(err) => {
+                            let http_err = HttpError::Payment(err);
+                            events
+                                .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                                    challenge: Some(challenge),
+                                    error: http_err.to_string(),
+                                    reason: None,
+                                }))
+                                .await;
+                            rollback_payments(provider, &pending_payments)
+                                .await
+                                .map_err(HttpError::Payment)?;
+                            return Err(http_err);
+                        }
                     }
-                },
+                }
             };
+
+            pending_payments.push((challenge.clone(), credential.clone()));
 
             events
                 .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
@@ -327,6 +355,9 @@ impl PaymentExt for RequestBuilder {
                             reason: None,
                         }))
                         .await;
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
                     return Err(http_err);
                 }
             };
@@ -342,15 +373,23 @@ impl PaymentExt for RequestBuilder {
                             reason: None,
                         }))
                         .await;
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
                     return Err(http_err);
                 }
             };
             let mut payment_headers = HeaderMap::new();
             payment_headers.insert(AUTHORIZATION, auth_header);
-            let retry = retry_builder
-                .try_clone()
-                .ok_or(HttpError::CloneFailed)?
-                .headers(payment_headers);
+            let retry = match retry_builder.try_clone() {
+                Some(retry) => retry.headers(payment_headers),
+                None => {
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
+                    return Err(HttpError::CloneFailed);
+                }
+            };
             resp = match retry.send().await {
                 Ok(resp) => resp,
                 Err(err) => {
@@ -362,6 +401,9 @@ impl PaymentExt for RequestBuilder {
                             reason: None,
                         }))
                         .await;
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
                     return Err(http_err);
                 }
             };
@@ -375,6 +417,9 @@ impl PaymentExt for RequestBuilder {
                         status,
                     }))
                     .await;
+                commit_payments(provider, &pending_payments)
+                    .await
+                    .map_err(HttpError::Payment)?;
                 return Ok(resp);
             }
 
@@ -382,6 +427,15 @@ impl PaymentExt for RequestBuilder {
             // payment flow error. Match MPPx by returning non-402 responses
             // and the final 402 without emitting `payment.failed`.
             if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == max_payment_retries {
+                if resp.headers().contains_key("payment-receipt") {
+                    commit_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
+                } else {
+                    rollback_payments(provider, &pending_payments)
+                        .await
+                        .map_err(HttpError::Payment)?;
+                }
                 return Ok(resp);
             }
         }
@@ -423,6 +477,8 @@ mod tests {
         #[derive(Clone)]
         struct MockProvider {
             pay_count: Arc<AtomicU32>,
+            commit_count: Arc<AtomicU32>,
+            rollback_count: Arc<AtomicU32>,
             challenge_ids: Arc<Mutex<Vec<String>>>,
             fail: bool,
         }
@@ -431,6 +487,8 @@ mod tests {
             fn new() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    commit_count: Arc::new(AtomicU32::new(0)),
+                    rollback_count: Arc::new(AtomicU32::new(0)),
                     challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: false,
                 }
@@ -439,6 +497,8 @@ mod tests {
             fn failing() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    commit_count: Arc::new(AtomicU32::new(0)),
+                    rollback_count: Arc::new(AtomicU32::new(0)),
                     challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: true,
                 }
@@ -450,6 +510,14 @@ mod tests {
 
             fn challenge_ids(&self) -> Vec<String> {
                 self.challenge_ids.lock().unwrap().clone()
+            }
+
+            fn commit_count(&self) -> u32 {
+                self.commit_count.load(Ordering::SeqCst)
+            }
+
+            fn rollback_count(&self) -> u32 {
+                self.rollback_count.load(Ordering::SeqCst)
             }
         }
 
@@ -475,6 +543,24 @@ mod tests {
                     echo,
                     PaymentPayload::hash("0xmockhash"),
                 ))
+            }
+
+            async fn commit_payment(
+                &self,
+                _challenge: &PaymentChallenge,
+                _credential: &PaymentCredential,
+            ) -> Result<(), MppError> {
+                self.commit_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+
+            async fn rollback_payment(
+                &self,
+                _challenge: &PaymentChallenge,
+                _credential: &PaymentCredential,
+            ) -> Result<(), MppError> {
+                self.rollback_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
             }
         }
 
@@ -659,6 +745,8 @@ mod tests {
 
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(provider.call_count(), 1);
+            assert_eq!(provider.commit_count(), 1);
+            assert_eq!(provider.rollback_count(), 0);
             assert_eq!(challenge_count.load(Ordering::SeqCst), 1);
             assert_eq!(credential_count.load(Ordering::SeqCst), 1);
             assert_eq!(response_count.load(Ordering::SeqCst), 1);
@@ -717,6 +805,8 @@ mod tests {
 
             assert_eq!(resp.status(), StatusCode::FORBIDDEN);
             assert_eq!(provider.call_count(), 1);
+            assert_eq!(provider.commit_count(), 0);
+            assert_eq!(provider.rollback_count(), 1);
             assert_eq!(response_count.load(Ordering::SeqCst), 0);
             assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -16,12 +16,31 @@ use crate::client::events::{
     ChallengeReceivedContext, ClientEvent, ClientEventSubscription, ClientEvents,
     CredentialCreatedContext, PaymentFailedContext, PaymentFailureReason, PaymentResponseContext,
 };
-use crate::client::provider::PaymentProvider;
+use crate::client::provider::{commit_payments, rollback_payments, PaymentProvider};
 use crate::client::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
 use crate::protocol::core::{
-    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
+    format_authorization, parse_www_authenticate_all, PaymentChallenge, PaymentCredential,
+    AUTHORIZATION_HEADER,
 };
+
+async fn commit_middleware_payments<P: PaymentProvider>(
+    provider: &P,
+    payments: &[(PaymentChallenge, PaymentCredential)],
+) -> reqwest_middleware::Result<()> {
+    commit_payments(provider, payments)
+        .await
+        .map_err(|error| reqwest_middleware::Error::Middleware(anyhow::anyhow!(error)))
+}
+
+async fn rollback_middleware_payments<P: PaymentProvider>(
+    provider: &P,
+    payments: &[(PaymentChallenge, PaymentCredential)],
+) -> reqwest_middleware::Result<()> {
+    rollback_payments(provider, payments)
+        .await
+        .map_err(|error| reqwest_middleware::Error::Middleware(anyhow::anyhow!(error)))
+}
 
 /// Middleware that automatically handles 402 Payment Required responses.
 ///
@@ -184,6 +203,7 @@ where
         };
 
         let mut paid_challenge_ids = std::collections::HashSet::new();
+        let mut pending_payments: Vec<(PaymentChallenge, PaymentCredential)> = Vec::new();
 
         for attempt in 0..self.max_payment_retries {
             if resp.status() != StatusCode::PAYMENT_REQUIRED {
@@ -205,6 +225,7 @@ where
                         reason: None,
                     }))
                     .await;
+                rollback_middleware_payments(&self.provider, &pending_payments).await?;
                 return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
                     "402 response missing WWW-Authenticate header"
                 )));
@@ -235,6 +256,7 @@ where
                             reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
                         }))
                         .await;
+                    rollback_middleware_payments(&self.provider, &pending_payments).await?;
                     return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
                         mpp_error
                     )));
@@ -248,6 +270,7 @@ where
                             reason: None,
                         }))
                         .await;
+                    rollback_middleware_payments(&self.provider, &pending_payments).await?;
                     return Err(reqwest_middleware::Error::Middleware(err));
                 }
             };
@@ -260,6 +283,7 @@ where
                         reason: None,
                     }))
                     .await;
+                rollback_middleware_payments(&self.provider, &pending_payments).await?;
                 return Ok(resp);
             }
 
@@ -284,10 +308,13 @@ where
                                 reason: None,
                             }))
                             .await;
+                        rollback_middleware_payments(&self.provider, &pending_payments).await?;
                         return Err(reqwest_middleware::Error::Middleware(err));
                     }
                 },
             };
+
+            pending_payments.push((challenge.clone(), credential.clone()));
 
             self.events
                 .emit(ClientEvent::CredentialCreated(CredentialCreatedContext {
@@ -307,6 +334,7 @@ where
                                 reason: None,
                             }))
                             .await;
+                        rollback_middleware_payments(&self.provider, &pending_payments).await?;
                         return Err(reqwest_middleware::Error::Middleware(err));
                     }
                 };
@@ -322,14 +350,16 @@ where
                                 reason: None,
                             }))
                             .await;
+                        rollback_middleware_payments(&self.provider, &pending_payments).await?;
                         return Err(reqwest_middleware::Error::Middleware(err));
                     }
                 };
-            let mut retry_req = base_retry_req.try_clone().ok_or_else(|| {
-                reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+            let Some(mut retry_req) = base_retry_req.try_clone() else {
+                rollback_middleware_payments(&self.provider, &pending_payments).await?;
+                return Err(reqwest_middleware::Error::Middleware(anyhow::anyhow!(
                     "request could not be cloned for payment retry"
-                ))
-            })?;
+                )));
+            };
             retry_req
                 .headers_mut()
                 .insert(AUTHORIZATION_HEADER, auth_header_value);
@@ -344,6 +374,7 @@ where
                             reason: None,
                         }))
                         .await;
+                    rollback_middleware_payments(&self.provider, &pending_payments).await?;
                     return Err(err);
                 }
             };
@@ -357,6 +388,7 @@ where
                         status,
                     }))
                     .await;
+                commit_middleware_payments(&self.provider, &pending_payments).await?;
                 return Ok(resp);
             }
 
@@ -364,6 +396,11 @@ where
             // payment flow error. Match MPPx by returning non-402 responses
             // and the final 402 without emitting `payment.failed`.
             if status != StatusCode::PAYMENT_REQUIRED || attempt + 1 == self.max_payment_retries {
+                if resp.headers().contains_key("payment-receipt") {
+                    commit_middleware_payments(&self.provider, &pending_payments).await?;
+                } else {
+                    rollback_middleware_payments(&self.provider, &pending_payments).await?;
+                }
                 return Ok(resp);
             }
         }
@@ -420,6 +457,8 @@ mod tests {
         #[derive(Clone)]
         struct TestProvider {
             pay_count: Arc<AtomicU32>,
+            commit_count: Arc<AtomicU32>,
+            rollback_count: Arc<AtomicU32>,
             challenge_ids: Arc<Mutex<Vec<String>>>,
             fail: bool,
         }
@@ -428,6 +467,8 @@ mod tests {
             fn new() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    commit_count: Arc::new(AtomicU32::new(0)),
+                    rollback_count: Arc::new(AtomicU32::new(0)),
                     challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: false,
                 }
@@ -436,6 +477,8 @@ mod tests {
             fn failing() -> Self {
                 Self {
                     pay_count: Arc::new(AtomicU32::new(0)),
+                    commit_count: Arc::new(AtomicU32::new(0)),
+                    rollback_count: Arc::new(AtomicU32::new(0)),
                     challenge_ids: Arc::new(Mutex::new(Vec::new())),
                     fail: true,
                 }
@@ -447,6 +490,14 @@ mod tests {
 
             fn challenge_ids(&self) -> Vec<String> {
                 self.challenge_ids.lock().unwrap().clone()
+            }
+
+            fn commit_count(&self) -> u32 {
+                self.commit_count.load(Ordering::SeqCst)
+            }
+
+            fn rollback_count(&self) -> u32 {
+                self.rollback_count.load(Ordering::SeqCst)
             }
         }
 
@@ -472,6 +523,24 @@ mod tests {
                     echo,
                     PaymentPayload::hash("0xmockhash"),
                 ))
+            }
+
+            async fn commit_payment(
+                &self,
+                _: &PaymentChallenge,
+                _: &PaymentCredential,
+            ) -> Result<(), MppError> {
+                self.commit_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+
+            async fn rollback_payment(
+                &self,
+                _: &PaymentChallenge,
+                _: &PaymentCredential,
+            ) -> Result<(), MppError> {
+                self.rollback_count.fetch_add(1, Ordering::SeqCst);
+                Ok(())
             }
         }
 
@@ -551,6 +620,8 @@ mod tests {
 
             assert_eq!(resp.status(), reqwest::StatusCode::OK);
             assert_eq!(provider.call_count(), 1);
+            assert_eq!(provider.commit_count(), 1);
+            assert_eq!(provider.rollback_count(), 0);
             assert_eq!(call_count.load(Ordering::SeqCst), 2);
         }
 
@@ -685,6 +756,8 @@ mod tests {
 
             assert_eq!(resp.status(), reqwest::StatusCode::FORBIDDEN);
             assert_eq!(provider.call_count(), 1);
+            assert_eq!(provider.commit_count(), 0);
+            assert_eq!(provider.rollback_count(), 1);
             assert_eq!(response_count.load(Ordering::SeqCst), 0);
             assert_eq!(failed_count.load(Ordering::SeqCst), 0);
         }

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -110,6 +110,26 @@ pub trait PaymentProvider: Clone + Send + Sync {
         }
     }
 
+    /// Commit optimistic provider state after the server accepts a credential.
+    fn commit_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> impl Future<Output = Result<(), MppError>> + Send {
+        let _ = (challenge, credential);
+        async { Ok(()) }
+    }
+
+    /// Roll back optimistic provider state after the server rejects a credential.
+    fn rollback_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> impl Future<Output = Result<(), MppError>> + Send {
+        let _ = (challenge, credential);
+        async { Ok(()) }
+    }
+
     /// Build an `Accept-Payment` header value from this provider's supported methods.
     ///
     /// Returns `None` if the provider does not advertise specific methods.
@@ -118,6 +138,26 @@ pub trait PaymentProvider: Clone + Send + Sync {
     fn accept_payment_header(&self) -> Option<String> {
         None
     }
+}
+
+pub(crate) async fn commit_payments<P: PaymentProvider>(
+    provider: &P,
+    payments: &[(PaymentChallenge, PaymentCredential)],
+) -> Result<(), MppError> {
+    for (challenge, credential) in payments {
+        provider.commit_payment(challenge, credential).await?;
+    }
+    Ok(())
+}
+
+pub(crate) async fn rollback_payments<P: PaymentProvider>(
+    provider: &P,
+    payments: &[(PaymentChallenge, PaymentCredential)],
+) -> Result<(), MppError> {
+    for (challenge, credential) in payments {
+        provider.rollback_payment(challenge, credential).await?;
+    }
+    Ok(())
 }
 
 /// A provider that wraps multiple payment providers and picks the right one.
@@ -238,6 +278,46 @@ impl PaymentProvider for MultiProvider {
         )))
     }
 
+    async fn commit_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        let method = challenge.method.as_str();
+        let intent = challenge.intent.as_str();
+
+        for provider in &self.providers {
+            if provider.dyn_supports(method, intent) {
+                return provider.dyn_commit_payment(challenge, credential).await;
+            }
+        }
+
+        Err(MppError::UnsupportedPaymentMethod(format!(
+            "no provider supports method={}, intent={}",
+            method, intent
+        )))
+    }
+
+    async fn rollback_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        let method = challenge.method.as_str();
+        let intent = challenge.intent.as_str();
+
+        for provider in &self.providers {
+            if provider.dyn_supports(method, intent) {
+                return provider.dyn_rollback_payment(challenge, credential).await;
+            }
+        }
+
+        Err(MppError::UnsupportedPaymentMethod(format!(
+            "no provider supports method={}, intent={}",
+            method, intent
+        )))
+    }
+
     fn accept_payment_header(&self) -> Option<String> {
         let headers: Vec<String> = self
             .providers
@@ -270,6 +350,16 @@ trait DynPaymentProvider: Send + Sync {
         challenge: &'a PaymentChallenge,
         context: PaymentContext,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<PaymentChallenge, MppError>> + Send + 'a>>;
+    fn dyn_commit_payment<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        credential: &'a PaymentCredential,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), MppError>> + Send + 'a>>;
+    fn dyn_rollback_payment<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        credential: &'a PaymentCredential,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), MppError>> + Send + 'a>>;
     fn dyn_accept_payment_header(&self) -> Option<String>;
     fn clone_box(&self) -> Box<dyn DynPaymentProvider>;
 }
@@ -304,6 +394,24 @@ impl<P: PaymentProvider + 'static> DynPaymentProvider for P {
     {
         Box::pin(PaymentProvider::prepare_application_websocket_challenge(
             self, challenge, context,
+        ))
+    }
+
+    fn dyn_commit_payment<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        credential: &'a PaymentCredential,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), MppError>> + Send + 'a>> {
+        Box::pin(PaymentProvider::commit_payment(self, challenge, credential))
+    }
+
+    fn dyn_rollback_payment<'a>(
+        &'a self,
+        challenge: &'a PaymentChallenge,
+        credential: &'a PaymentCredential,
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), MppError>> + Send + 'a>> {
+        Box::pin(PaymentProvider::rollback_payment(
+            self, challenge, credential,
         ))
     }
 

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -43,7 +43,7 @@ use crate::error::{MppError, ResultExt};
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, Receipt};
 use crate::protocol::intents::{ChargeRequest, SessionRequest};
 use crate::protocol::methods::tempo::proof::sign_proof_primitive;
-use crate::protocol::methods::tempo::session::TempoSessionExt;
+use crate::protocol::methods::tempo::session::{SessionCredentialPayload, TempoSessionExt};
 
 /// Tempo session provider with automatic channel management.
 ///
@@ -90,12 +90,20 @@ pub struct TempoSessionProvider {
     channel_store: Arc<dyn ChannelStore>,
     /// Maps channel ID hex → channel key for reverse lookup.
     channel_id_to_key: Arc<Mutex<HashMap<String, String>>>,
+    /// Newly prepared channels awaiting acceptance by the server.
+    pending_opens: Arc<Mutex<HashMap<String, PendingOpen>>>,
     /// Optional callback for channel state changes.
     on_channel_update: Option<Arc<dyn Fn(&ChannelEntry) + Send + Sync>>,
     /// Last challenge received from the server, used for `close()`.
     last_challenge: Arc<Mutex<Option<PaymentChallenge>>>,
     /// Serializes channel recovery, cumulative advancement, and credential creation.
     payment_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+#[derive(Clone, Debug)]
+struct PendingOpen {
+    challenge_id: String,
+    store_key: String,
 }
 
 struct ApplicationTopUp<'a> {
@@ -128,6 +136,7 @@ impl TempoSessionProvider {
             channels: Arc::new(Mutex::new(HashMap::new())),
             channel_store: Arc::new(MemoryChannelStore::default()),
             channel_id_to_key: Arc::new(Mutex::new(HashMap::new())),
+            pending_opens: Arc::new(Mutex::new(HashMap::new())),
             on_channel_update: None,
             last_challenge: Arc::new(Mutex::new(None)),
             payment_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -320,6 +329,82 @@ impl TempoSessionProvider {
         }
         self.channel_store
             .set(&Self::stored_entry(entry)?)
+            .await
+            .map_err(Self::store_error)
+    }
+
+    fn credential_channel_id(credential: &PaymentCredential) -> Option<String> {
+        let payload: SessionCredentialPayload =
+            serde_json::from_value(credential.payload.clone()).ok()?;
+        Some(match payload {
+            SessionCredentialPayload::Open { channel_id, .. }
+            | SessionCredentialPayload::TopUp { channel_id, .. }
+            | SessionCredentialPayload::Voucher { channel_id, .. }
+            | SessionCredentialPayload::Close { channel_id, .. } => channel_id,
+        })
+    }
+
+    fn commit_referenced_open(&self, channel_id: &str) {
+        let runtime_key = self
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .get(channel_id)
+            .cloned();
+        let is_current = runtime_key.is_some_and(|runtime_key| {
+            self.channels
+                .lock()
+                .unwrap()
+                .get(&runtime_key)
+                .is_some_and(|entry| entry.channel_id.to_string() == channel_id)
+        });
+        if is_current {
+            self.pending_opens.lock().unwrap().remove(channel_id);
+        }
+    }
+
+    fn commit_credential(&self, credential: &PaymentCredential) {
+        let Some(channel_id) = Self::credential_channel_id(credential) else {
+            return;
+        };
+        self.commit_referenced_open(&channel_id);
+    }
+
+    async fn rollback_credential(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        let Some(channel_id) = Self::credential_channel_id(credential) else {
+            return Ok(());
+        };
+        let _guard = self.payment_lock.lock().await;
+        let pending = {
+            let mut pending_opens = self.pending_opens.lock().unwrap();
+            let Some(pending) = pending_opens.get(&channel_id) else {
+                return Ok(());
+            };
+            if pending.challenge_id != challenge.id {
+                return Ok(());
+            }
+            let Some(pending) = pending_opens.remove(&channel_id) else {
+                return Ok(());
+            };
+            pending
+        };
+
+        let runtime_key = self.channel_id_to_key.lock().unwrap().remove(&channel_id);
+        if let Some(runtime_key) = runtime_key {
+            let mut channels = self.channels.lock().unwrap();
+            if channels
+                .get(&runtime_key)
+                .is_some_and(|entry| entry.channel_id.to_string() == channel_id)
+            {
+                channels.remove(&runtime_key);
+            }
+        }
+        self.channel_store
+            .delete(&pending.store_key)
             .await
             .map_err(Self::store_error)
     }
@@ -1468,6 +1553,9 @@ impl TempoSessionProvider {
         };
         let key = Self::channel_key(&payee, &currency, &escrow_contract, chain_id);
         let session_snapshot = session_req.session_snapshot();
+        if let Some(snapshot) = &session_snapshot {
+            self.commit_referenced_open(&snapshot.channel_id);
+        }
 
         let provider =
             ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(self.rpc_url.clone());
@@ -1682,6 +1770,13 @@ impl TempoSessionProvider {
             .insert(entry.channel_id.to_string(), key.clone());
         self.persist_channel(&entry).await?;
         self.channels.lock().unwrap().insert(key, entry.clone());
+        self.pending_opens.lock().unwrap().insert(
+            entry.channel_id.to_string(),
+            PendingOpen {
+                challenge_id: challenge.id.clone(),
+                store_key: Self::stored_entry(&entry)?.key(),
+            },
+        );
         self.notify_update(&entry);
 
         Ok(build_credential(challenge, payload, chain_id, payer))
@@ -1725,6 +1820,23 @@ impl PaymentProvider for TempoSessionProvider {
             challenge,
         )
         .await
+    }
+
+    async fn commit_payment(
+        &self,
+        _challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.commit_credential(credential);
+        Ok(())
+    }
+
+    async fn rollback_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.rollback_credential(challenge, credential).await
     }
 }
 
@@ -2236,6 +2348,129 @@ mod tests {
             }))
             .unwrap(),
         )
+    }
+
+    #[tokio::test]
+    async fn rejected_open_rolls_back_unless_server_snapshot_commits_it() {
+        use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        use crate::protocol::methods::tempo::session::{
+            ChannelDescriptor, SessionCredentialPayload,
+        };
+
+        let store = Arc::new(MemoryChannelStore::default());
+        let provider = make_test_provider().with_channel_store(store.clone());
+        let payer = provider.signer.address();
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let channel_id = B256::repeat_byte(0x33);
+        let descriptor = ChannelDescriptor {
+            payer: payer.to_string(),
+            payee: payee.to_string(),
+            operator: Address::ZERO.to_string(),
+            token: currency.to_string(),
+            salt: B256::repeat_byte(0x44).to_string(),
+            authorized_signer: payer.to_string(),
+            expiring_nonce_hash: B256::repeat_byte(0x55).to_string(),
+        };
+        let entry = ChannelEntry {
+            channel_id,
+            salt: B256::repeat_byte(0x44),
+            cumulative_amount: 100,
+            deposit: 500_000,
+            descriptor: Some(descriptor),
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            chain_id: 4217,
+            opened: true,
+        };
+        let stored = TempoSessionProvider::stored_entry(&entry).unwrap();
+        let store_key = stored.key();
+        let runtime_key = TempoSessionProvider::channel_key(
+            &payee,
+            &currency,
+            &TIP20_CHANNEL_RESERVE_ADDRESS,
+            4217,
+        );
+        let challenge = make_test_challenge();
+
+        store.set(&stored).await.unwrap();
+        provider
+            .channels
+            .lock()
+            .unwrap()
+            .insert(runtime_key.clone(), entry.clone());
+        provider
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .insert(channel_id.to_string(), runtime_key.clone());
+        provider.pending_opens.lock().unwrap().insert(
+            channel_id.to_string(),
+            PendingOpen {
+                challenge_id: challenge.id.clone(),
+                store_key: store_key.clone(),
+            },
+        );
+
+        let credential = PaymentCredential::with_source(
+            challenge.to_echo(),
+            PaymentCredential::evm_did(4217, &payer.to_string()),
+            SessionCredentialPayload::Voucher {
+                channel_id: channel_id.to_string(),
+                descriptor: None,
+                cumulative_amount: "100".into(),
+                signature: "0x00".into(),
+            },
+        );
+
+        let mut concurrent_challenge = challenge.clone();
+        concurrent_challenge.id = "concurrent-voucher".into();
+        provider
+            .rollback_payment(&concurrent_challenge, &credential)
+            .await
+            .unwrap();
+        assert_eq!(provider.pending_opens.lock().unwrap().len(), 1);
+        assert!(store.get(&store_key).await.unwrap().is_some());
+
+        provider
+            .rollback_payment(&challenge, &credential)
+            .await
+            .unwrap();
+
+        assert!(provider.channels.lock().unwrap().is_empty());
+        assert!(provider.channel_id_to_key.lock().unwrap().is_empty());
+        assert!(provider.pending_opens.lock().unwrap().is_empty());
+        assert!(store.get(&store_key).await.unwrap().is_none());
+
+        store.set(&stored).await.unwrap();
+        provider
+            .channels
+            .lock()
+            .unwrap()
+            .insert(runtime_key.clone(), entry);
+        provider
+            .channel_id_to_key
+            .lock()
+            .unwrap()
+            .insert(channel_id.to_string(), runtime_key);
+        provider.pending_opens.lock().unwrap().insert(
+            channel_id.to_string(),
+            PendingOpen {
+                challenge_id: challenge.id.clone(),
+                store_key: store_key.clone(),
+            },
+        );
+
+        provider.commit_referenced_open(&channel_id.to_string());
+        provider
+            .rollback_payment(&challenge, &credential)
+            .await
+            .unwrap();
+
+        assert_eq!(provider.channels.lock().unwrap().len(), 1);
+        assert_eq!(provider.channel_id_to_key.lock().unwrap().len(), 1);
+        assert!(provider.pending_opens.lock().unwrap().is_empty());
+        assert!(store.get(&store_key).await.unwrap().is_some());
     }
 
     // --- send_voucher error paths ---


### PR DESCRIPTION
## Summary

- finalize optimistic payment-provider state from the reqwest, reqwest-middleware, and canonical application WebSocket transports
- remove a newly persisted Tempo session channel when its opening credential is rejected or the paid request fails before acceptance
- commit the open when a successful response or authoritative server session snapshot accepts it, matching current MPPx behavior
- bind rollback to the opening challenge so an unrelated concurrent voucher failure cannot delete another in-flight request's channel

## Real negative control

A live Conduit session attempt persisted a proposed native channel in `channels.db`, then the service returned HTTP 410 `session/channel-not-found`. The channel never existed on-chain, but Wallet CLI reported the ghost row as 0.4999 available session balance. Current main has no post-credential rollback hook, so the row survives.

With this change, the same rejection path rolls the optimistic entry out of both the in-memory registry and the durable `ChannelStore`. A later challenge carrying an authoritative snapshot commits the open instead, so a subsequent application error does not erase an accepted channel.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- 1,073 library tests passed
- canonical application WebSocket suites passed (5 lifecycle tests + 23 integration tests)
- 22/22 chain-backed charge integration tests passed against `ghcr.io/tempoxyz/tempo:latest`
- focused regressions cover rejected HTTP opens, rejected WebSocket opens, snapshot commit, and concurrent rollback isolation