### PR TITLE
chore: centralize Tempo SDK revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ default-members = ["."]
 exclude = ["fuzz"]
 resolver = "2"
 
+[workspace.dependencies]
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false }
+
 [features]
 default = ["reqwest-default-tls"]
 
@@ -122,7 +125,7 @@ alloy = { version = "2.1.0", default-features = false, features = [
 ], optional = true }
 
 # Tempo dependencies (optional)
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "19915e655c2679f8c0f02400f88c10bb222d3912", default-features = false, optional = true }
+tempo-alloy = { workspace = true, optional = true }
 p256 = { version = "0.13", features = ["ecdsa"], optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }
 

--- a/examples/axum-extractor/Cargo.toml
+++ b/examples/axum-extractor/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo", "axum"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-alloy.workspace = true
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-alloy.workspace = true
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/examples/session/multi-fetch/Cargo.toml
+++ b/examples/session/multi-fetch/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http", "sol-types", "contract"] }
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-alloy.workspace = true
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }

--- a/examples/session/sse/Cargo.toml
+++ b/examples/session/sse/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/client.rs"
 [dependencies]
 mpp = { path = "../../..", features = ["server", "client", "tempo"] }
 alloy = { version = "2.0", features = ["provider-http"] }
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-alloy.workspace = true
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
## Summary
- pin `tempo-alloy` once at the workspace boundary
- reuse that pin from the crate and every Tempo example
- advance to Tempo `9081cc65940c419ab60ebd1fd8170483ee49cfe1`, which centralizes Accounts call-scope matching and rejects noncanonical recipient padding

This prevents a second Tempo revision from entering the workspace through examples.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features --lib --bins --examples` (1,087 unit tests)
- `cargo test --locked --workspace --all-features --doc` (61 doctests)

The blanket workspace test command also reached the localnet-only integration suite; those tests require an RPC node at `127.0.0.1:8545`, which was intentionally not started for this dependency-only change.