### PR TITLE
feat(alloy): add paid HTTP JSON-RPC transport

### DIFF
--- a/.changelog/alloy-http-transport.md
+++ b/.changelog/alloy-http-transport.md
@@ -3,4 +3,5 @@
 ---
 
 Add an Alloy HTTP JSON-RPC transport that delegates automatic 402 challenge,
-payment retry, and commit/rollback handling to the canonical MPP client flow.
+payment retry, and commit/rollback handling to the canonical MPP client flow,
+with an optional concurrency bound for high-fanout consumers.

--- a/.changelog/alloy-http-transport.md
+++ b/.changelog/alloy-http-transport.md
@@ -1,0 +1,6 @@
+---
+"alloy-transport-mpp": minor
+---
+
+Add an Alloy HTTP JSON-RPC transport that delegates automatic 402 challenge,
+payment retry, and commit/rollback handling to the canonical MPP client flow.

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -34,6 +34,7 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing"] }
+tower-service = "0.3"
 tracing = "0.1"
 url = "2"
 

--- a/crates/alloy-transport-mpp/README.md
+++ b/crates/alloy-transport-mpp/README.md
@@ -1,14 +1,28 @@
 # alloy-transport-mpp
 
 [Machine Payments Protocol (MPP)](https://github.com/tempoxyz/mpp-rs)
-WebSocket transport for [alloy](https://github.com/alloy-rs/alloy).
+transports for [alloy](https://github.com/alloy-rs/alloy).
 
-This crate adds opt-in WebSocket transports that speak the MPP wire protocol.
-`MppWsConnect` is a drop-in Alloy `PubSubConnect` implementation for JSON-RPC,
-while `MppApplicationWsConnect` carries arbitrary text application messages.
-Both wrap payloads in canonical MPP `message` envelopes and handle payment
-`challenge`, `needVoucher`, `receipt`, signed session close, and `error` frames
-internally via a user-supplied
+`MppHttpTransport` is a drop-in Alloy transport for paid HTTP JSON-RPC
+endpoints. It delegates the canonical 402 challenge, payment retry, and
+commit/rollback lifecycle to `mpp`:
+
+```rust,ignore
+use alloy_provider::ProviderBuilder;
+use alloy_rpc_client::RpcClient;
+use alloy_transport_mpp::MppHttpTransport;
+
+let transport = MppHttpTransport::with_default_client(rpc_url, payment_provider)?;
+let client = RpcClient::new(transport, false);
+let provider = ProviderBuilder::new().connect_client(client);
+```
+
+The crate also includes opt-in WebSocket transports that speak the MPP wire
+protocol. `MppWsConnect` is a drop-in Alloy `PubSubConnect` implementation for
+JSON-RPC, while `MppApplicationWsConnect` carries arbitrary text application
+messages. Both wrap payloads in canonical MPP `message` envelopes and handle
+payment `challenge`, `needVoucher`, `receipt`, signed session close, and `error`
+frames internally via a user-supplied
 [`PaymentProvider`](https://docs.rs/mpp/latest/mpp/client/trait.PaymentProvider.html)
 (and a `VoucherProvider` for streaming/session intents).
 

--- a/crates/alloy-transport-mpp/README.md
+++ b/crates/alloy-transport-mpp/README.md
@@ -12,7 +12,8 @@ use alloy_provider::ProviderBuilder;
 use alloy_rpc_client::RpcClient;
 use alloy_transport_mpp::MppHttpTransport;
 
-let transport = MppHttpTransport::with_default_client(rpc_url, payment_provider)?;
+let transport = MppHttpTransport::with_default_client(rpc_url, payment_provider)?
+    .with_max_concurrent_requests(16);
 let client = RpcClient::new(transport, false);
 let provider = ProviderBuilder::new().connect_client(client);
 ```

--- a/crates/alloy-transport-mpp/src/http.rs
+++ b/crates/alloy-transport-mpp/src/http.rs
@@ -1,11 +1,12 @@
 //! Alloy HTTP JSON-RPC transport with automatic MPP payments.
 
-use std::{fmt, task};
+use std::{fmt, sync::Arc, task};
 
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
 use mpp::client::{Fetch, PaymentProvider};
 use reqwest::Url;
+use tokio::sync::Semaphore;
 use tower_service::Service;
 
 /// An Alloy HTTP transport that pays MPP challenges before replaying JSON-RPC requests.
@@ -18,6 +19,7 @@ pub struct MppHttpTransport<P> {
     client: reqwest::Client,
     url: Url,
     provider: P,
+    request_limit: Option<(usize, Arc<Semaphore>)>,
 }
 
 impl<P> MppHttpTransport<P> {
@@ -38,7 +40,19 @@ impl<P> MppHttpTransport<P> {
             client,
             url,
             provider,
+            request_limit: None,
         }
+    }
+
+    /// Bound concurrent HTTP payment flows.
+    ///
+    /// This is useful for consumers such as fork databases that can fan out a
+    /// large number of paid reads at once. The permit covers the complete HTTP
+    /// request, including any 402 payment and authenticated replay. A limit of
+    /// zero restores the default unbounded behavior.
+    pub fn with_max_concurrent_requests(mut self, limit: usize) -> Self {
+        self.request_limit = (limit != 0).then(|| (limit, Arc::new(Semaphore::new(limit))));
+        self
     }
 
     /// Return the underlying HTTP client.
@@ -61,6 +75,10 @@ impl<P> fmt::Debug for MppHttpTransport<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MppHttpTransport")
             .field("url", &redact_url(&self.url))
+            .field(
+                "max_concurrent_requests",
+                &self.request_limit.as_ref().map(|(limit, _)| limit),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -70,6 +88,12 @@ where
     P: PaymentProvider,
 {
     async fn request(self, packet: RequestPacket) -> TransportResult<ResponsePacket> {
+        let _permit = match self.request_limit {
+            Some((_, limit)) => Some(limit.acquire_owned().await.map_err(|_| {
+                TransportErrorKind::custom_str("MPP HTTP concurrency limiter is unavailable")
+            })?),
+            None => None,
+        };
         let body = serde_json::to_vec(&packet).map_err(TransportErrorKind::custom)?;
         let headers = packet.headers();
         let response = self
@@ -142,6 +166,7 @@ mod tests {
             atomic::{AtomicUsize, Ordering},
             Arc,
         },
+        time::Duration,
     };
 
     use alloy_json_rpc::{Id, Request, RequestMeta};
@@ -360,6 +385,48 @@ mod tests {
         assert!(error.to_string().contains("402"));
         assert_eq!(provider.commits.load(Ordering::SeqCst), 0);
         assert_eq!(provider.rollbacks.load(Ordering::SeqCst), 1);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn bounds_concurrent_request_flows() {
+        #[derive(Clone, Default)]
+        struct AppState {
+            active: Arc<AtomicUsize>,
+            maximum: Arc<AtomicUsize>,
+        }
+
+        let state = AppState::default();
+        let observed = state.clone();
+        let app = Router::new()
+            .route(
+                "/",
+                post(|State(state): State<AppState>| async move {
+                    let active = state.active.fetch_add(1, Ordering::SeqCst) + 1;
+                    state.maximum.fetch_max(active, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    state.active.fetch_sub(1, Ordering::SeqCst);
+                    axum::Json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": "0x2a"
+                    }))
+                }),
+            )
+            .with_state(state);
+        let (url, task) = server(app).await;
+        let transport = MppHttpTransport::new(client(), url, MockProvider::default())
+            .with_max_concurrent_requests(2);
+
+        let requests = (0..8).map(|_| {
+            let mut transport = transport.clone();
+            tokio::spawn(async move { transport.call(request()).await.unwrap() })
+        });
+        for result in futures::future::join_all(requests).await {
+            result.unwrap();
+        }
+
+        assert_eq!(observed.maximum.load(Ordering::SeqCst), 2);
         task.abort();
     }
 

--- a/crates/alloy-transport-mpp/src/http.rs
+++ b/crates/alloy-transport-mpp/src/http.rs
@@ -1,0 +1,380 @@
+//! Alloy HTTP JSON-RPC transport with automatic MPP payments.
+
+use std::{fmt, task};
+
+use alloy_json_rpc::{RequestPacket, ResponsePacket};
+use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
+use mpp::client::{Fetch, PaymentProvider};
+use reqwest::Url;
+use tower_service::Service;
+
+/// An Alloy HTTP transport that pays MPP challenges before replaying JSON-RPC requests.
+///
+/// The canonical MPP client flow owns challenge selection, credential creation,
+/// payment retries, and provider commit/rollback. This adapter only translates
+/// between Alloy JSON-RPC packets and `reqwest` requests.
+#[derive(Clone)]
+pub struct MppHttpTransport<P> {
+    client: reqwest::Client,
+    url: Url,
+    provider: P,
+}
+
+impl<P> MppHttpTransport<P> {
+    /// Create an MPP transport with a default HTTP client.
+    ///
+    /// This installs the crate-selected Rustls crypto provider before building
+    /// the client.
+    pub fn with_default_client(url: Url, provider: P) -> Result<Self, reqwest::Error> {
+        install_default_crypto_provider();
+        reqwest::Client::builder()
+            .build()
+            .map(|client| Self::new(client, url, provider))
+    }
+
+    /// Create an MPP transport for `url` using `provider`.
+    pub const fn new(client: reqwest::Client, url: Url, provider: P) -> Self {
+        Self {
+            client,
+            url,
+            provider,
+        }
+    }
+
+    /// Return the underlying HTTP client.
+    pub const fn client(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Return the paid JSON-RPC endpoint.
+    pub const fn url(&self) -> &Url {
+        &self.url
+    }
+
+    /// Return the payment provider.
+    pub const fn payment_provider(&self) -> &P {
+        &self.provider
+    }
+}
+
+impl<P> fmt::Debug for MppHttpTransport<P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MppHttpTransport")
+            .field("url", &redact_url(&self.url))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P> MppHttpTransport<P>
+where
+    P: PaymentProvider,
+{
+    async fn request(self, packet: RequestPacket) -> TransportResult<ResponsePacket> {
+        let body = serde_json::to_vec(&packet).map_err(TransportErrorKind::custom)?;
+        let headers = packet.headers();
+        let response = self
+            .client
+            .post(self.url)
+            .headers(headers)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send_with_payment(&self.provider)
+            .await
+            .map_err(TransportErrorKind::custom)?;
+        decode_response(response).await
+    }
+}
+
+impl<P> Service<RequestPacket> for MppHttpTransport<P>
+where
+    P: PaymentProvider + 'static,
+{
+    type Response = ResponsePacket;
+    type Error = TransportError;
+    type Future = TransportFut<'static>;
+
+    fn poll_ready(&mut self, _cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, packet: RequestPacket) -> Self::Future {
+        Box::pin(self.clone().request(packet))
+    }
+}
+
+async fn decode_response(response: reqwest::Response) -> TransportResult<ResponsePacket> {
+    let status = response.status();
+    let body = response.bytes().await.map_err(TransportErrorKind::custom)?;
+    if !status.is_success() {
+        return Err(TransportErrorKind::http_error(
+            status.as_u16(),
+            String::from_utf8_lossy(&body).into_owned(),
+        ));
+    }
+    serde_json::from_slice(&body)
+        .map_err(|error| TransportError::deser_err(error, String::from_utf8_lossy(&body)))
+}
+
+fn redact_url(url: &Url) -> String {
+    let mut redacted = url.clone();
+    let _ = redacted.set_username("");
+    let _ = redacted.set_password(None);
+    redacted.set_query(None);
+    redacted.to_string()
+}
+
+fn install_default_crypto_provider() {
+    #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        #[cfg(feature = "aws-lc-rs")]
+        let provider = rustls::crypto::aws_lc_rs::default_provider();
+        #[cfg(all(feature = "ring", not(feature = "aws-lc-rs")))]
+        let provider = rustls::crypto::ring::default_provider();
+        let _ = rustls::crypto::CryptoProvider::install_default(provider);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    use alloy_json_rpc::{Id, Request, RequestMeta};
+    use axum::{
+        extract::State, http::StatusCode as AxumStatusCode, response::IntoResponse, routing::post,
+        Router,
+    };
+    use mpp::{
+        client::PaymentProvider,
+        format_www_authenticate, parse_authorization,
+        protocol::core::{
+            Base64UrlJson, IntentName, MethodName, PaymentChallenge, PaymentCredential,
+        },
+        MppError,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Debug, Default)]
+    struct MockProvider {
+        commits: Arc<AtomicUsize>,
+        rollbacks: Arc<AtomicUsize>,
+    }
+
+    impl PaymentProvider for MockProvider {
+        fn supports(&self, method: &str, intent: &str) -> bool {
+            method == "tempo" && intent == "charge"
+        }
+
+        fn pay(
+            &self,
+            challenge: &PaymentChallenge,
+        ) -> impl Future<Output = Result<PaymentCredential, MppError>> + Send {
+            let credential = PaymentCredential::with_source(
+                challenge.to_echo(),
+                "test-source".to_owned(),
+                serde_json::json!({"tx": "0xsigned"}),
+            );
+            async move { Ok(credential) }
+        }
+
+        async fn commit_payment(
+            &self,
+            _challenge: &PaymentChallenge,
+            _credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn rollback_payment(
+            &self,
+            _challenge: &PaymentChallenge,
+            _credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.rollbacks.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn challenge() -> PaymentChallenge {
+        PaymentChallenge {
+            id: "rpc-charge".to_owned(),
+            realm: "rpc.example".to_owned(),
+            method: MethodName::new("tempo"),
+            intent: IntentName::new("charge"),
+            request: Base64UrlJson::from_value(&serde_json::json!({
+                "amount": "1",
+                "currency": "0x20c0000000000000000000000000000000000000",
+                "recipient": "0x0000000000000000000000000000000000000001",
+                "methodDetails": {"chainId": 42431}
+            }))
+            .unwrap(),
+            expires: None,
+            description: None,
+            digest: None,
+            opaque: None,
+        }
+    }
+
+    fn request() -> RequestPacket {
+        RequestPacket::Single(
+            Request {
+                meta: RequestMeta::new("eth_blockNumber".into(), Id::Number(1)),
+                params: serde_json::Value::Array(Vec::new()),
+            }
+            .serialize()
+            .unwrap(),
+        )
+    }
+
+    async fn server(app: Router) -> (Url, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap())
+            .parse()
+            .unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (url, task)
+    }
+
+    fn client() -> reqwest::Client {
+        install_default_crypto_provider();
+        reqwest::Client::builder().no_proxy().build().unwrap()
+    }
+
+    #[tokio::test]
+    async fn passes_through_free_json_rpc() {
+        let app = Router::new().route(
+            "/",
+            post(|| async {
+                axum::Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": "0x2a"
+                }))
+            }),
+        );
+        let (url, task) = server(app).await;
+        let provider = MockProvider::default();
+        let mut transport = MppHttpTransport::new(client(), url, provider.clone());
+
+        let response = transport.call(request()).await.unwrap();
+        assert!(matches!(response, ResponsePacket::Single(response) if response.is_success()));
+        assert_eq!(provider.commits.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.rollbacks.load(Ordering::SeqCst), 0);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn pays_and_replays_json_rpc() {
+        #[derive(Clone)]
+        struct AppState {
+            challenge: String,
+        }
+
+        let app = Router::new()
+            .route(
+                "/",
+                post(
+                    |State(state): State<AppState>,
+                     request: axum::http::Request<axum::body::Body>| async move {
+                        if let Some(authorization) = request.headers().get("authorization") {
+                            let credential =
+                                parse_authorization(authorization.to_str().unwrap()).unwrap();
+                            assert_eq!(credential.challenge.id, "rpc-charge");
+                            (
+                                AxumStatusCode::OK,
+                                axum::Json(serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": 1,
+                                    "result": "0x2a"
+                                })),
+                            )
+                                .into_response()
+                        } else {
+                            (
+                                AxumStatusCode::PAYMENT_REQUIRED,
+                                [("www-authenticate", state.challenge)],
+                                "payment required",
+                            )
+                                .into_response()
+                        }
+                    },
+                ),
+            )
+            .with_state(AppState {
+                challenge: format_www_authenticate(&challenge()).unwrap(),
+            });
+        let (url, task) = server(app).await;
+        let provider = MockProvider::default();
+        let mut transport = MppHttpTransport::new(client(), url, provider.clone());
+
+        let response = transport.call(request()).await.unwrap();
+        assert!(matches!(response, ResponsePacket::Single(response) if response.is_success()));
+        assert_eq!(provider.commits.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.rollbacks.load(Ordering::SeqCst), 0);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn rolls_back_rejected_payment() {
+        #[derive(Clone)]
+        struct AppState {
+            challenge: String,
+        }
+
+        let app = Router::new()
+            .route(
+                "/",
+                post(
+                    |State(state): State<AppState>,
+                     request: axum::http::Request<axum::body::Body>| async move {
+                        let message = if request.headers().contains_key("authorization") {
+                            "payment rejected"
+                        } else {
+                            "payment required"
+                        };
+                        (
+                            AxumStatusCode::PAYMENT_REQUIRED,
+                            [("www-authenticate", state.challenge)],
+                            message,
+                        )
+                    },
+                ),
+            )
+            .with_state(AppState {
+                challenge: format_www_authenticate(&challenge()).unwrap(),
+            });
+        let (url, task) = server(app).await;
+        let provider = MockProvider::default();
+        let mut transport = MppHttpTransport::new(client(), url, provider.clone());
+
+        let error = transport.call(request()).await.unwrap_err();
+        assert!(error.to_string().contains("402"));
+        assert_eq!(provider.commits.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.rollbacks.load(Ordering::SeqCst), 1);
+        task.abort();
+    }
+
+    #[test]
+    fn debug_redacts_credentials_and_query() {
+        let transport = MppHttpTransport::new(
+            client(),
+            "https://user:password@example.com/rpc?token=secret"
+                .parse()
+                .unwrap(),
+            MockProvider::default(),
+        );
+        let debug = format!("{transport:?}");
+        assert!(!debug.contains("password"));
+        assert!(!debug.contains("secret"));
+        assert!(debug.contains("https://example.com/rpc"));
+    }
+}

--- a/crates/alloy-transport-mpp/src/lib.rs
+++ b/crates/alloy-transport-mpp/src/lib.rs
@@ -8,12 +8,16 @@ extern crate tracing;
 #[cfg(not(target_family = "wasm"))]
 mod application;
 #[cfg(not(target_family = "wasm"))]
+mod http;
+#[cfg(not(target_family = "wasm"))]
 mod ws;
 #[cfg(not(target_family = "wasm"))]
 pub use application::{
     MppApplicationEvent, MppApplicationHandle, MppApplicationWs, MppApplicationWsConnect,
     MppWsError,
 };
+#[cfg(not(target_family = "wasm"))]
+pub use http::MppHttpTransport;
 #[cfg(not(target_family = "wasm"))]
 pub use ws::{
     CloseProvider, CloseRequest, MppEvent, MppHandle, MppWsConnect, NoVoucher, VoucherProvider,


### PR DESCRIPTION
## What changed

- add `MppHttpTransport<P>` to `alloy-transport-mpp`
- adapt Alloy `RequestPacket`/`ResponsePacket` to the canonical `mpp::client::Fetch` HTTP payment flow
- preserve request headers and JSON-RPC batches
- expose constructors for caller-owned and default Reqwest clients
- redact URL credentials and query parameters from debug output

## Why

Alloy consumers currently have to reimplement the HTTP 402 → challenge selection → payment → authenticated retry → commit/rollback lifecycle. That duplicates `mpp-rs` behavior and can introduce application-specific serialization or lifecycle bugs. This adapter keeps the MPP state machine in `mpp-rs`; integrations only supply a `PaymentProvider` and connect the resulting transport to an Alloy `RpcClient`.

## Validation

- `cargo test -p alloy-transport-mpp --all-features` (46 passed across unit and integration suites)
- `cargo +nightly clippy -p alloy-transport-mpp --all-targets --all-features --no-deps -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

The full workspace feature-combination Clippy invocation still reports six pre-existing warnings in the root `mpp` crate; the changed package itself is warning-clean.