### PR TITLE
chore: batch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,20 @@
 version: 2
+
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
-    groups:
-      rust-deps:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    cooldown:
-      default-days: 7
-    groups:
-      actions:
-        patterns: ["*"]
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,12 @@ updates:
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "weekly-dependencies"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     patterns: ["*"]
     multi-ecosystem-group: "weekly-dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,16 @@
+name: Dependabot
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions: {}
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@1d20c6f032568c0aea39c0e7e57e4ba350516281

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,4 +13,4 @@ jobs:
       checks: read
       contents: write
       pull-requests: write
-    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@a3e10e71acb070d4c69c133ea97cb1e29ff24ac6
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@b7a4a46ce767748c34d9a02fd221e6245298e4d2

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,7 +1,7 @@
 name: Dependabot
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions: {}
@@ -13,4 +13,4 @@ jobs:
       checks: read
       contents: write
       pull-requests: write
-    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@1d20c6f032568c0aea39c0e7e57e4ba350516281
+    uses: tempoxyz/mpp-tools/.github/workflows/dependabot.yml@a3e10e71acb070d4c69c133ea97cb1e29ff24ac6


### PR DESCRIPTION
## Motivation

Routine Cargo and GitHub Actions updates currently arrive as separate pull requests and require repetitive merge handling.

## Summary

- Batch routine Cargo and GitHub Actions updates into one weekly pull request
- Call the reusable Dependabot workflow from tempoxyz/mpp-tools#67 at an exact commit
- Automatically squash-merge patch and minor updates after every pull request check passes
- Keep major updates manual and security updates independent of the weekly version-update schedule

## Key design considerations

- Pin the shared workflow to commit `1d20c6f032568c0aea39c0e7e57e4ba350516281`
- Keep merge policy centralized in `mpp-tools`
- Depend on tempoxyz/mpp-tools#67