### PR TITLE
chore(tempo): update Accounts store integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "d01d0e267a4cbfbc7a1cd6b05834ec1235303bb4", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]


### PR DESCRIPTION
Pins the Tempo Accounts SDK revision that adds canonical Store.json lifecycle operations for caller-managed access keys.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets --all-features -- -D warnings\n- 1,087 library tests, Alloy transport tests, and WebSocket integration tests passed\n- RPC-backed integration_charge tests require a local Tempo node and were not run successfully in this standalone checkout