### PR TITLE
feat(client): support preferred challenge selection

### DIFF
--- a/src/client/challenge_selection.rs
+++ b/src/client/challenge_selection.rs
@@ -16,6 +16,7 @@ pub(crate) fn select_supported_challenge<'a>(
     challenges: &'a [PaymentChallenge],
     ranking_accept: Option<&str>,
     mut supports: impl FnMut(&PaymentChallenge) -> bool,
+    mut select: impl FnMut(&[&'a PaymentChallenge]) -> Option<&'a PaymentChallenge>,
 ) -> Result<&'a PaymentChallenge, ChallengeSelectionError> {
     let ranking_preferences = ranking_accept.and_then(|header| accept_payment::parse(header).ok());
     let supported: Vec<_> = challenges
@@ -28,11 +29,17 @@ pub(crate) fn select_supported_challenge<'a>(
         .filter(|challenge| !challenge.is_expired())
         .collect();
 
-    if let Some(challenge) = select_ranked_challenge(&payable, ranking_preferences.as_deref()) {
-        return Ok(challenge);
+    let payable = rank_challenges(&payable, ranking_preferences.as_deref());
+    if !payable.is_empty() {
+        return select(&payable).ok_or_else(|| {
+            ChallengeSelectionError::NoSupportedChallenge(
+                "provider rejected all supported payment challenges".to_string(),
+            )
+        });
     }
 
-    if let Some(challenge) = select_ranked_challenge(&supported, ranking_preferences.as_deref()) {
+    let supported = rank_challenges(&supported, ranking_preferences.as_deref());
+    if let Some(challenge) = select(&supported) {
         return Err(ChallengeSelectionError::Expired(Box::new(
             challenge.clone(),
         )));
@@ -48,13 +55,16 @@ pub(crate) fn select_supported_challenge<'a>(
     )))
 }
 
-fn select_ranked_challenge<'a>(
+fn rank_challenges<'a>(
     challenges: &[&'a PaymentChallenge],
     preferences: Option<&[Entry]>,
-) -> Option<&'a PaymentChallenge> {
+) -> Vec<&'a PaymentChallenge> {
     match preferences {
-        Some(preferences) => accept_payment::select(challenges, preferences).copied(),
-        None => challenges.first().copied(),
+        Some(preferences) => accept_payment::rank(challenges, preferences)
+            .into_iter()
+            .copied()
+            .collect(),
+        None => challenges.to_vec(),
     }
 }
 
