### PR TITLE
fix(client): retain cold session state across CLIs

### DIFF
--- a/src/client/tempo/session/store.rs
+++ b/src/client/tempo/session/store.rs
@@ -463,7 +463,8 @@ mod sqlite {
                 "UPDATE channels
                  SET scope_key = origin || char(10) || lower(payee) || ':' || lower(token) || ':' ||
                      lower(escrow_contract) || ':' || chain_id
-                 WHERE scope_key IS NULL AND session_protocol = 'v2' AND descriptor_json IS NOT NULL;
+                 WHERE scope_key IS NULL AND origin <> '' AND session_protocol = 'v2'
+                     AND descriptor_json IS NOT NULL;
                  CREATE UNIQUE INDEX IF NOT EXISTS idx_channels_scope_key
                      ON channels(scope_key) WHERE scope_key IS NOT NULL;
                  CREATE INDEX IF NOT EXISTS idx_channels_origin ON channels(origin);",
@@ -648,6 +649,86 @@ mod tests {
         .unwrap();
         assert_eq!(store.get(&current.key()).await.unwrap(), Some(current));
         drop(store);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_preserves_multiple_unscoped_recovered_sessions() {
+        let directory =
+            std::env::temp_dir().join(format!("mpp-rs-recovered-store-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let path = directory.join("channels.db");
+        let current = entry();
+        let descriptor = serde_json::to_string(&current.descriptor).unwrap();
+        {
+            let connection = rusqlite::Connection::open(&path).unwrap();
+            connection
+                .execute_batch(
+                    "CREATE TABLE channels (
+                        channel_id TEXT PRIMARY KEY, version INTEGER NOT NULL DEFAULT 1,
+                        origin TEXT NOT NULL, request_url TEXT NOT NULL DEFAULT '',
+                        chain_id INTEGER NOT NULL, escrow_contract TEXT NOT NULL,
+                        token TEXT NOT NULL, payee TEXT NOT NULL, payer TEXT NOT NULL,
+                        authorized_signer TEXT NOT NULL, salt TEXT NOT NULL,
+                        deposit TEXT NOT NULL, cumulative_amount TEXT NOT NULL,
+                        challenge_echo TEXT NOT NULL, state TEXT NOT NULL DEFAULT 'active',
+                        close_requested_at INTEGER NOT NULL DEFAULT 0,
+                        grace_ready_at INTEGER NOT NULL DEFAULT 0, created_at INTEGER NOT NULL,
+                        last_used_at INTEGER NOT NULL,
+                        accepted_cumulative TEXT NOT NULL DEFAULT '0',
+                        server_spent TEXT NOT NULL DEFAULT '0',
+                        session_protocol TEXT NOT NULL DEFAULT 'v1', descriptor_json TEXT
+                    );",
+                )
+                .unwrap();
+            for channel_id in [B256::repeat_byte(0x11), B256::repeat_byte(0x12)] {
+                connection
+                    .execute(
+                        "INSERT INTO channels (
+                            channel_id, version, origin, request_url, chain_id, escrow_contract,
+                            token, payee, payer, authorized_signer, salt, deposit,
+                            cumulative_amount, challenge_echo, state, close_requested_at,
+                            grace_ready_at, created_at, last_used_at, accepted_cumulative,
+                            server_spent, session_protocol, descriptor_json
+                         ) VALUES (?1, 1, '', '', ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                            '{}', 'active', 0, 0, 1, 1, '0', '0', 'v2', ?11)",
+                        rusqlite::params![
+                            format!("{channel_id:#x}"),
+                            i64::try_from(current.chain_id).unwrap(),
+                            format!("{:#x}", current.escrow),
+                            current.descriptor.token,
+                            current.descriptor.payee,
+                            current.descriptor.payer,
+                            current.descriptor.authorized_signer,
+                            current.descriptor.salt,
+                            current.deposit.to_string(),
+                            current.cumulative_amount.to_string(),
+                            descriptor,
+                        ],
+                    )
+                    .unwrap();
+            }
+        }
+
+        let store = SqliteChannelStore::open(SqliteChannelStoreOptions {
+            namespace: "https://api.example.com".into(),
+            path: Some(path.clone()),
+            request_url: None,
+        })
+        .unwrap();
+        drop(store);
+
+        let connection = rusqlite::Connection::open(&path).unwrap();
+        let scoped: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM channels WHERE scope_key IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(scoped, 0);
+        drop(connection);
         std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/src/client/tempo/session/store.rs
+++ b/src/client/tempo/session/store.rs
@@ -258,6 +258,37 @@ mod sqlite {
             &self.path
         }
 
+        /// Return the signer of the most recently used active session for this service.
+        ///
+        /// Wallet-backed clients can use this before constructing their session
+        /// provider so a cold process retains the exact access key authorized by
+        /// the existing channel descriptor.
+        pub fn latest_authorized_signer(&self) -> ChannelStoreResult<Option<Address>> {
+            let value = self
+                .connection
+                .lock()
+                .unwrap()
+                .query_row(
+                    "SELECT authorized_signer FROM channels
+                     WHERE origin = ?1 AND state = 'active' AND session_protocol = 'v2'
+                         AND scope_key IS NOT NULL
+                     ORDER BY last_used_at DESC LIMIT 1",
+                    [&self.origin],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(io_error)?;
+            value
+                .map(|address| {
+                    address.parse().map_err(|error| {
+                        ChannelStoreError::InvalidEntry(format!(
+                            "invalid authorized_signer: {error}"
+                        ))
+                    })
+                })
+                .transpose()
+        }
+
         fn scoped_key(&self, key: &str) -> String {
             format!("{}\n{}", self.namespace, key)
         }
@@ -568,6 +599,10 @@ mod tests {
         assert_eq!(
             store.get(&current.key()).await.unwrap(),
             Some(current.clone())
+        );
+        assert_eq!(
+            store.latest_authorized_signer().unwrap(),
+            Some(current.descriptor.authorized_signer.parse().unwrap())
         );
 
         let connection = rusqlite::Connection::open(path).unwrap();

--- a/src/client/tempo/wallet.rs
+++ b/src/client/tempo/wallet.rs
@@ -69,10 +69,30 @@ impl TempoWallet {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        Self::load_at(path, now)
+        Self::load_at(path, now, None)
     }
 
-    fn load_at(path: impl AsRef<Path>, now: u64) -> Result<Self, TempoWalletError> {
+    /// Load the active account, preferring a specific locally signable access key.
+    ///
+    /// This allows a durable session client to keep using the key recorded in
+    /// its channel descriptor while retaining normal persisted-order fallback
+    /// when that key is expired, scoped, or no longer available locally.
+    pub fn load_preferred(
+        path: impl AsRef<Path>,
+        preferred_access_key: Address,
+    ) -> Result<Self, TempoWalletError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Self::load_at(path, now, Some(preferred_access_key))
+    }
+
+    fn load_at(
+        path: impl AsRef<Path>,
+        now: u64,
+        preferred_access_key: Option<Address>,
+    ) -> Result<Self, TempoWalletError> {
         let path = path.as_ref();
         let bytes = fs::read(path).map_err(|source| TempoWalletError::Read {
             path: path.to_owned(),
@@ -85,35 +105,45 @@ impl TempoWallet {
             })?;
         let state = file.store.state;
         let account = active_account(&state)?;
-        state
+        let chain_id = state.chain_id;
+        let mut fallback = None;
+        for key in state
             .access_keys
             .into_iter()
-            .filter(|key| key.chain_id == state.chain_id && key.access == account)
+            .filter(|key| key.chain_id == chain_id && key.access == account)
             .filter(|key| key.expiry.is_none_or(|expiry| expiry >= now))
             // Mirrors Accounts `accessKeys.select({ calls: undefined })`: a
             // scoped key requires concrete calls and is not selected generically.
             .filter(|key| key.scopes.is_none())
-            .find_map(|key| {
-                let signer = hydrate_access_key(&key).ok()?;
-                if signer.address() != key.address {
-                    return None;
-                }
-                let key_authorization = key
-                    .key_authorization
-                    .as_ref()
-                    .map(parse_key_authorization)
-                    .transpose()
-                    .ok()?
-                    .map(Box::new);
-                Some(Self {
-                    account,
-                    access_key: key.address,
-                    chain_id: state.chain_id,
-                    signer,
-                    key_authorization,
-                })
-            })
-            .ok_or(TempoWalletError::MissingAccessKey(state.chain_id))
+        {
+            let Some(signer) = hydrate_access_key(&key).ok() else {
+                continue;
+            };
+            if signer.address() != key.address {
+                continue;
+            }
+            let Some(key_authorization) = key
+                .key_authorization
+                .as_ref()
+                .map(parse_key_authorization)
+                .transpose()
+                .ok()
+            else {
+                continue;
+            };
+            let wallet = Self {
+                account,
+                access_key: key.address,
+                chain_id,
+                signer,
+                key_authorization: key_authorization.map(Box::new),
+            };
+            if preferred_access_key == Some(key.address) {
+                return Ok(wallet);
+            }
+            fallback.get_or_insert(wallet);
+        }
+        fallback.ok_or(TempoWalletError::MissingAccessKey(chain_id))
     }
 
     /// Load `~/.tempo/wallet/store.json`.
@@ -618,7 +648,7 @@ mod tests {
             },
         ]));
 
-        let wallet = TempoWallet::load_at(&path, 100).unwrap();
+        let wallet = TempoWallet::load_at(&path, 100, None).unwrap();
         fs::remove_file(path).unwrap();
 
         assert_eq!(wallet.signer.address(), selected.address());
@@ -643,11 +673,43 @@ mod tests {
             },
         ]));
 
