### PR TITLE
perf(tempo): consume primitives through tempo-alloy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ tempo = [
   "evm",
   "tokio",
   "tempo-alloy",
-  "tempo-primitives",
-  "dep:tempo-contracts",
   "dep:async-trait",
   "dep:p256",
   "uuid",
@@ -124,9 +122,7 @@ alloy = { version = "2.1.0", default-features = false, features = [
 ], optional = true }
 
 # Tempo dependencies (optional)
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488", optional = true }
-tempo-primitives = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488", optional = true }
-tempo-contracts = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488", optional = true }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "19915e655c2679f8c0f02400f88c10bb222d3912", default-features = false, optional = true }
 p256 = { version = "0.13", features = ["ecdsa"], optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }
 

--- a/src/client/tempo/accounts_provider.rs
+++ b/src/client/tempo/accounts_provider.rs
@@ -290,7 +290,7 @@ mod tests {
         signers::local::PrivateKeySigner,
         sol_types::SolCall,
     };
-    use tempo_primitives::{
+    use tempo_alloy::primitives::{
         transaction::{
             KeyAuthorization, KeychainVersion, PrimitiveSignature, SignatureType, TempoSignature,
         },

--- a/src/client/tempo/autoswap.rs
+++ b/src/client/tempo/autoswap.rs
@@ -29,7 +29,7 @@ use alloy::sol_types::SolCall;
 use tempo_alloy::contracts::precompiles::{
     IStablecoinDEX, ITIP20, STABLECOIN_DEX_ADDRESS as DEX_ADDRESS,
 };
-use tempo_primitives::transaction::Call;
+use tempo_alloy::primitives::transaction::Call;
 
 use crate::error::{MppError, ResultExt};
 

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -36,7 +36,7 @@ use alloy::eips::Encodable2718;
 use alloy::network::NetworkWallet;
 use alloy::primitives::{Address, TxKind, U256};
 use alloy::providers::Provider;
-use tempo_primitives::transaction::{
+use tempo_alloy::primitives::transaction::{
     Call, SignatureType, SignedKeyAuthorization, TempoTransaction, FEE_PAYER_SIGNATURE_MARKER,
 };
 

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -7,9 +7,9 @@ use std::num::NonZeroU64;
 
 use alloy::primitives::{Address, Signature, U256};
 use alloy::providers::Provider;
+use tempo_alloy::primitives::transaction::{Call, SignedKeyAuthorization, TempoTransaction};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::{Call, SignedKeyAuthorization, TempoTransaction};
 
 use crate::error::MppError;
 use crate::protocol::core::{PaymentChallenge, PaymentCredential, PaymentPayload};
@@ -288,7 +288,9 @@ mod tests {
     #[test]
     fn test_build_tempo_tx_with_key_authorization() {
         use alloy::signers::{local::PrivateKeySigner, SignerSync};
-        use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature, SignatureType};
+        use tempo_alloy::primitives::transaction::{
+            KeyAuthorization, PrimitiveSignature, SignatureType,
+        };
 
         let signer: PrivateKeySigner =
             "0x1234567890123456789012345678901234567890123456789012345678901234"

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -12,9 +12,9 @@ use alloy::providers::Provider;
 use alloy::signers::Signer;
 use alloy::sol_types::{SolCall, SolValue};
 use tempo_alloy::contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
+use tempo_alloy::primitives::transaction::{Call, SignatureType, TempoTransaction};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::{Call, SignatureType, TempoTransaction};
 
 use crate::client::tempo::charge::tx_builder::{build_tempo_tx, estimate_gas, TempoTxOptions};
 use crate::error::{MppError, ResultExt};
@@ -174,7 +174,7 @@ pub async fn create_precompile_voucher_payload(
 /// Native primitive-signature version of [`create_precompile_voucher_payload`].
 #[cfg(feature = "tempo")]
 pub async fn create_precompile_voucher_payload_primitive(
-    signer: &impl Signer<tempo_primitives::transaction::PrimitiveSignature>,
+    signer: &impl Signer<tempo_alloy::primitives::transaction::PrimitiveSignature>,
     channel_id: B256,
     cumulative_amount: u128,
     chain_id: u64,
@@ -210,7 +210,7 @@ pub async fn create_precompile_voucher_payload_with_descriptor(
 /// Native primitive-signature voucher payload with the descriptor required for recovery.
 #[cfg(feature = "tempo")]
 pub async fn create_precompile_voucher_payload_with_descriptor_primitive(
-    signer: &impl Signer<tempo_primitives::transaction::PrimitiveSignature>,
+    signer: &impl Signer<tempo_alloy::primitives::transaction::PrimitiveSignature>,
     descriptor: ChannelDescriptor,
     cumulative_amount: u128,
     chain_id: u64,
@@ -314,7 +314,7 @@ pub async fn create_precompile_close_payload(
 /// Native primitive-signature version of [`create_precompile_close_payload`].
 #[cfg(feature = "tempo")]
 pub async fn create_precompile_close_payload_primitive(
-    signer: &impl Signer<tempo_primitives::transaction::PrimitiveSignature>,
+    signer: &impl Signer<tempo_alloy::primitives::transaction::PrimitiveSignature>,
     channel_id: B256,
     cumulative_amount: u128,
     chain_id: u64,
@@ -352,7 +352,7 @@ pub async fn create_precompile_close_payload_with_descriptor(
 /// Native primitive-signature close payload with the descriptor required for recovery.
 #[cfg(feature = "tempo")]
 pub async fn create_precompile_close_payload_with_descriptor_primitive(
-    signer: &impl Signer<tempo_primitives::transaction::PrimitiveSignature>,
+    signer: &impl Signer<tempo_alloy::primitives::transaction::PrimitiveSignature>,
     channel_id: B256,
     descriptor: ChannelDescriptor,
     cumulative_amount: u128,
@@ -456,7 +456,7 @@ where
     S: Signer + Clone,
 {
     use alloy::sol;
-    use tempo_primitives::transaction::Call;
+    use tempo_alloy::primitives::transaction::Call;
 
     let default_mode = crate::client::tempo::signing::TempoSigningMode::Direct;
     let signing_mode = signing_mode.unwrap_or(&default_mode);
@@ -1343,10 +1343,10 @@ mod tests {
         // (crates/primitives/src/transaction/mod.rs L37-L45).
         use alloy::consensus::SignableTransaction;
         use alloy::primitives::keccak256;
-        use tempo_primitives::transaction::TempoTransaction;
+        use tempo_alloy::primitives::transaction::TempoTransaction;
 
         let payer = Address::repeat_byte(0xAA);
-        let calls = vec![tempo_primitives::transaction::Call {
+        let calls = vec![tempo_alloy::primitives::transaction::Call {
             to: TxKind::Call(Address::repeat_byte(0x11)),
             value: U256::ZERO,
             input: alloy::primitives::Bytes::new(),

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -18,8 +18,8 @@ use alloy::{
     signers::Signer,
 };
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use tempo_alloy::primitives::transaction::Call;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::Call;
 
 use self::channel_ops::{
     build_credential, create_close_payload, create_open_payload,

--- a/src/client/tempo/signing/keychain.rs
+++ b/src/client/tempo/signing/keychain.rs
@@ -6,8 +6,8 @@
 
 use alloy::primitives::{Address, U256};
 use tempo_alloy::contracts::precompiles::{IAccountKeychain, ACCOUNT_KEYCHAIN_ADDRESS};
+use tempo_alloy::primitives::transaction::SignedKeyAuthorization;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::SignedKeyAuthorization;
 
 use crate::client::tempo::TempoClientError;
 use crate::error::{MppError, ResultExt};
@@ -165,7 +165,7 @@ mod tests {
 
     use super::*;
     use alloy::signers::{local::PrivateKeySigner, SignerSync};
-    use tempo_primitives::transaction::{
+    use tempo_alloy::primitives::transaction::{
         KeyAuthorization, PrimitiveSignature, SignatureType, TokenLimit,
     };
 

--- a/src/client/tempo/signing/mod.rs
+++ b/src/client/tempo/signing/mod.rs
@@ -12,13 +12,13 @@ pub use p256::{P256Jwk, P256SignerError, TempoP256Signer, TempoPrimitiveSigner};
 use alloy::eips::eip2930::AccessList;
 use alloy::eips::Encodable2718;
 use alloy::primitives::{Address, U256};
-use tempo_primitives::transaction::{
+use tempo_alloy::primitives::transaction::{
     KeychainSignature, PrimitiveSignature, SignedKeyAuthorization, TempoSignature,
 };
-use tempo_primitives::TempoTxEnvelope;
+use tempo_alloy::primitives::TempoTxEnvelope;
 
-// Re-export so callers can set the version without importing tempo_primitives directly.
-pub use tempo_primitives::transaction::KeychainVersion;
+// Re-export so callers can set the version without importing Tempo primitives directly.
+pub use tempo_alloy::primitives::transaction::KeychainVersion;
 
 use crate::error::{MppError, ResultExt};
 use crate::protocol::methods::tempo::FeePayerEnvelope78;
@@ -122,7 +122,7 @@ fn build_tempo_signature_primitive(
 /// Uses the provided signing mode to produce either a primitive ECDSA
 /// signature (direct) or a keychain envelope signature.
 pub fn sign_and_encode(
-    tx: tempo_primitives::transaction::TempoTransaction,
+    tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::SignerSync,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -144,7 +144,7 @@ pub fn sign_and_encode(
 /// `tx.access_list` is stripped before signing so the signature binds the
 /// shape the sponsor reconstructs (see [`FeePayerEnvelope78::to_recoverable_signed`]).
 pub fn sign_and_encode_fee_payer_envelope(
-    mut tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &(impl alloy::signers::SignerSync + alloy::signers::Signer),
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -184,7 +184,7 @@ pub fn sign_and_encode_fee_payer_envelope(
 
 /// Async version of [`sign_and_encode`] for signers that require async signing.
 pub async fn sign_and_encode_async(
-    tx: tempo_primitives::transaction::TempoTransaction,
+    tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -202,7 +202,7 @@ pub async fn sign_and_encode_async(
 /// Sign a Tempo transaction with a signer that emits a native primitive
 /// signature, including Accounts SDK P-256 access keys.
 pub async fn sign_and_encode_primitive_async(
-    tx: tempo_primitives::transaction::TempoTransaction,
+    tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer<PrimitiveSignature>,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -222,7 +222,7 @@ pub async fn sign_and_encode_primitive_async(
 /// fee-payer marker. The marker lets the server recover the payer against the
 /// same preimage the payer signed, then replace it with the sponsor signature.
 pub async fn sign_and_encode_fee_payer_request_async(
-    mut tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -265,7 +265,7 @@ pub async fn sign_and_encode_fee_payer_request_async(
 
 /// Primitive-signature version of [`sign_and_encode_fee_payer_request_async`].
 pub async fn sign_and_encode_fee_payer_request_primitive_async(
-    mut tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer<PrimitiveSignature>,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -309,7 +309,7 @@ pub async fn sign_and_encode_fee_payer_request_primitive_async(
 /// This mirrors MPPx/Tempo's sender-only `signTransaction({ feePayer: true })`
 /// encoding for both charge credentials and TIP-1034 session management.
 pub async fn sign_and_encode_fee_payer_envelope_primitive_async(
-    mut tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer<PrimitiveSignature>,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -389,7 +389,7 @@ pub(crate) fn encode_signed_fee_payer_envelope(
 
 /// Async version of [`sign_and_encode_fee_payer_envelope`].
 pub async fn sign_and_encode_fee_payer_envelope_async(
-    mut tx: tempo_primitives::transaction::TempoTransaction,
+    mut tx: tempo_alloy::primitives::transaction::TempoTransaction,
     signer: &impl alloy::signers::Signer,
     mode: &TempoSigningMode,
 ) -> Result<Vec<u8>, MppError> {
@@ -435,7 +435,7 @@ mod tests {
     use super::*;
     use alloy::primitives::{Bytes, TxKind, U256};
     use alloy::signers::local::PrivateKeySigner;
-    use tempo_primitives::transaction::{AASigned, Call, TempoTransaction};
+    use tempo_alloy::primitives::transaction::{AASigned, Call, TempoTransaction};
 
     fn test_signer() -> PrivateKeySigner {
         "0x1234567890123456789012345678901234567890123456789012345678901234"
@@ -514,7 +514,9 @@ mod tests {
     #[test]
     fn test_key_authorization_keychain_some() {
         use alloy::signers::SignerSync;
-        use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature, SignatureType};
+        use tempo_alloy::primitives::transaction::{
+            KeyAuthorization, PrimitiveSignature, SignatureType,
+        };
 
         let signer = test_signer();
         let auth = KeyAuthorization {
@@ -668,7 +670,10 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(bytes[0], tempo_primitives::transaction::TEMPO_TX_TYPE_ID);
+        assert_eq!(
+            bytes[0],
+            tempo_alloy::primitives::transaction::TEMPO_TX_TYPE_ID
+        );
     }
 
     #[test]
@@ -804,7 +809,9 @@ mod tests {
     fn test_sign_and_encode_with_key_authorization_in_tx() {
         use alloy::eips::eip2718::Decodable2718;
         use alloy::signers::SignerSync;
-        use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature, SignatureType};
+        use tempo_alloy::primitives::transaction::{
+            KeyAuthorization, PrimitiveSignature, SignatureType,
+        };
 
         let signer = test_signer();
         let auth = KeyAuthorization {
@@ -928,7 +935,7 @@ mod tests {
     #[test]
     fn test_sign_and_encode_direct_produces_primitive_signature() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let signer = test_signer();
         let bytes = sign_and_encode(test_tx(), &signer, &TempoSigningMode::Direct).unwrap();
@@ -943,7 +950,7 @@ mod tests {
     #[test]
     fn test_sign_and_encode_keychain_produces_keychain_signature() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let wallet = Address::repeat_byte(0xAA);
         let mode = TempoSigningMode::Keychain {
@@ -971,7 +978,7 @@ mod tests {
     #[tokio::test]
     async fn test_sign_and_encode_async_direct_produces_primitive_signature() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let signer = test_signer();
         let bytes = sign_and_encode_async(test_tx(), &signer, &TempoSigningMode::Direct)
@@ -988,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_sign_and_encode_async_keychain_produces_keychain_signature() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let wallet = Address::repeat_byte(0xBB);
         let mode = TempoSigningMode::Keychain {
@@ -1081,7 +1088,7 @@ mod tests {
     #[test]
     fn test_v1_key_id_recovers_signer() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let signer = test_signer();
         let mode = keychain_mode(KeychainVersion::V1);
@@ -1108,7 +1115,7 @@ mod tests {
     #[test]
     fn test_v2_key_id_recovers_signer() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let signer = test_signer();
         let mode = keychain_mode(KeychainVersion::V2);
@@ -1135,7 +1142,7 @@ mod tests {
     #[tokio::test]
     async fn test_v2_async_key_id_recovers_signer() {
         use alloy::eips::eip2718::Decodable2718;
-        use tempo_primitives::transaction::TempoSignature;
+        use tempo_alloy::primitives::transaction::TempoSignature;
 
         let signer = test_signer();
         let mode = keychain_mode(KeychainVersion::V2);

--- a/src/client/tempo/signing/p256.rs
+++ b/src/client/tempo/signing/p256.rs
@@ -13,7 +13,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use p256::ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
-use tempo_primitives::transaction::{
+use tempo_alloy::primitives::transaction::{
     derive_p256_address, tt_signature::P256SignatureWithPreHash, PrimitiveSignature,
 };
 

--- a/src/client/tempo/wallet.rs
+++ b/src/client/tempo/wallet.rs
@@ -10,7 +10,7 @@ use std::{
 use alloy::primitives::{Address, Bytes, Signature, B256, U256};
 use alloy::signers::{local::PrivateKeySigner, Signer};
 use serde::Deserialize;
-use tempo_primitives::transaction::{
+use tempo_alloy::primitives::transaction::{
     tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
     KeyAuthorization, PrimitiveSignature, SignatureType, SignedKeyAuthorization, TokenLimit,
 };

--- a/src/protocol/methods/tempo/fee_payer_envelope.rs
+++ b/src/protocol/methods/tempo/fee_payer_envelope.rs
@@ -18,7 +18,7 @@ use alloy::eips::eip2930::AccessList;
 use alloy::primitives::{Address, Bytes, U256};
 use alloy::rlp::{Buf, BufMut, Decodable, Encodable, Error as RlpError, Header, EMPTY_STRING_CODE};
 
-use tempo_primitives::transaction::{
+use tempo_alloy::primitives::transaction::{
     Call, SignedKeyAuthorization, TempoSignature, TempoSignedAuthorization,
 };
 
@@ -27,7 +27,7 @@ use tempo_primitives::transaction::{
 /// Tempo primitives defines this as the fee payer signature domain-separation
 /// magic byte.
 pub const TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID: u8 =
-    tempo_primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE;
+    tempo_alloy::primitives::transaction::tempo_transaction::FEE_PAYER_SIGNATURE_MAGIC_BYTE;
 
 /// RLP payload sent by a client when requesting fee sponsorship.
 ///
@@ -62,7 +62,7 @@ impl FeePayerEnvelope78 {
     ///
     /// Any `tx.access_list` is dropped; see [`Self::to_recoverable_signed`].
     pub fn from_signing_tx(
-        tx: tempo_primitives::transaction::TempoTransaction,
+        tx: tempo_alloy::primitives::transaction::TempoTransaction,
         sender: Address,
         signature: TempoSignature,
     ) -> Self {
@@ -122,8 +122,8 @@ impl FeePayerEnvelope78 {
     /// the empty shape, so a tampered wire access list is structurally
     /// stripped and a malicious access-list-bound signature fails recovery.
     #[must_use]
-    pub fn to_recoverable_signed(&self) -> tempo_primitives::AASigned {
-        let tx = tempo_primitives::TempoTransaction {
+    pub fn to_recoverable_signed(&self) -> tempo_alloy::primitives::AASigned {
+        let tx = tempo_alloy::primitives::TempoTransaction {
             chain_id: self.chain_id,
             nonce: self.nonce,
             nonce_key: self.nonce_key,
@@ -144,7 +144,7 @@ impl FeePayerEnvelope78 {
             tempo_authorization_list: self.tempo_authorization_list.clone(),
         };
 
-        tempo_primitives::AASigned::new_unhashed(tx, self.signature.clone())
+        tempo_alloy::primitives::AASigned::new_unhashed(tx, self.signature.clone())
     }
 }
 
@@ -308,7 +308,7 @@ mod tests {
     use alloy::primitives::{Bytes, TxKind};
     use alloy::signers::local::PrivateKeySigner;
     use alloy::signers::SignerSync;
-    use tempo_primitives::transaction::{
+    use tempo_alloy::primitives::transaction::{
         Call, KeyAuthorization, PrimitiveSignature, SignatureType, TempoTransaction, TokenLimit,
     };
 
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn roundtrip_with_keychain_signature() {
-        use tempo_primitives::transaction::KeychainSignature;
+        use tempo_alloy::primitives::transaction::KeychainSignature;
 
         let signer = test_signer();
         let tx = base_fee_payer_tx();

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -35,9 +35,9 @@ use std::sync::Arc;
 use tempo_alloy::contracts::precompiles::{
     IAccountKeychain, IStablecoinDEX, ACCOUNT_KEYCHAIN_ADDRESS, ITIP20, STABLECOIN_DEX_ADDRESS,
 };
+use tempo_alloy::primitives::transaction::{PrimitiveSignature, TempoSignature};
 use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
 use tokio::sync::OnceCell;
 
 use crate::protocol::core::{PaymentCredential, Receipt};
@@ -89,7 +89,7 @@ fn call_selector(data: &Bytes) -> Option<[u8; 4]> {
     }
 }
 
-fn decode_approve_spender(call: &tempo_primitives::transaction::Call) -> Option<Address> {
+fn decode_approve_spender(call: &tempo_alloy::primitives::transaction::Call) -> Option<Address> {
     if call_selector(&call.input) != Some(ITIP20::approveCall::SELECTOR) || call.input.len() != 68 {
         return None;
     }
@@ -97,7 +97,7 @@ fn decode_approve_spender(call: &tempo_primitives::transaction::Call) -> Option<
     Some(Address::from_slice(&call.input[16..36]))
 }
 
-fn decode_swap_token_in(call: &tempo_primitives::transaction::Call) -> Option<Address> {
+fn decode_swap_token_in(call: &tempo_alloy::primitives::transaction::Call) -> Option<Address> {
     if call_selector(&call.input) != Some(IStablecoinDEX::swapExactAmountOutCall::SELECTOR) {
         return None;
     }
@@ -108,7 +108,7 @@ fn decode_swap_token_in(call: &tempo_primitives::transaction::Call) -> Option<Ad
 }
 
 fn transfer_call_offset(
-    calls: &[tempo_primitives::transaction::Call],
+    calls: &[tempo_alloy::primitives::transaction::Call],
 ) -> Result<usize, VerificationError> {
     let first_selector = calls.first().and_then(|call| call_selector(&call.input));
 
@@ -126,8 +126,8 @@ fn transfer_call_offset(
 }
 
 fn get_transfer_calls(
-    calls: &[tempo_primitives::transaction::Call],
-) -> Result<&[tempo_primitives::transaction::Call], VerificationError> {
+    calls: &[tempo_alloy::primitives::transaction::Call],
+) -> Result<&[tempo_alloy::primitives::transaction::Call], VerificationError> {
     let offset = transfer_call_offset(calls)?;
     let transfer_calls = &calls[offset..];
 
@@ -146,7 +146,7 @@ fn get_transfer_calls(
 }
 
 fn validate_fee_payer_calls(
-    calls: &[tempo_primitives::transaction::Call],
+    calls: &[tempo_alloy::primitives::transaction::Call],
 ) -> Result<(), VerificationError> {
     if calls.is_empty() {
         return Err(disallowed_fee_payer_call_pattern_error());
@@ -852,14 +852,14 @@ where
 
         // Skip type byte (0x76) for Tempo transactions
         let tx_data = if !tx_bytes.is_empty()
-            && tx_bytes[0] == tempo_primitives::transaction::TEMPO_TX_TYPE_ID
+            && tx_bytes[0] == tempo_alloy::primitives::transaction::TEMPO_TX_TYPE_ID
         {
             &tx_bytes[1..]
         } else {
             tx_bytes
         };
 
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..])
+        let signed = tempo_alloy::primitives::AASigned::rlp_decode(&mut &tx_data[..])
             .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {}", e)))?;
         let tx = signed.tx();
 
@@ -1110,8 +1110,8 @@ where
     fn build_simulate_payload(
         final_tx_bytes: &[u8],
     ) -> Result<SimulatePayload<TempoTransactionRequest>, VerificationError> {
-        let signed =
-            tempo_primitives::AASigned::decode_2718(&mut &final_tx_bytes[..]).map_err(|e| {
+        let signed = tempo_alloy::primitives::AASigned::decode_2718(&mut &final_tx_bytes[..])
+            .map_err(|e| {
                 VerificationError::new(format!("Failed to decode co-signed tx for simulation: {e}"))
             })?;
         let sender = signed.recover_signer().map_err(|e| {
@@ -1249,7 +1249,7 @@ where
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
         use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
-        use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
+        use tempo_alloy::primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         if tx_bytes.is_empty() {
             return Err(VerificationError::new("Empty transaction bytes"));
@@ -1822,13 +1822,15 @@ mod tests {
     // ==================== Fee payer co-sign unit tests ====================
 
     /// Helper: build a valid TempoTransaction for fee payer tests.
-    fn make_fee_payer_tx(valid_before_secs_from_now: u64) -> tempo_primitives::TempoTransaction {
+    fn make_fee_payer_tx(
+        valid_before_secs_from_now: u64,
+    ) -> tempo_alloy::primitives::TempoTransaction {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs();
 
-        tempo_primitives::TempoTransaction {
+        tempo_alloy::primitives::TempoTransaction {
             chain_id: CHAIN_ID,
             nonce: 0,
             nonce_key: U256::MAX,
@@ -1843,7 +1845,7 @@ mod tests {
             )),
             valid_before: NonZeroU64::new(now + valid_before_secs_from_now),
             valid_after: None,
-            calls: vec![tempo_primitives::transaction::Call {
+            calls: vec![tempo_alloy::primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x20)),
                 value: U256::ZERO,
                 input: Bytes::from(vec![0xa9, 0x05, 0x9c, 0xbb]), // transfer selector
@@ -1883,14 +1885,14 @@ mod tests {
     }
 
     fn encode_signed_tx(
-        calls: Vec<tempo_primitives::transaction::Call>,
+        calls: Vec<tempo_alloy::primitives::transaction::Call>,
         gas_limit: u64,
     ) -> Vec<u8> {
         use alloy::eips::Encodable2718;
         use alloy::signers::SignerSync;
 
         let signer = alloy::signers::local::PrivateKeySigner::random();
-        let tx = tempo_primitives::TempoTransaction {
+        let tx = tempo_alloy::primitives::TempoTransaction {
             chain_id: CHAIN_ID,
             nonce: 0,
             nonce_key: U256::MAX,
@@ -1907,7 +1909,7 @@ mod tests {
             key_authorization: None,
         };
 
-        let signature: tempo_primitives::transaction::TempoSignature =
+        let signature: tempo_alloy::primitives::transaction::TempoSignature =
             signer.sign_hash_sync(&tx.signature_hash()).unwrap().into();
 
         tx.into_signed(signature).encoded_2718()
@@ -2320,7 +2322,7 @@ mod tests {
 
     /// Helper: sign a tx and encode as a 0x78 fee payer envelope.
     fn sign_and_encode_0x78(
-        tx: tempo_primitives::TempoTransaction,
+        tx: tempo_alloy::primitives::TempoTransaction,
         signer: &alloy::signers::local::PrivateKeySigner,
     ) -> Vec<u8> {
         use super::super::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
@@ -2328,7 +2330,7 @@ mod tests {
 
         let sig_hash = tx.signature_hash();
         let sig = signer.sign_hash_sync(&sig_hash).unwrap();
-        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+        let signature: tempo_alloy::primitives::transaction::TempoSignature = sig.into();
         let encoded =
             FeePayerEnvelope78::from_signing_tx(tx, signer.address(), signature).encoded_envelope();
         assert_eq!(encoded[0], TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID);
@@ -2354,7 +2356,7 @@ mod tests {
         // Encode as a 0x78 fee payer envelope (sender address in the fee_payer slot).
         let sig_hash = tx.signature_hash();
         let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
-        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+        let signature: tempo_alloy::primitives::transaction::TempoSignature = sig.into();
 
         let encoded = FeePayerEnvelope78::from_signing_tx(tx, client_signer.address(), signature)
             .encoded_envelope();
@@ -2377,12 +2379,12 @@ mod tests {
         // Result should be a valid 0x76 transaction
         assert_eq!(
             co_signed[0],
-            tempo_primitives::transaction::TEMPO_TX_TYPE_ID,
+            tempo_alloy::primitives::transaction::TEMPO_TX_TYPE_ID,
             "co-signed output should be 0x76"
         );
 
         // It should be decodable by AASigned
-        let signed = tempo_primitives::AASigned::decode_2718(&mut &co_signed[..])
+        let signed = tempo_alloy::primitives::AASigned::decode_2718(&mut &co_signed[..])
             .expect("co-signed tx should be decodable as AASigned");
 
         let decoded_tx = signed.tx();
@@ -2410,12 +2412,12 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(Address::repeat_byte(0x44)),
                     value: U256::ZERO,
                     input: Bytes::from(vec![0u8; 4]),
@@ -2452,17 +2454,17 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(token_in),
                     value: U256::ZERO,
                     input: make_approve_input(STABLECOIN_DEX_ADDRESS, U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(STABLECOIN_DEX_ADDRESS),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2502,22 +2504,22 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(token_in),
                     value: U256::ZERO,
                     input: make_approve_input(STABLECOIN_DEX_ADDRESS, U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(STABLECOIN_DEX_ADDRESS),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(primary_recipient, U256::from(90u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(split_recipient, U256::from(10u64)),
@@ -2549,12 +2551,12 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(STABLECOIN_DEX_ADDRESS),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2591,17 +2593,17 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(token_in),
                     value: U256::ZERO,
                     input: make_approve_input(Address::repeat_byte(0x99), U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(STABLECOIN_DEX_ADDRESS),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2635,17 +2637,17 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(Address::repeat_byte(0x99)),
                     value: U256::ZERO,
                     input: make_approve_input(STABLECOIN_DEX_ADDRESS, U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(STABLECOIN_DEX_ADDRESS),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2681,17 +2683,17 @@ mod tests {
 
         let tx_bytes = encode_signed_tx(
             vec![
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(token_in),
                     value: U256::ZERO,
                     input: make_approve_input(STABLECOIN_DEX_ADDRESS, U256::from(100u64)),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(Address::repeat_byte(0x98)),
                     value: U256::ZERO,
                     input: make_swap_input(token_in, currency, 100),
                 },
-                tempo_primitives::transaction::Call {
+                tempo_alloy::primitives::transaction::Call {
                     to: TxKind::Call(currency),
                     value: U256::ZERO,
                     input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2723,7 +2725,7 @@ mod tests {
         }];
 
         let tx_bytes = encode_signed_tx(
-            vec![tempo_primitives::transaction::Call {
+            vec![tempo_alloy::primitives::transaction::Call {
                 to: TxKind::Call(currency),
                 value: U256::ZERO,
                 input: make_transfer_input(recipient, U256::from(100u64)),
@@ -2747,7 +2749,7 @@ mod tests {
             recipient,
             memo: None,
         }];
-        let calls = vec![tempo_primitives::transaction::Call {
+        let calls = vec![tempo_alloy::primitives::transaction::Call {
             to: TxKind::Call(currency),
             value: U256::ZERO,
             input: make_transfer_input(recipient, U256::from(100u64)),
@@ -3731,7 +3733,7 @@ mod tests {
 
         // Honest tx with empty access list, signed by the client.
         let tx = make_fee_payer_tx(60);
-        let signature: tempo_primitives::transaction::TempoSignature = client_signer
+        let signature: tempo_alloy::primitives::transaction::TempoSignature = client_signer
             .sign_hash_sync(&tx.signature_hash())
             .unwrap()
             .into();
@@ -3773,7 +3775,8 @@ mod tests {
             )
             .expect("sponsor must cosign tampered envelope");
 
-        let signed = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
+        let signed =
+            tempo_alloy::primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
         assert!(
             signed.tx().access_list.is_empty(),
             "broadcast tx must have empty access list"
@@ -3797,7 +3800,7 @@ mod tests {
         let tx = make_fee_payer_tx(60);
         let sig_hash = tx.signature_hash();
         let sig = client_signer.sign_hash_sync(&sig_hash).unwrap();
-        let signature: tempo_primitives::transaction::TempoSignature = sig.into();
+        let signature: tempo_alloy::primitives::transaction::TempoSignature = sig.into();
         let envelope = FeePayerEnvelope78::from_signing_tx(tx, client_signer.address(), signature)
             .encoded_envelope();
 
@@ -3819,7 +3822,7 @@ mod tests {
     fn make_keychain_cosigned_fee_payer_tx() -> (Vec<u8>, Address, Address) {
         use super::super::FeePayerEnvelope78;
         use alloy::signers::SignerSync;
-        use tempo_primitives::transaction::{
+        use tempo_alloy::primitives::transaction::{
             KeychainSignature, PrimitiveSignature, TempoSignature,
         };
 
@@ -3877,7 +3880,7 @@ mod tests {
         );
         assert_eq!(
             call.key_type,
-            Some(tempo_primitives::SignatureType::Secp256k1)
+            Some(tempo_alloy::primitives::SignatureType::Secp256k1)
         );
         // Otherwise the assertions above would be vacuous.
         assert_ne!(wallet, access_key);
@@ -3908,7 +3911,7 @@ mod tests {
         assert!(call.key_id.is_none(), "plain EOA tx must not set keyId");
         assert_eq!(
             call.key_type,
-            Some(tempo_primitives::SignatureType::Secp256k1),
+            Some(tempo_alloy::primitives::SignatureType::Secp256k1),
             "primitive tx must advertise its keyType for gas sizing"
         );
         assert!(
@@ -3927,7 +3930,8 @@ mod tests {
         let cosigned = make_cosigned_fee_payer_tx();
 
         // The from we expect is the client sender recovered from the cosigned tx.
-        let signed = tempo_primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
+        let signed =
+            tempo_alloy::primitives::AASigned::decode_2718(&mut cosigned.as_slice()).unwrap();
         let expected_from = signed.recover_signer().unwrap();
         let expected_calls = signed.tx().calls.clone();
 
@@ -4005,17 +4009,17 @@ mod tests {
         // Three distinct calls so a reordering bug (e.g. moving the first call)
         // would be observable.
         let calls = vec![
-            tempo_primitives::transaction::Call {
+            tempo_alloy::primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x11)),
                 value: U256::ZERO,
                 input: Bytes::from(vec![0xaa]),
             },
-            tempo_primitives::transaction::Call {
+            tempo_alloy::primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x22)),
                 value: U256::from(7u64),
                 input: Bytes::from(vec![0xbb, 0xbb]),
             },
-            tempo_primitives::transaction::Call {
+            tempo_alloy::primitives::transaction::Call {
                 to: TxKind::Call(Address::repeat_byte(0x33)),
                 value: U256::ZERO,
                 input: Bytes::from(vec![0xcc, 0xcc, 0xcc]),
@@ -4024,7 +4028,7 @@ mod tests {
 
         let mut tx = make_fee_payer_tx(60);
         tx.calls = calls.clone();
-        let signature: tempo_primitives::transaction::TempoSignature =
+        let signature: tempo_alloy::primitives::transaction::TempoSignature =
             signer.sign_hash_sync(&tx.signature_hash()).unwrap().into();
         let signed_bytes = tx.into_signed(signature).encoded_2718();
 

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -8,7 +8,7 @@
 //! - [`TempoMethodDetails`]: Tempo-specific method details (2D nonces, fee payer)
 //! - [`TempoChargeExt`]: Extension trait for ChargeRequest with Tempo-specific accessors
 //! - [`TempoTransactionRequest`]: Transaction request builder (from tempo-alloy)
-//! - [`TempoTransaction`]: Full Tempo transaction type 0x76 (from tempo-primitives)
+//! - [`TempoTransaction`]: Full Tempo transaction type 0x76
 //!
 //! # Constants
 //!

--- a/src/protocol/methods/tempo/precompile_voucher.rs
+++ b/src/protocol/methods/tempo/precompile_voucher.rs
@@ -11,7 +11,7 @@ use alloy::sol_types::{eip712_domain, SolStruct, SolValue};
 #[cfg(feature = "tempo")]
 use tempo_alloy::contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
 #[cfg(feature = "tempo")]
-use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
+use tempo_alloy::primitives::transaction::{PrimitiveSignature, TempoSignature};
 
 #[cfg(feature = "tempo")]
 use crate::error::{MppError, Result};

--- a/src/protocol/methods/tempo/proof.rs
+++ b/src/protocol/methods/tempo/proof.rs
@@ -3,7 +3,7 @@
 use alloy::primitives::{keccak256, Address, B256};
 use alloy::sol_types::{eip712_domain, SolStruct};
 #[cfg(feature = "evm")]
-use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
+use tempo_alloy::primitives::transaction::{PrimitiveSignature, TempoSignature};
 
 use crate::error::{MppError, ResultExt};
 

--- a/src/protocol/methods/tempo/session_method.rs
+++ b/src/protocol/methods/tempo/session_method.rs
@@ -362,16 +362,19 @@ where
 
         // Strip type byte (0x76) if present.
         let tx_data = if !tx_bytes.is_empty()
-            && tx_bytes[0] == tempo_primitives::transaction::TEMPO_TX_TYPE_ID
+            && tx_bytes[0] == tempo_alloy::primitives::transaction::TEMPO_TX_TYPE_ID
         {
             &tx_bytes[1..]
         } else {
             tx_bytes
         };
 
-        let signed = tempo_primitives::AASigned::rlp_decode(&mut &tx_data[..]).map_err(|e| {
-            VerificationError::invalid_payload(format!("failed to decode open transaction: {e}"))
-        })?;
+        let signed =
+            tempo_alloy::primitives::AASigned::rlp_decode(&mut &tx_data[..]).map_err(|e| {
+                VerificationError::invalid_payload(format!(
+                    "failed to decode open transaction: {e}"
+                ))
+            })?;
 
         let sender = signed
             .recover_signer()
@@ -966,8 +969,8 @@ where
             use alloy::primitives::Bytes;
             use alloy::signers::SignerSync;
             use alloy::sol_types::SolCall;
-            use tempo_primitives::transaction::Call;
-            use tempo_primitives::TempoTransaction;
+            use tempo_alloy::primitives::transaction::Call;
+            use tempo_alloy::primitives::TempoTransaction;
 
             alloy::sol! {
                 interface IEscrowClose {
@@ -2587,8 +2590,8 @@ mod tests {
         use alloy::signers::local::PrivateKeySigner;
         use alloy::signers::SignerSync;
         use alloy::sol_types::SolCall;
-        use tempo_primitives::transaction::Call;
-        use tempo_primitives::TempoTransaction;
+        use tempo_alloy::primitives::transaction::Call;
+        use tempo_alloy::primitives::TempoTransaction;
 
         alloy::sol! {
             interface IEscrowOpen {
@@ -2681,8 +2684,8 @@ mod tests {
         use alloy::signers::local::PrivateKeySigner;
         use alloy::signers::SignerSync;
         use alloy::sol_types::SolCall;
-        use tempo_primitives::transaction::Call;
-        use tempo_primitives::TempoTransaction;
+        use tempo_alloy::primitives::transaction::Call;
+        use tempo_alloy::primitives::TempoTransaction;
 
         alloy::sol! {
             interface IEscrowOpen {

--- a/src/protocol/methods/tempo/transaction.rs
+++ b/src/protocol/methods/tempo/transaction.rs
@@ -1,12 +1,12 @@
 //! Tempo transaction types for building and submitting transactions.
 //!
-//! This module re-exports transaction types from `tempo-alloy` and `tempo-primitives`
+//! This module re-exports transaction types from `tempo-alloy`
 //! for building Tempo transactions (type 0x76).
 //!
 //! # Transaction Types
 //!
 //! - [`TempoTransactionRequest`]: Builder for Tempo transactions (from tempo-alloy)
-//! - [`TempoTransaction`]: Full Tempo transaction with RLP encoding (from tempo-primitives)
+//! - [`TempoTransaction`]: Full Tempo transaction with RLP encoding
 //!
 //! # Transaction Flow
 //!
@@ -43,7 +43,7 @@
 /// - `tempo_authorization_list`: Tempo-specific authorization list
 pub use tempo_alloy::rpc::TempoTransactionRequest;
 
-/// Re-export TempoTransaction from tempo-primitives.
+/// Re-export [`TempoTransaction`] from `tempo-alloy`.
 ///
 /// This is the full Tempo transaction type (0x76) with:
 /// - RLP encoding/decoding
@@ -51,10 +51,10 @@ pub use tempo_alloy::rpc::TempoTransactionRequest;
 /// - Fee payer signature support
 /// - Multi-call support
 /// - TIP-20 fee token support
-pub use tempo_primitives::TempoTransaction;
+pub use tempo_alloy::primitives::TempoTransaction;
 
-/// Re-export transaction primitives from tempo-primitives.
-pub use tempo_primitives::transaction::{Call, SignatureType, TEMPO_TX_TYPE_ID};
+/// Re-export transaction primitives from `tempo-alloy`.
+pub use tempo_alloy::primitives::transaction::{Call, SignatureType, TEMPO_TX_TYPE_ID};
 
 /// JSON-RPC method name for Tempo transactions.
 pub const TEMPO_SEND_TRANSACTION_METHOD: &str = "tempo_sendTransaction";

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -30,9 +30,9 @@ use mpp::server::{tempo, Mpp, TempoConfig};
 use reqwest::Client;
 use tempo_alloy::contracts::precompiles::tip20::ITIP20;
 use tempo_alloy::contracts::precompiles::ITIPFeeAMM;
+use tempo_alloy::primitives::transaction::Call;
+use tempo_alloy::primitives::TempoTransaction;
 use tempo_alloy::TempoNetwork;
-use tempo_primitives::transaction::Call;
-use tempo_primitives::TempoTransaction;
 use tokio::sync::Mutex;
 
 /// Well-known dev private key (account[0] of test mnemonic).
@@ -229,7 +229,7 @@ async fn fund_account_amount(rpc: &str, to: Address, amount: U256) {
 fn encode_fee_payer_envelope_for_test(
     tx: &TempoTransaction,
     sender: Address,
-    signature: tempo_primitives::transaction::TempoSignature,
+    signature: tempo_alloy::primitives::transaction::TempoSignature,
 ) -> Vec<u8> {
     mpp::protocol::methods::tempo::FeePayerEnvelope78::from_signing_tx(
         tx.clone(),


### PR DESCRIPTION
## Summary

- consume Tempo primitive types through the `tempo-alloy` re-export
- remove direct `tempo-primitives` and unused `tempo-contracts` dependencies
- pin the updated Accounts branch that gates node RPC primitives behind the `reth` feature

For the normal Tempo client/server feature set, the resolved dependency graph drops from 565 to 414 unique package entries and contains no Reth/Revm packages.

## Validation

- nightly rustfmt check
- Clippy with warnings denied for all affected targets
- 953 unit tests and 61 doctests
- Tempo client/server feature build over Rustls