@@ -82,9 +92,12 @@ mod tests {
     fn select_supported_challenge_fails_closed_for_malformed_expiry() {
         let challenges = vec![challenge_with_expires(Some("not-a-date"))];
 
-        let err = select_supported_challenge(&challenges, None, |challenge| {
-            challenge.method.as_str() == "tempo"
-        })
+        let err = select_supported_challenge(
+            &challenges,
+            None,
+            |challenge| challenge.method.as_str() == "tempo",
+            |candidates| candidates.first().copied(),
+        )
         .unwrap_err();
 
         assert!(matches!(err, ChallengeSelectionError::Expired(_)));
@@ -94,11 +107,38 @@ mod tests {
     fn select_supported_challenge_rejects_past_expiry() {
         let challenges = vec![challenge_with_expires(Some("2020-01-01T00:00:00Z"))];
 
-        let err = select_supported_challenge(&challenges, None, |challenge| {
-            challenge.method.as_str() == "tempo"
-        })
+        let err = select_supported_challenge(
+            &challenges,
+            None,
+            |challenge| challenge.method.as_str() == "tempo",
+            |candidates| candidates.first().copied(),
+        )
         .unwrap_err();
 
         assert!(matches!(err, ChallengeSelectionError::Expired(_)));
+    }
+
+    #[test]
+    fn provider_selects_between_equivalent_supported_challenges() {
+        let challenges = vec![
+            challenge_with_expires(None),
+            PaymentChallenge::new(
+                "challenge-preferred",
+                "api.example.com",
+                "tempo",
+                "charge",
+                Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap(),
+            ),
+        ];
+
+        let selected = select_supported_challenge(
+            &challenges,
+            None,
+            |_| true,
+            |candidates| candidates.get(1).copied(),
+        )
+        .unwrap();
+
+        assert_eq!(selected.id, "challenge-preferred");
     }
 }

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -296,44 +296,46 @@ async fn send_with_payment<P: PaymentProvider>(
             .filter_map(|r| r.ok())
             .collect();
 
-        let challenge =
-            match select_supported_challenge(&challenges, ranking_accept.as_deref(), |challenge| {
-                provider.supports(challenge.method.as_str(), challenge.intent.as_str())
-            }) {
-                Ok(challenge) => challenge.clone(),
-                Err(ChallengeSelectionError::Expired(challenge)) => {
-                    let err = HttpError::Payment(expired_payment_error(&challenge));
-                    let error = err.to_string();
-                    let expires = challenge.expires.clone();
-                    events
-                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: Some(*challenge),
-                            error,
-                            reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
-                        }))
-                        .await;
-                    pending_payments
-                        .rollback()
-                        .await
-                        .map_err(HttpError::Payment)?;
-                    return Err(err);
-                }
-                Err(ChallengeSelectionError::NoSupportedChallenge(message)) => {
-                    let err = HttpError::NoSupportedChallenge(message);
-                    events
-                        .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
-                            challenge: None,
-                            error: err.to_string(),
-                            reason: None,
-                        }))
-                        .await;
-                    pending_payments
-                        .rollback()
-                        .await
-                        .map_err(HttpError::Payment)?;
-                    return Err(err);
-                }
-            };
+        let challenge = match select_supported_challenge(
+            &challenges,
+            ranking_accept.as_deref(),
+            |challenge| provider.supports(challenge.method.as_str(), challenge.intent.as_str()),
+            |challenges| provider.select_challenge(challenges),
+        ) {
+            Ok(challenge) => challenge.clone(),
+            Err(ChallengeSelectionError::Expired(challenge)) => {
+                let err = HttpError::Payment(expired_payment_error(&challenge));
+                let error = err.to_string();
+                let expires = challenge.expires.clone();
+                events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: Some(*challenge),
+                        error,
+                        reason: Some(PaymentFailureReason::PreSigningExpired { expires }),
+                    }))
+                    .await;
+                pending_payments
+                    .rollback()
+                    .await
+                    .map_err(HttpError::Payment)?;
+                return Err(err);
+            }
+            Err(ChallengeSelectionError::NoSupportedChallenge(message)) => {
+                let err = HttpError::NoSupportedChallenge(message);
+                events
+                    .emit(ClientEvent::PaymentFailed(PaymentFailedContext {
+                        challenge: None,
+                        error: err.to_string(),
+                        reason: None,
+                    }))
+                    .await;
+                pending_payments
+                    .rollback()
+                    .await
+                    .map_err(HttpError::Payment)?;
+                return Err(err);
+            }
+        };
 
         let Some(url) = url.clone() else {
             pending_payments

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -247,6 +247,7 @@ where
                     self.provider
                         .supports(challenge.method.as_str(), challenge.intent.as_str())
                 },
