### PR TITLE
chore: update Tempo SDK revision

### DIFF
--- a/.changelog/tempo-sponsor-validation.md
+++ b/.changelog/tempo-sponsor-validation.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Update the Tempo SDK revision so fee-payer relays can select the transaction fee token.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]


### PR DESCRIPTION
## Summary

- update the centralized `tempo-alloy` revision to include sponsor-selected fee-token validation
- keep downstream consumers such as Foundry on one coherent Tempo dependency graph

Depends on tempoxyz/tempo#6965.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- 1,087 unit tests pass
- all 22 live charge integration tests pass against Tempo Anvil, including fee sponsorship, Accounts Store/keychain signing, replay rejection, and sequential payments
- `git diff --check`