### PR TITLE
feat: add provider-neutral Reqwest TLS feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ ws = ["server", "client", "dep:tokio-tungstenite", "dep:futures-util"]
 reqwest-default-tls = ["reqwest?/default-tls"]
 reqwest-native-tls = ["reqwest?/native-tls"]
 reqwest-rustls-tls = ["reqwest?/rustls"]
+reqwest-rustls-tls-no-provider = ["reqwest?/rustls-no-provider"]
 
 # Integration tests (requires a running Tempo localnet)
 integration = ["tempo", "server", "client", "axum"]


### PR DESCRIPTION
## Summary

Add a `reqwest-rustls-tls-no-provider` feature that forwards to Reqwest's provider-neutral Rustls integration.

The existing `reqwest-rustls-tls` feature remains unchanged. Applications with a shared Rustls graph can now select exactly one process-level provider themselves instead of having MPP force AWS-LC.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --no-default-features --features client,tempo,reqwest-rustls-tls-no-provider`
