### PR TITLE
fix(alloy): redact request URL secrets

### DIFF
--- a/.changelog/alloy-http-transport.md
+++ b/.changelog/alloy-http-transport.md
@@ -5,4 +5,5 @@
 Add an Alloy HTTP JSON-RPC transport that delegates automatic 402 challenge,
 payment retry, and commit/rollback handling to the canonical MPP client flow,
 with an optional concurrency bound for high-fanout consumers. Preserve
-whitelisted HTTP diagnostics on unsuccessful JSON-RPC responses.
+whitelisted HTTP diagnostics on unsuccessful JSON-RPC responses, and redact URL
+credentials and query parameters from request error reports.

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alloy-transport-mpp"
-description = "Machine Payments Protocol (MPP) transport layer over WebSocket for alloy"
+description = "Machine Payments Protocol (MPP) transports for Alloy HTTP and WebSocket clients"
 version = "0.2.0"
 edition = "2021"
 rust-version = "1.91"

--- a/crates/alloy-transport-mpp/src/http.rs
+++ b/crates/alloy-transport-mpp/src/http.rs
@@ -4,7 +4,7 @@ use std::{fmt, sync::Arc, task};
 
 use alloy_json_rpc::{RequestPacket, ResponsePacket};
 use alloy_transport::{TransportError, TransportErrorKind, TransportFut, TransportResult};
-use mpp::client::{Fetch, PaymentProvider};
+use mpp::client::{Fetch, HttpError, PaymentProvider};
 use reqwest::Url;
 use tokio::sync::Semaphore;
 use tower_service::Service;
@@ -96,6 +96,7 @@ where
         };
         let body = serde_json::to_vec(&packet).map_err(TransportErrorKind::custom)?;
         let headers = packet.headers();
+        let origin = redact_url(&self.url);
         let response = self
             .client
             .post(self.url)
@@ -104,9 +105,17 @@ where
             .body(body)
             .send_with_payment(&self.provider)
             .await
-            .map_err(TransportErrorKind::custom)?;
+            .map_err(|source| TransportErrorKind::custom(MppHttpRequestError { origin, source }))?;
         decode_response(response).await
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("MPP HTTP request to {origin} failed")]
+struct MppHttpRequestError {
+    origin: String,
+    #[source]
+    source: HttpError,
 }
 
 impl<P> Service<RequestPacket> for MppHttpTransport<P>
@@ -440,6 +449,31 @@ mod tests {
         assert!(!error.contains("secret"));
 
         task.abort();
+    }
+
+    #[tokio::test]
+    async fn request_errors_redact_url_credentials_and_query() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+
+        let url = format!("http://user:password@{address}/rpc?api_key=query-secret")
+            .parse()
+            .unwrap();
+        let mut transport = MppHttpTransport::new(client(), url, MockProvider::default());
+
+        let error = transport.call(request()).await.unwrap_err();
+        let report = format!("{error}\n{error:?}");
+        assert!(!report.contains("password"), "password leaked: {report}");
+        assert!(
+            !report.contains("query-secret"),
+            "query secret leaked: {report}"
+        );
+        assert!(!report.contains("api_key"), "query key leaked: {report}");
+        assert!(
+            report.contains(&format!("http://{address}/rpc")),
+            "missing safe origin: {report}"
+        );
     }
 
     #[tokio::test]

--- a/src/client/error.rs
+++ b/src/client/error.rs
@@ -66,8 +66,18 @@ impl From<MppError> for HttpError {
 }
 
 #[cfg(feature = "client")]
+impl HttpError {
+    pub(crate) fn request(error: reqwest::Error) -> Self {
+        // Request URLs commonly carry API keys in query parameters. Reqwest
+        // includes the complete URL in its Display and source chain, so remove
+        // it before the error can reach logs, reports, or client event hooks.
+        Self::Request(error.without_url())
+    }
+}
+
+#[cfg(feature = "client")]
 impl From<reqwest::Error> for HttpError {
     fn from(e: reqwest::Error) -> Self {
-        Self::Request(e)
+        Self::request(e)
     }
 }

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -393,7 +393,7 @@ impl PaymentExt for RequestBuilder {
             resp = match retry.send().await {
                 Ok(resp) => resp,
                 Err(err) => {
-                    let http_err = HttpError::Request(err);
+                    let http_err = HttpError::request(err);
                     events
                         .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
                             challenge: Some(challenge),


### PR DESCRIPTION
## What changed

- remove request URLs from reqwest errors before they enter MPP error reports, source chains, or client events
- have the Alloy HTTP transport report only a sanitized origin with URL userinfo and query parameters removed
- add a regression test covering both Display and Debug/source-chain output
- correct the transport crate description now that it supports both HTTP and WebSocket

## Why

Reqwest includes the full request URL in connection errors. A paid RPC URL such as `https://host/rpc?api_key=secret` therefore exposed query credentials in Cast/Forge stderr even though transport Debug output already redacted them.

## Validation

- `cargo test -p alloy-transport-mpp` (21 unit, 5 application-WS, and 23 WS integration tests passed)
- `cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`