### PR TITLE
fix(tempo): share Accounts wallet directory

### DIFF
--- a/src/client/tempo/mod.rs
+++ b/src/client/tempo/mod.rs
@@ -15,24 +15,6 @@ pub use accounts_provider::TempoAccountsProvider;
 pub use autoswap::AutoswapConfig;
 pub use error::TempoClientError;
 
-#[cfg(all(feature = "sqlite", not(windows)))]
-fn default_wallet_directory() -> Option<std::path::PathBuf> {
-    std::env::var_os("HOME")
-        .map(std::path::PathBuf::from)
-        .map(|home| home.join(".tempo").join("wallet"))
-}
-
-#[cfg(all(feature = "sqlite", windows))]
-fn default_wallet_directory() -> Option<std::path::PathBuf> {
-    std::env::var_os("USERPROFILE")
-        .map(std::path::PathBuf::from)
-        .or_else(|| {
-            let drive = std::env::var_os("HOMEDRIVE")?;
-            let path = std::env::var_os("HOMEPATH")?;
-            Some(std::path::PathBuf::from(drive).join(path))
-        })
-        .map(|home| home.join(".tempo").join("wallet"))
-}
 pub use provider::TempoProvider;
 
 /// Build the RPC provider used while preparing Tempo payments.

--- a/src/client/tempo/session/store.rs
+++ b/src/client/tempo/session/store.rs
@@ -229,9 +229,9 @@ mod sqlite {
 
     /// Return the database path shared by Tempo command-line applications.
     pub fn default_channel_database_path() -> ChannelStoreResult<PathBuf> {
-        super::super::super::default_wallet_directory()
-            .map(|directory| directory.join("channels.db"))
-            .ok_or_else(|| ChannelStoreError::Io("home directory is unavailable".into()))
+        tempo_alloy::accounts::default_accounts_store_path()
+            .map(|path| path.with_file_name("channels.db"))
+            .map_err(|error| ChannelStoreError::Io(error.to_string()))
     }
 
     impl SqliteChannelStore {
@@ -627,6 +627,23 @@ pub use sqlite::{default_channel_database_path, Options as SqliteChannelStoreOpt
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn default_database_path_follows_tempo_home() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap();
+        let directory =
+            std::env::temp_dir().join(format!("mpp-rs-tempo-home-{}", uuid::Uuid::new_v4()));
+        let previous = std::env::var_os("TEMPO_HOME");
+        std::env::set_var("TEMPO_HOME", &directory);
+        let actual = default_channel_database_path().unwrap();
+        match previous {
+            Some(value) => std::env::set_var("TEMPO_HOME", value),
+            None => std::env::remove_var("TEMPO_HOME"),
+        }
+        assert_eq!(actual, directory.join("wallet/channels.db"));
+    }
 
     fn entry() -> StoredChannelEntry {
         StoredChannelEntry {


### PR DESCRIPTION
Use alloy-tempo’s canonical Accounts store path when deriving the default `channels.db` location. This makes MPP session persistence honor `TEMPO_HOME` and keeps channel state beside `wallet/store.json` across platforms.

Validation:
- `cargo fmt --all -- --check`
- focused `TEMPO_HOME` regression test
- all-target/all-feature Clippy with warnings denied