+                |challenges| self.provider.select_challenge(challenges),
             ) {
                 Ok(challenge) => challenge.clone(),
                 Err(ChallengeSelectionError::Expired(challenge)) => {

--- a/src/client/provider.rs
+++ b/src/client/provider.rs
@@ -68,6 +68,20 @@ pub trait PaymentProvider: Clone + Send + Sync {
     /// `true` if this provider can handle the combination.
     fn supports(&self, method: &str, intent: &str) -> bool;
 
+    /// Select one challenge from the supported, unexpired candidates.
+    ///
+    /// Candidates have already been ordered by the caller's `Accept-Payment`
+    /// preferences. The default preserves that order. Providers may override
+    /// this to choose between otherwise equivalent offers using complete
+    /// challenge details such as currency, chain, or amount. Returning `None`
+    /// rejects every candidate.
+    fn select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge> {
+        challenges.first().copied()
+    }
+
     /// Execute payment for the given challenge and return a credential.
     ///
     /// This method should:
@@ -300,6 +314,25 @@ impl PaymentProvider for MultiProvider {
         self.has_support(method, intent)
     }
 
+    fn select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge> {
+        let first = challenges.first()?;
+        let provider = self
+            .providers
+            .iter()
+            .find(|provider| provider.dyn_supports(first.method.as_str(), first.intent.as_str()))?;
+        let candidates = challenges
+            .iter()
+            .copied()
+            .filter(|challenge| {
+                provider.dyn_supports(challenge.method.as_str(), challenge.intent.as_str())
+            })
+            .collect::<Vec<_>>();
+        provider.dyn_select_challenge(&candidates)
+    }
+
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
         let method = challenge.method.as_str();
         let intent = challenge.intent.as_str();
@@ -450,6 +483,10 @@ impl PaymentProvider for MultiProvider {
 /// Object-safe version of PaymentProvider for use in MultiProvider.
 trait DynPaymentProvider: Send + Sync {
     fn dyn_supports(&self, method: &str, intent: &str) -> bool;
+    fn dyn_select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge>;
     fn dyn_pay<'a>(
         &'a self,
         challenge: &'a PaymentChallenge,
@@ -489,6 +526,13 @@ trait DynPaymentProvider: Send + Sync {
 impl<P: PaymentProvider + 'static> DynPaymentProvider for P {
     fn dyn_supports(&self, method: &str, intent: &str) -> bool {
         PaymentProvider::supports(self, method, intent)
+    }
+
+    fn dyn_select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge> {
+        PaymentProvider::select_challenge(self, challenges)
     }
 
     fn dyn_pay<'a>(

--- a/src/client/tempo/accounts_provider.rs
+++ b/src/client/tempo/accounts_provider.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use alloy::primitives::Address;
 use tempo_alloy::accounts::{
     TempoAccountsError, TempoAccountsWallet, TempoAuthorizationReservation,
 };
@@ -20,6 +21,7 @@ use crate::{
     client::{PaymentContext, PaymentProvider},
     error::{MppError, ResultExt},
     protocol::core::{PaymentChallenge, PaymentCredential},
+    protocol::intents::ChargeRequest,
     protocol::methods::tempo::network::TempoNetwork as TempoChain,
 };
 
@@ -34,6 +36,7 @@ pub struct TempoAccountsProvider {
     rpc_url: Option<reqwest::Url>,
     client_id: Option<String>,
     autoswap: Option<AutoswapConfig>,
+    preferred_currency: Option<Address>,
     expected_chain_id: Option<u64>,
     pending_authorizations: Arc<Mutex<HashMap<String, TempoAuthorizationReservation>>>,
     session: Option<AccountsSession>,
@@ -59,6 +62,7 @@ impl TempoAccountsProvider {
             rpc_url: None,
             client_id: None,
             autoswap: None,
+            preferred_currency: None,
             expected_chain_id: None,
             pending_authorizations: Arc::new(Mutex::new(HashMap::new())),
             session: None,
@@ -100,6 +104,20 @@ impl TempoAccountsProvider {
     /// Get the autoswap configuration, if set.
     pub fn autoswap(&self) -> Option<&AutoswapConfig> {
         self.autoswap.as_ref()
+    }
+
+    /// Prefer Tempo Charge offers denominated in this currency.
+    ///
+    /// The provider falls back to the protocol-ranked first challenge when a
+    /// matching currency is not offered.
+    pub fn with_preferred_currency(mut self, currency: Address) -> Self {
+        self.preferred_currency = Some(currency);
+        self
+    }
+
+    /// Get the preferred Tempo Charge currency, if configured.
+    pub const fn preferred_currency(&self) -> Option<Address> {
+        self.preferred_currency
     }
 
     fn fee_token(&self) -> Option<alloy::primitives::Address> {
@@ -330,6 +348,35 @@ impl PaymentProvider for TempoAccountsProvider {
                     && self.session.is_some()))
     }
 
+    fn select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge> {
+        let first = challenges.first().copied()?;
+        let Some(preferred_currency) = self.preferred_currency else {
+            return Some(first);
+        };
+        if first.method.as_str() != crate::protocol::methods::tempo::METHOD_NAME
+            || first.intent.as_str() != crate::protocol::methods::tempo::INTENT_CHARGE
+        {
+            return Some(first);
+        }
+        challenges
+            .iter()
+            .copied()
+            .find(|challenge| {
+                challenge.method.as_str() == first.method.as_str()
+                    && challenge.intent.as_str() == first.intent.as_str()
+                    && challenge
+                        .request
+                        .decode::<ChargeRequest>()
+                        .ok()
+                        .and_then(|request| request.currency.parse::<Address>().ok())
+                        == Some(preferred_currency)
+            })
+            .or(Some(first))
+    }
+
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
         if challenge.intent.as_str() == crate::protocol::methods::tempo::INTENT_SESSION {
             return self.configured_session_provider()?.pay(challenge).await;
@@ -530,20 +577,56 @@ mod tests {
     }
 
     fn challenge(amount: &str, fee_payer: bool) -> PaymentChallenge {
+        challenge_with_currency(
+            "challenge-123",
+            amount,
+            fee_payer,
+            "0x20c0000000000000000000000000000000000000",
+        )
+    }
+
+    fn challenge_with_currency(
+        id: &str,
+        amount: &str,
+        fee_payer: bool,
+        currency: &str,
+    ) -> PaymentChallenge {
         let request = Base64UrlJson::from_value(&serde_json::json!({
             "amount": amount,
-            "currency": "0x20c0000000000000000000000000000000000000",
+            "currency": currency,
             "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
             "methodDetails": {"chainId": 4217, "feePayer": fee_payer},
         }))
         .unwrap();
-        PaymentChallenge::new(
-            "challenge-123",
-            "api.example.com",
-            "tempo",
-            "charge",
-            request,
-        )
+        PaymentChallenge::new(id, "api.example.com", "tempo", "charge", request)
+    }
+
+    #[test]
+    fn selects_the_preferred_charge_currency() {
+        let (provider, path, _) = provider();
+        let preferred_currency = Address::repeat_byte(0x33);
+        let first = challenge_with_currency(
+            "first",
+            "1",
+            false,
+            Address::repeat_byte(0x22).to_string().as_str(),
+        );
+        let preferred = challenge_with_currency(
+            "preferred",
+            "1",
+            false,
+            preferred_currency.to_string().as_str(),
+        );
+        let provider = provider.with_preferred_currency(preferred_currency);
+
+        assert_eq!(provider.preferred_currency(), Some(preferred_currency));
+        assert_eq!(
+            provider
+                .select_challenge(&[&first, &preferred])
+                .map(|challenge| challenge.id.as_str()),
+            Some("preferred")
+        );
+        std::fs::remove_file(path).unwrap();
     }
 
     fn assert_accounts_signature(signed: &AASigned, account: Address, key: Address) {


### PR DESCRIPTION
## Summary
- add a provider-level challenge selector after support, expiry, and `Accept-Payment` ranking
- route fetch, middleware, and multi-provider payment flows through the selector
- let `TempoAccountsProvider` prefer a configured charge currency while preserving method/intent priority

This follows MPPX’s post-protocol-ranking `OrderChallenges` pattern and removes the need for consumers to rewrite `WWW-Authenticate` headers to choose among multi-currency offers.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --all-features provider_selects_between_equivalent_supported_challenges`
- `cargo test --all-features selects_the_preferred_charge_currency`
- `cargo clippy --all-features --all-targets -- -D warnings`