-        let wallet = TempoWallet::load_at(&path, 100).unwrap();
+        let wallet = TempoWallet::load_at(&path, 100, None).unwrap();
         fs::remove_file(path).unwrap();
 
         assert_eq!(wallet.signer.address(), signer.address());
         assert_eq!(wallet.access_key, signer.address());
+    }
+
+    #[test]
+    fn prefers_retained_session_access_key_over_persisted_order() {
+        let root = "0x1111111111111111111111111111111111111111";
+        let first_key = format!("0x{}", "01".repeat(32));
+        let retained_key = format!("0x{}", "02".repeat(32));
+        let first = TempoP256Signer::from_slice(&alloy::hex::decode(&first_key).unwrap()).unwrap();
+        let retained =
+            TempoP256Signer::from_slice(&alloy::hex::decode(&retained_key).unwrap()).unwrap();
+        let path = write_store(serde_json::json!([
+            {
+                "access": root,
+                "address": first.address(),
+                "chainId": 4217,
+                "keyType": "p256",
+                "privateKey": first_key,
+            },
+            {
+                "access": root,
+                "address": retained.address(),
+                "chainId": 4217,
+                "keyType": "p256",
+                "privateKey": retained_key,
+            },
+        ]));
+
+        let wallet = TempoWallet::load_at(&path, 100, Some(retained.address())).unwrap();
+        fs::remove_file(path).unwrap();
+
+        assert_eq!(wallet.signer.address(), retained.address());
+        assert_eq!(wallet.access_key, retained.address());
     }
 
     fn write_store(access_keys: serde_json::Value) -> PathBuf {


### PR DESCRIPTION
## Summary

- left recovered TIP-1034 rows without an origin unscoped during SQLite migration
- preserved normal MPPx/wallet rows with a known origin as reusable scoped sessions
- allowed wallet-backed clients to prefer the access key authorized by their latest retained service session
- covered reopening multiple same-scope recovered channels and retained-key selection

## Regressions

A real shared `~/.tempo/wallet/channels.db` contained multiple recovered sessions with empty origins. Opening it from mpp-rs attempted to assign the same scope to every row and failed on `idx_channels_scope_key` before Nanocodex could connect. MPPx uses the same rule: an orphan without a service origin remains unscoped until a normal request identifies the service scope.

After that fix, the first wallet key in persisted order had exhausted its PathUSD spending limit while an existing OpenAI channel was authorized to a later still-signable key. A cold Rust client tried to open a replacement channel and the autoswap reverted with `SpendingLimitExceeded()`. The store now exposes the latest retained signer and `TempoWallet::load_preferred` uses it when available, with the existing Accounts-compatible selection as fallback.

## Validation

- `cargo test --all-features client::tempo::wallet::tests --lib`
- `cargo test --all-features client::tempo::session::store::tests --lib`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`