### PR TITLE
chore(deps): bump Tempo revision

### DIFF
--- a/.changelog/bump-tempo-769.md
+++ b/.changelog/bump-tempo-769.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Pinned the Tempo dependency to the coordinated 7690815 revision.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]


### PR DESCRIPTION
Update the MPP Tempo dependency to revision 7690815 so downstream consumers can share one Tempo source revision.

Prompted by: @grandizzy

This PR was written primarily by Codex.