### PR TITLE
feat: add split charge validation and Tempo relay

### DIFF
--- a/.changelog/tempo-relay-adapter.md
+++ b/.changelog/tempo-relay-adapter.md
@@ -1,0 +1,5 @@
+---
+mpp: minor
+---
+
+Add separate non-mutating charge validation and terminal broadcast APIs, retaining verification as a compatibility alias and falling back to legacy method implementations. Add `TempoRelayConfig` and `TempoBuilder::relay` for delegating Tempo charge credential validation and finalization to Tempo API or a compatible MPP relay. Relay requests normalize the echoed challenge request, derive deterministic broadcast idempotency keys, validate returned receipts, and hide private relay failures. Add an Axum charge-relay example dogfooded against Tempo Moderato.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "examples/axum-extractor",
   "examples/basic",
   "examples/catalog-client",
+  "examples/charge-relay",
   "examples/session/multi-fetch",
   "examples/session/sse",
   "examples/stripe",
@@ -45,6 +46,7 @@ tempo = [
   "tempo-alloy",
   "dep:async-trait",
   "dep:p256",
+  "dep:reqwest",
   "uuid",
 ]
 stripe = ["dep:reqwest", "reqwest?/form"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   tempo-node:
-    image: ghcr.io/tempoxyz/tempo:latest
+    image: ghcr.io/tempoxyz/tempo:1.8.1
     container_name: tempo-dev-node
     command: >
       node --dev

--- a/examples/charge-relay/Cargo.toml
+++ b/examples/charge-relay/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "charge-relay-example"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "charge-relay-server"
+path = "src/server.rs"
+
+[dependencies]
+mpp = { path = "../..", features = ["server", "tempo"] }
+axum = "0.8"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"

--- a/examples/charge-relay/README.md
+++ b/examples/charge-relay/README.md
@@ -1,0 +1,43 @@
+# Axum Charge Relay
+
+A small Axum API that accepts pathUSD on Tempo Moderato. The server issues MPP
+charges locally, then delegates credential validation and finalization to Tempo
+API's MPP relay.
+
+## Setup
+
+Create a Tempo API key with the `mpp:write` scope and provide it only to the
+server process:
+
+```bash
+export TEMPO_API_KEY=tempo:sk:...
+export TEMPO_API_URL=https://api.tempo.xyz
+export MPP_SECRET_KEY=$(openssl rand -base64 32)
+cargo run -p charge-relay-example --bin charge-relay-server
+```
+
+`TEMPO_API_URL` may target a compatible self-hosted or preview Tempo API.
+`MPP_SECRET_KEY` has a development-only default for local use.
+
+In another terminal, run the basic MPP client against the paid photo route:
+
+```bash
+cargo run -p basic-example --bin basic-client -- http://localhost:5173/api/photo
+```
+
+The flow is:
+
+1. The server returns a `tempo/charge` challenge for pathUSD.
+2. The payer signs a Tempo transaction and returns the MPP credential.
+3. The adapter calls `POST /v1/mpp/validate`, then `POST /v1/mpp/broadcast`.
+4. The relay receipt becomes the `Payment-Receipt` response header.
+
+The handler uses `Mpp::broadcast_credential`, which re-validates before the
+terminal relay call. `Mpp::validate_credential` is also available for advisory,
+non-mutating pre-checks; `verify_credential` remains a compatibility alias for
+the broadcast path.
+
+The relay broadcasts pull credentials. For push credentials, it recognizes the
+already-broadcast transaction and returns its receipt without sending it again.
+Relay failures are converted to payment failures without exposing API keys,
+private relay messages, or relay URLs.

--- a/examples/charge-relay/src/server.rs
+++ b/examples/charge-relay/src/server.rs
@@ -1,0 +1,110 @@
+//! Payment-gated photo API backed by Tempo API's MPP relay.
+
+use axum::{
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Json, Router,
+};
+use mpp::server::{
+    tempo, ChargeOptions, Mpp, TempoChargeMethod, TempoConfig, TempoProvider, TempoRelayConfig,
+};
+use mpp::{format_www_authenticate, parse_authorization, PrivateKeySigner};
+use std::sync::Arc;
+
+type Payment = Mpp<TempoChargeMethod<TempoProvider>>;
+
+#[tokio::main]
+async fn main() {
+    let api_key = std::env::var("TEMPO_API_KEY")
+        .expect("Set TEMPO_API_KEY to a Tempo API key with the mpp:write scope");
+    let api_url =
+        std::env::var("TEMPO_API_URL").unwrap_or_else(|_| "https://api.tempo.xyz".to_string());
+    let rpc_url =
+        std::env::var("RPC_URL").unwrap_or_else(|_| "https://rpc.moderato.tempo.xyz".to_string());
+    let signer = PrivateKeySigner::random();
+    let recipient = signer.address().to_string();
+
+    let payment = Mpp::create(
+        tempo(TempoConfig {
+            recipient: &recipient,
+        })
+        .rpc_url(&rpc_url)
+        .relay(TempoRelayConfig::new(api_key).api_base_url(api_url))
+        .secret_key(
+            &std::env::var("MPP_SECRET_KEY")
+                .unwrap_or_else(|_| "mpp-rs-demo-tempo-api-relay-secret-key".to_string()),
+        ),
+    )
+    .expect("failed to create relay-backed payment handler");
+
+    let app = Router::new()
+        .route("/api/health", get(health))
+        .route("/api/photo", get(photo))
+        .with_state(Arc::new(payment));
+    let port = std::env::var("PORT").unwrap_or_else(|_| "5173".to_string());
+    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{port}"))
+        .await
+        .expect("failed to bind");
+
+    println!("Charge relay API listening on http://localhost:{port}");
+    println!("Recipient: {recipient}");
+    axum::serve(listener, app).await.expect("server error");
+}
+
+async fn health() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+async fn photo(State(payment): State<Arc<Payment>>, headers: HeaderMap) -> impl IntoResponse {
+    if let Some(auth) = headers.get(header::AUTHORIZATION) {
+        if let Ok(credential) = auth
+            .to_str()
+            .map_err(|_| ())
+            .and_then(|value| parse_authorization(value).map_err(|_| ()))
+        {
+            return match payment.broadcast_credential(&credential).await {
+                Ok(receipt) => (
+                    StatusCode::OK,
+                    [("payment-receipt", receipt.to_header().unwrap_or_default())],
+                    Json(serde_json::json!({ "url": "https://picsum.photos/1024/1024" })),
+                )
+                    .into_response(),
+                Err(error) => (
+                    StatusCode::PAYMENT_REQUIRED,
+                    Json(serde_json::json!({ "error": error.to_string() })),
+                )
+                    .into_response(),
+            };
+        }
+    }
+
+    match payment.charge_with_options(
+        "0.01",
+        ChargeOptions {
+            description: Some("Random stock photo"),
+            supported_modes: Some(&["pull"]),
+            ..Default::default()
+        },
+    ) {
+        Ok(challenge) => match format_www_authenticate(&challenge) {
+            Ok(value) => (
+                StatusCode::PAYMENT_REQUIRED,
+                [(header::WWW_AUTHENTICATE, value)],
+                Json(serde_json::json!({ "error": "Payment Required" })),
+            )
+                .into_response(),
+            Err(error) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": error.to_string() })),
+            )
+                .into_response(),
+        },
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error.to_string() })),
+        )
+            .into_response(),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,9 @@ pub use protocol::intents::{
     SessionRequest,
 };
 
+#[cfg(feature = "server")]
+pub use protocol::traits::{ChargeMethod, ChargeValidation, ErrorCode, VerificationError};
+
 // ==================== Alloy Re-exports ====================
 
 #[cfg(feature = "evm")]

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -40,16 +40,18 @@ use tempo_alloy::rpc::TempoTransactionRequest;
 use tempo_alloy::TempoNetwork;
 use tokio::sync::OnceCell;
 
-use crate::protocol::core::{PaymentCredential, Receipt};
+use crate::protocol::core::{ChallengeEcho, PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
-use crate::protocol::traits::{ChargeMethod as ChargeMethodTrait, VerificationError};
+use crate::protocol::traits::{
+    ChargeMethod as ChargeMethodTrait, ChargeValidation, VerificationError,
+};
 use crate::store::Store;
 use crate::tempo::attribution;
 
 use super::transfers::{get_request_transfers, Transfer};
 use super::{
-    network::TempoNetwork as KnownTempoNetwork, proof, TempoChargeExt, CHAIN_ID,
-    DEFAULT_CURRENCY_TESTNET, INTENT_CHARGE, METHOD_NAME,
+    network::TempoNetwork as KnownTempoNetwork, proof, relay::Relay, RelayConfig, TempoChargeExt,
+    CHAIN_ID, DEFAULT_CURRENCY_TESTNET, INTENT_CHARGE, METHOD_NAME,
 };
 
 const MAX_FEE_PAYER_GAS_LIMIT: u64 = 2_000_000;
@@ -579,6 +581,7 @@ pub struct ChargeMethod<P> {
     fee_payer_policy_override: Option<FeePayerPolicyOverride>,
     validate_sender: Option<Arc<ValidateSenderCallback>>,
     fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
+    relay: Option<Relay>,
 }
 
 #[derive(Debug, Clone)]
@@ -696,7 +699,17 @@ where
             fee_payer_policy_override: None,
             validate_sender: None,
             fee_payer_allowed_fee_tokens: None,
+            relay: None,
         }
+    }
+
+    /// Delegate credential validation and finalization to a Tempo API relay.
+    ///
+    /// The relay broadcasts pull credentials and finalizes already-broadcast
+    /// push credentials without submitting them again.
+    pub fn with_relay(mut self, config: RelayConfig) -> crate::error::Result<Self> {
+        self.relay = Some(Relay::new(config)?);
+        Ok(self)
     }
 
     /// Set a callback invoked when a hash-credential transfer's sender differs
@@ -773,8 +786,8 @@ where
         charge: &ChargeRequest,
         source: Option<&str>,
         expected_chain_id: u64,
-        challenge_id: &str,
-        realm: &str,
+        challenge: &ChallengeEcho,
+        reserve: bool,
     ) -> Result<Receipt, VerificationError> {
         // Validate the source before reserving the hash.
         let source_address = parse_hash_credential_source(source, expected_chain_id)?;
@@ -829,15 +842,28 @@ where
         )?;
 
         if charge.memo().is_none() {
-            assert_challenge_bound_memo(&matched_logs, challenge_id, realm)?;
+            assert_challenge_bound_memo(&matched_logs, &challenge.id, &challenge.realm)?;
         }
 
         if let Some(store) = &self.store {
-            let claimed = store
-                .put_if_absent(&replay_key, serde_json::Value::Bool(true))
+            if reserve {
+                let claimed = store
+                    .put_if_absent(&replay_key, serde_json::Value::Bool(true))
+                    .await
+                    .map_err(|e| {
+                        VerificationError::new(format!("Failed to record tx hash: {e}"))
+                    })?;
+                if !claimed {
+                    return Err(VerificationError::new(
+                        "Transaction hash has already been used.",
+                    ));
+                }
+            } else if store
+                .get(&replay_key)
                 .await
-                .map_err(|e| VerificationError::new(format!("Failed to record tx hash: {e}")))?;
-            if !claimed {
+                .map_err(|e| VerificationError::new(format!("Failed to check tx hash: {e}")))?
+                .is_some()
+            {
                 return Err(VerificationError::new(
                     "Transaction hash has already been used.",
                 ));
@@ -873,7 +899,6 @@ where
     /// Validate that a transaction contains all expected payment calls (supports splits).
     ///
     /// Uses order-insensitive matching with memo-specificity sorting.
-    #[cfg(test)]
     fn validate_transaction_transfers(
         &self,
         tx_bytes: &[u8],
@@ -1063,6 +1088,258 @@ where
         }
 
         Ok(None)
+    }
+
+    async fn validate_proof_credential(
+        &self,
+        credential: &PaymentCredential,
+        signature: &str,
+        expected_chain_id: u64,
+    ) -> Result<Address, VerificationError> {
+        let source = credential
+            .source
+            .as_deref()
+            .ok_or_else(|| VerificationError::new("Proof credential must include a source."))?;
+        let parsed_source = proof::parse_proof_source(source)
+            .map_err(|_| VerificationError::new("Proof credential source is invalid."))?;
+
+        if parsed_source.chain_id != expected_chain_id {
+            return Err(VerificationError::new(
+                "Proof credential source is invalid.",
+            ));
+        }
+
+        if !proof::verify_proof(
+            parsed_source.address,
+            expected_chain_id,
+            &credential.challenge.id,
+            &credential.challenge.realm,
+            signature,
+            parsed_source.address,
+        ) {
+            let recovered = proof::recover_proof_signer(
+                parsed_source.address,
+                expected_chain_id,
+                &credential.challenge.id,
+                &credential.challenge.realm,
+                signature,
+            )
+            .map_err(|_| VerificationError::new("Proof signature does not match source."))?;
+
+            let keychain = IAccountKeychain::new(ACCOUNT_KEYCHAIN_ADDRESS, &*self.provider);
+            let key_info = keychain
+                .getKey(parsed_source.address, recovered)
+                .call()
+                .await
+                .map_err(|_| VerificationError::new("Proof signature does not match source."))?;
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            if key_info.expiry == 0 || key_info.isRevoked || key_info.expiry <= now_secs {
+                return Err(VerificationError::new(
+                    "Proof signature does not match source.",
+                ));
+            }
+        }
+
+        Ok(parsed_source.address)
+    }
+
+    async fn reserve_proof_credential(
+        &self,
+        credential: &PaymentCredential,
+        signature: &str,
+        source_address: Address,
+        expected_chain_id: u64,
+    ) -> Result<(), VerificationError> {
+        let Some(store) = &self.store else {
+            return Ok(());
+        };
+        let replay_key =
+            Self::proof_replay_key(credential, signature, source_address, expected_chain_id)?;
+        let reserved = store
+            .put_if_absent(&replay_key, serde_json::Value::Bool(true))
+            .await
+            .map_err(|e| VerificationError::new(format!("Failed to record proof: {e}")))?;
+        if !reserved {
+            return Err(VerificationError::new(
+                "Proof credential has already been used.",
+            ));
+        }
+        Ok(())
+    }
+
+    fn proof_replay_key(
+        credential: &PaymentCredential,
+        signature: &str,
+        source_address: Address,
+        expected_chain_id: u64,
+    ) -> Result<String, VerificationError> {
+        let fingerprint = proof::proof_fingerprint(
+            &credential.challenge.id,
+            source_address,
+            expected_chain_id,
+            signature,
+        )
+        .map_err(|e| VerificationError::new(format!("Failed to record proof: {e}")))?;
+        Ok(format!("mpp:proof:{fingerprint:x}"))
+    }
+
+    fn validate_transaction_credential(
+        &self,
+        signed_tx: &str,
+        charge: &ChargeRequest,
+        expected_chain_id: u64,
+    ) -> Result<Address, VerificationError> {
+        use alloy::eips::Encodable2718;
+
+        let tx_bytes = signed_tx
+            .parse::<Bytes>()
+            .map_err(|e| VerificationError::new(format!("Invalid transaction bytes: {e}")))?;
+        let currency = charge.currency_address().map_err(|e| {
+            VerificationError::new(format!("Invalid currency address in request: {e}"))
+        })?;
+        let expected = Self::expected_transfers(charge)?;
+
+        if charge.fee_payer() {
+            if self.fee_payer_signer.is_none() {
+                return Err(VerificationError::new(
+                    "feePayer requested but fee sponsorship is not configured on this server",
+                ));
+            }
+            let (signed, sender) = self.validate_fee_payer_transaction(&tx_bytes, currency)?;
+            self.validate_transaction_transfers(
+                &signed.encoded_2718(),
+                currency,
+                &expected,
+                expected_chain_id,
+                true,
+            )?;
+            return Ok(sender);
+        }
+
+        self.validate_transaction_transfers(
+            &tx_bytes,
+            currency,
+            &expected,
+            expected_chain_id,
+            false,
+        )?;
+        let signed = tempo_alloy::primitives::AASigned::decode_2718(&mut &tx_bytes[..])
+            .map_err(|e| VerificationError::new(format!("Failed to decode transaction: {e}")))?;
+        signed
+            .recover_signer()
+            .map_err(|e| VerificationError::new(format!("Failed to recover sender: {e}")))
+    }
+
+    async fn validate_local(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> Result<ChargeValidation, VerificationError> {
+        if credential.challenge.method.as_str() != METHOD_NAME {
+            return Err(VerificationError::credential_mismatch(format!(
+                "Method mismatch: expected {METHOD_NAME}, got {}",
+                credential.challenge.method
+            )));
+        }
+        if credential.challenge.intent.as_str() != INTENT_CHARGE {
+            return Err(VerificationError::credential_mismatch(format!(
+                "Intent mismatch: expected {INTENT_CHARGE}, got {}",
+                credential.challenge.intent
+            )));
+        }
+
+        let expected_chain_id = request.chain_id().unwrap_or(CHAIN_ID);
+        let actual_chain_id = *self
+            .cached_chain_id
+            .get_or_try_init(|| async {
+                self.provider.get_chain_id().await.map_err(|e| {
+                    VerificationError::network_error(format!("Failed to fetch chain ID: {e}"))
+                })
+            })
+            .await?;
+        if actual_chain_id != expected_chain_id {
+            return Err(VerificationError::chain_id_mismatch(format!(
+                "Chain ID mismatch: expected {expected_chain_id}, got {actual_chain_id}"
+            )));
+        }
+
+        let payload = credential.charge_payload().map_err(|e| {
+            VerificationError::with_code(
+                format!("Expected charge payload: {e}"),
+                crate::protocol::traits::ErrorCode::InvalidCredential,
+            )
+        })?;
+        let is_zero_amount = request
+            .amount_u256()
+            .map_err(|e| VerificationError::new(format!("Invalid amount in request: {e}")))?
+            .is_zero();
+        if is_zero_amount && !payload.is_proof() {
+            return Err(VerificationError::new(
+                "Zero-amount challenges require a proof credential.",
+            ));
+        }
+
+        let details = if payload.is_hash() {
+            self.verify_hash(
+                payload.tx_hash().unwrap(),
+                request,
+                credential.source.as_deref(),
+                expected_chain_id,
+                &credential.challenge,
+                false,
+            )
+            .await?;
+            serde_json::json!({ "mode": "push" })
+        } else if payload.is_proof() {
+            if !is_zero_amount {
+                return Err(VerificationError::new(
+                    "Proof credentials are only valid for zero-amount challenges.",
+                ));
+            }
+            let sender = self
+                .validate_proof_credential(
+                    credential,
+                    payload.proof_signature().unwrap(),
+                    expected_chain_id,
+                )
+                .await?;
+            if let Some(store) = &self.store {
+                let replay_key = Self::proof_replay_key(
+                    credential,
+                    payload.proof_signature().unwrap(),
+                    sender,
+                    expected_chain_id,
+                )?;
+                if store
+                    .get(&replay_key)
+                    .await
+                    .map_err(|e| VerificationError::new(format!("Failed to check proof: {e}")))?
+                    .is_some()
+                {
+                    return Err(VerificationError::new(
+                        "Proof credential has already been used.",
+                    ));
+                }
+            }
+            serde_json::json!({ "mode": "proof", "sender": format!("{sender:#x}") })
+        } else {
+            let serialized_transaction = payload.signed_tx().unwrap();
+            let sender = self.validate_transaction_credential(
+                serialized_transaction,
+                request,
+                expected_chain_id,
+            )?;
+            serde_json::json!({
+                "mode": "pull",
+                "sender": format!("{sender:#x}"),
+                "serializedTransaction": serialized_transaction,
+            })
+        };
+
+        Ok(ChargeValidation::new(credential, request, details))
     }
 
     async fn broadcast_transaction(
@@ -1315,20 +1592,12 @@ where
         Ok(())
     }
 
-    /// Co-sign a fee payer transaction.
-    ///
-    /// Accepts a `0x78` fee payer envelope, recovers the sender via
-    /// ecrecover, validates fee-payer invariants, then co-signs and
-    /// returns a complete `0x76` transaction ready for broadcast.
-    fn cosign_fee_payer_transaction(
+    fn validate_fee_payer_transaction(
         &self,
         tx_bytes: &[u8],
-        fee_payer_signer: &alloy::signers::local::PrivateKeySigner,
         fee_token: Address,
-    ) -> Result<Vec<u8>, VerificationError> {
+    ) -> Result<(tempo_alloy::primitives::AASigned, Address), VerificationError> {
         use super::fee_payer_envelope::{FeePayerEnvelope78, TEMPO_FEE_PAYER_ENVELOPE_TYPE_ID};
-        use alloy::eips::Encodable2718;
-        use alloy::signers::SignerSync;
         use tempo_alloy::primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
 
         if tx_bytes.is_empty() {
@@ -1454,6 +1723,25 @@ where
             )));
         }
 
+        Ok((signed, sender))
+    }
+
+    /// Co-sign a fee payer transaction.
+    ///
+    /// Accepts a `0x78` fee payer envelope, recovers the sender via
+    /// ecrecover, validates fee-payer invariants, then co-signs and
+    /// returns a complete `0x76` transaction ready for broadcast.
+    fn cosign_fee_payer_transaction(
+        &self,
+        tx_bytes: &[u8],
+        fee_payer_signer: &alloy::signers::local::PrivateKeySigner,
+        fee_token: Address,
+    ) -> Result<Vec<u8>, VerificationError> {
+        use alloy::eips::Encodable2718;
+        use alloy::signers::SignerSync;
+
+        let (signed, sender) = self.validate_fee_payer_transaction(tx_bytes, fee_token)?;
+
         // Rebuild the transaction with fee_token set and real fee_payer_signature
         let (tx, client_signature, _hash) = signed.into_parts();
         let mut tx = tx;
@@ -1503,6 +1791,44 @@ where
         METHOD_NAME
     }
 
+    fn supports_validation(&self) -> bool {
+        true
+    }
+
+    fn validate(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> impl Future<Output = Result<ChargeValidation, VerificationError>> + Send {
+        let relay = self.relay.clone();
+        let this = self.clone();
+        let credential = credential.clone();
+        let request = request.clone();
+        async move {
+            match relay {
+                Some(relay) => relay.validate(&credential, &request).await,
+                None => this.validate_local(&credential, &request).await,
+            }
+        }
+    }
+
+    fn broadcast(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> impl Future<Output = Result<Receipt, VerificationError>> + Send {
+        let this = self.clone();
+        let credential = credential.clone();
+        let request = request.clone();
+        async move {
+            if let Some(relay) = &this.relay {
+                relay.broadcast(&credential, METHOD_NAME).await
+            } else {
+                ChargeMethodTrait::verify(&this, &credential, &request).await
+            }
+        }
+    }
+
     fn verify(
         &self,
         credential: &PaymentCredential,
@@ -1517,8 +1843,14 @@ where
         let fee_payer_policy_override = self.fee_payer_policy_override.clone();
         let validate_sender = self.validate_sender.clone();
         let fee_payer_allowed_fee_tokens = self.fee_payer_allowed_fee_tokens.clone();
+        let relay = self.relay.clone();
 
         async move {
+            if let Some(relay) = relay {
+                relay.validate(&credential, &request).await?;
+                return relay.broadcast(&credential, METHOD_NAME).await;
+            }
+
             let this = ChargeMethod {
                 provider,
                 fee_payer_signer,
@@ -1527,6 +1859,7 @@ where
                 fee_payer_policy_override,
                 validate_sender,
                 fee_payer_allowed_fee_tokens,
+                relay: None,
             };
 
             if credential.challenge.method.as_str() != METHOD_NAME {
@@ -1584,8 +1917,8 @@ where
                     &request,
                     credential.source.as_deref(),
                     expected_chain_id,
-                    &credential.challenge.id,
-                    &credential.challenge.realm,
+                    &credential.challenge,
+                    true,
                 )
                 .await
             } else if charge_payload.is_proof() {
@@ -1595,84 +1928,17 @@ where
                     ));
                 }
 
-                let source = credential.source.as_deref().ok_or_else(|| {
-                    VerificationError::new("Proof credential must include a source.")
-                })?;
-                let parsed_source = proof::parse_proof_source(source)
-                    .map_err(|_| VerificationError::new("Proof credential source is invalid."))?;
-
-                if parsed_source.chain_id != expected_chain_id {
-                    return Err(VerificationError::new(
-                        "Proof credential source is invalid.",
-                    ));
-                }
-
                 let sig_hex = charge_payload.proof_signature().unwrap();
-
-                // Fast path: signer IS the source address (Direct mode).
-                if !proof::verify_proof(
-                    parsed_source.address,
-                    expected_chain_id,
-                    &credential.challenge.id,
-                    &credential.challenge.realm,
+                let source_address = this
+                    .validate_proof_credential(&credential, sig_hex, expected_chain_id)
+                    .await?;
+                this.reserve_proof_credential(
+                    &credential,
                     sig_hex,
-                    parsed_source.address,
-                ) {
-                    // Keychain fallback: signer may be an access key authorized
-                    // for the source wallet. Recover the signer and check on-chain.
-                    let recovered = proof::recover_proof_signer(
-                        parsed_source.address,
-                        expected_chain_id,
-                        &credential.challenge.id,
-                        &credential.challenge.realm,
-                        sig_hex,
-                    )
-                    .map_err(|_| {
-                        VerificationError::new("Proof signature does not match source.")
-                    })?;
-
-                    let keychain = IAccountKeychain::new(ACCOUNT_KEYCHAIN_ADDRESS, &*this.provider);
-                    let key_info = keychain
-                        .getKey(parsed_source.address, recovered)
-                        .call()
-                        .await
-                        .map_err(|_| {
-                            VerificationError::new("Proof signature does not match source.")
-                        })?;
-                    let now_secs = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    if key_info.expiry == 0 || key_info.isRevoked || key_info.expiry <= now_secs {
-                        return Err(VerificationError::new(
-                            "Proof signature does not match source.",
-                        ));
-                    }
-                }
-
-                // Single-use: atomically reserve a canonical credential
-                // fingerprint after verifying.
-                if let Some(store) = &this.store {
-                    let fingerprint = proof::proof_fingerprint(
-                        &credential.challenge.id,
-                        parsed_source.address,
-                        parsed_source.chain_id,
-                        sig_hex,
-                    )
-                    .map_err(|e| VerificationError::new(format!("Failed to record proof: {e}")))?;
-                    let replay_key = format!("mpp:proof:{:x}", fingerprint);
-                    let reserved = store
-                        .put_if_absent(&replay_key, serde_json::Value::Bool(true))
-                        .await
-                        .map_err(|e| {
-                            VerificationError::new(format!("Failed to record proof: {e}"))
-                        })?;
-                    if !reserved {
-                        return Err(VerificationError::new(
-                            "Proof credential has already been used.",
-                        ));
-                    }
-                }
+                    source_address,
+                    expected_chain_id,
+                )
+                .await?;
 
                 Ok(Receipt::success(METHOD_NAME, &credential.challenge.id))
             } else {
@@ -3347,6 +3613,154 @@ mod tests {
         // Replaying the identical credential is rejected.
         let err = method.verify(&credential, &request).await.unwrap_err();
         assert!(err.to_string().contains("already been used"));
+    }
+
+    #[tokio::test]
+    async fn test_proof_validation_does_not_reserve_replay_state() {
+        use crate::store::{MemoryStore, Store};
+
+        let signer = alloy::signers::local::PrivateKeySigner::random();
+        let request = test_charge_request_with_amount("0");
+        let challenge = test_proof_challenge(&request);
+        let signature = proof::sign_proof(
+            &signer,
+            signer.address(),
+            42431,
+            &challenge.id,
+            &challenge.realm,
+        )
+        .await
+        .unwrap();
+        let credential = PaymentCredential::with_source(
+            challenge.to_echo(),
+            proof::proof_source(signer.address(), 42431),
+            crate::protocol::core::PaymentPayload::proof(signature.clone()),
+        );
+
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let store = Arc::new(MemoryStore::new());
+        let method = ChargeMethod::new(provider).with_store(store.clone());
+        method.cached_chain_id.set(42431).unwrap();
+
+        let validation = ChargeMethodTrait::validate(&method, &credential, &request)
+            .await
+            .unwrap();
+        assert_eq!(validation.details["mode"], "proof");
+
+        let fingerprint =
+            proof::proof_fingerprint(&challenge.id, signer.address(), 42431, &signature).unwrap();
+        let key = format!("mpp:proof:{:x}", fingerprint);
+        assert!(store.get(&key).await.unwrap().is_none());
+
+        let receipt = ChargeMethodTrait::broadcast(&method, &credential, &request)
+            .await
+            .unwrap();
+        assert_eq!(receipt.reference, challenge.id);
+        assert!(store.get(&key).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_local_validation_rejects_invalid_credentials_before_broadcast() {
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider);
+        method.cached_chain_id.set(42431).unwrap();
+
+        let zero_request = test_charge_request_with_amount("0");
+        let paid_request = test_charge_request_with_amount("1");
+
+        let mut wrong_method = test_proof_challenge(&zero_request).to_echo();
+        wrong_method.method = "stripe".into();
+        let mut wrong_intent = test_proof_challenge(&zero_request).to_echo();
+        wrong_intent.intent = "session".into();
+        let mut wrong_chain_request = zero_request.clone();
+        wrong_chain_request.method_details = Some(serde_json::json!({ "chainId": 1 }));
+
+        let cases = vec![
+            (
+                "method",
+                PaymentCredential::new(
+                    wrong_method,
+                    crate::protocol::core::PaymentPayload::proof("0x00"),
+                ),
+                zero_request.clone(),
+                "Method mismatch",
+            ),
+            (
+                "intent",
+                PaymentCredential::new(
+                    wrong_intent,
+                    crate::protocol::core::PaymentPayload::proof("0x00"),
+                ),
+                zero_request.clone(),
+                "Intent mismatch",
+            ),
+            (
+                "chain",
+                PaymentCredential::new(
+                    test_proof_challenge(&wrong_chain_request).to_echo(),
+                    crate::protocol::core::PaymentPayload::proof("0x00"),
+                ),
+                wrong_chain_request,
+                "Chain ID mismatch",
+            ),
+            (
+                "zero-hash",
+                PaymentCredential::new(
+                    test_proof_challenge(&zero_request).to_echo(),
+                    crate::protocol::core::PaymentPayload::hash("0x00"),
+                ),
+                zero_request.clone(),
+                "Zero-amount challenges require a proof credential",
+            ),
+            (
+                "positive-proof",
+                PaymentCredential::new(
+                    test_proof_challenge(&paid_request).to_echo(),
+                    crate::protocol::core::PaymentPayload::proof("0x00"),
+                ),
+                paid_request.clone(),
+                "Proof credentials are only valid for zero-amount challenges",
+            ),
+            (
+                "proof-source",
+                PaymentCredential::with_source(
+                    test_proof_challenge(&zero_request).to_echo(),
+                    "invalid-source",
+                    crate::protocol::core::PaymentPayload::proof("0x00"),
+                ),
+                zero_request.clone(),
+                "Proof credential source is invalid",
+            ),
+            (
+                "transaction",
+                PaymentCredential::new(
+                    test_proof_challenge(&paid_request).to_echo(),
+                    crate::protocol::core::PaymentPayload::transaction("not-hex"),
+                ),
+                paid_request.clone(),
+                "Invalid transaction bytes",
+            ),
+            (
+                "hash",
+                PaymentCredential::new(
+                    test_proof_challenge(&paid_request).to_echo(),
+                    crate::protocol::core::PaymentPayload::hash("not-hex"),
+                ),
+                paid_request,
+                "Invalid transaction hash",
+            ),
+        ];
+
+        for (name, credential, request, expected) in cases {
+            let error = ChargeMethodTrait::validate(&method, &credential, &request)
+                .await
+                .unwrap_err();
+            assert!(error.message.contains(expected), "{name}: {error}");
+        }
     }
 
     #[tokio::test]

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -114,6 +114,8 @@ pub mod voucher;
 #[cfg(feature = "server")]
 pub mod method;
 #[cfg(feature = "server")]
+pub mod relay;
+#[cfg(feature = "server")]
 pub mod session_method;
 
 pub use charge::TempoChargeExt;
@@ -147,6 +149,8 @@ pub use voucher::{compute_channel_id, sign_voucher, DOMAIN_NAME, DOMAIN_VERSION}
 
 #[cfg(feature = "server")]
 pub use method::{ChargeMethod, FeePayerPolicy, FeePayerPolicyOverride};
+#[cfg(feature = "server")]
+pub use relay::{RelayConfig, RelayErrorCode};
 #[cfg(feature = "server")]
 pub use session_method::{
     ChannelState, ChannelStore, InMemoryChannelStore, SessionMethod, SessionMethodConfig,

--- a/src/protocol/methods/tempo/relay.rs
+++ b/src/protocol/methods/tempo/relay.rs
@@ -1,0 +1,944 @@
+//! Tempo API MPP relay adapter.
+
+use alloy::primitives::keccak256;
+use reqwest::{Client, Url};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use time::format_description::well_known::Rfc3339;
+
+use crate::error::MppError;
+use crate::protocol::core::{PaymentCredential, Receipt, ReceiptStatus};
+use crate::protocol::intents::ChargeRequest;
+use crate::protocol::traits::{ChargeValidation, VerificationError};
+
+const DEFAULT_API_BASE_URL: &str = "https://api.tempo.xyz";
+
+/// Configuration for Tempo API's MPP relay.
+#[derive(Clone)]
+pub struct RelayConfig {
+    api_key: String,
+    api_base_url: String,
+    client: Client,
+}
+
+impl RelayConfig {
+    /// Create relay configuration using `https://api.tempo.xyz`.
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            api_base_url: DEFAULT_API_BASE_URL.to_string(),
+            client: Client::new(),
+        }
+    }
+
+    /// Override the Tempo API base URL, including an optional path prefix.
+    #[must_use]
+    pub fn api_base_url(mut self, api_base_url: impl Into<String>) -> Self {
+        self.api_base_url = api_base_url.into();
+        self
+    }
+
+    /// Use a custom HTTP client.
+    #[must_use]
+    pub fn client(mut self, client: Client) -> Self {
+        self.client = client;
+        self
+    }
+}
+
+impl std::fmt::Debug for RelayConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayConfig")
+            .field("api_key", &"[REDACTED]")
+            .field("api_base_url", &self.api_base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Stable machine-readable failure codes returned by Tempo API's MPP relay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RelayErrorCode {
+    AlreadyUsed,
+    BroadcastFailed,
+    Expired,
+    InvalidPayment,
+    InsufficientFunds,
+    PolicyDenied,
+    ScreenRejected,
+    SimulationFailed,
+    TemporarilyUnavailable,
+    Unsupported,
+    Unknown,
+}
+
+impl RelayErrorCode {
+    /// Return the relay's wire-format code.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AlreadyUsed => "already_used",
+            Self::BroadcastFailed => "broadcast_failed",
+            Self::Expired => "expired",
+            Self::InvalidPayment => "invalid_payment",
+            Self::InsufficientFunds => "insufficient_funds",
+            Self::PolicyDenied => "policy_denied",
+            Self::ScreenRejected => "screen_rejected",
+            Self::SimulationFailed => "simulation_failed",
+            Self::TemporarilyUnavailable => "temporarily_unavailable",
+            Self::Unsupported => "unsupported",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "already_used" => Self::AlreadyUsed,
+            "broadcast_failed" => Self::BroadcastFailed,
+            "expired" => Self::Expired,
+            "invalid_payment" => Self::InvalidPayment,
+            "insufficient_funds" => Self::InsufficientFunds,
+            "policy_denied" => Self::PolicyDenied,
+            "screen_rejected" => Self::ScreenRejected,
+            "simulation_failed" => Self::SimulationFailed,
+            "temporarily_unavailable" => Self::TemporarilyUnavailable,
+            "unsupported" => Self::Unsupported,
+            "unknown" => Self::Unknown,
+            _ => return None,
+        })
+    }
+
+    fn is_safe(self) -> bool {
+        matches!(
+            self,
+            Self::AlreadyUsed
+                | Self::BroadcastFailed
+                | Self::InvalidPayment
+                | Self::InsufficientFunds
+                | Self::SimulationFailed
+                | Self::TemporarilyUnavailable
+                | Self::Unsupported
+        )
+    }
+}
+
+impl std::fmt::Display for RelayErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Relay {
+    api_key: String,
+    api_base_url: Url,
+    client: Client,
+}
+
+impl Relay {
+    pub(crate) fn new(config: RelayConfig) -> crate::error::Result<Self> {
+        if config.api_key.trim().is_empty() {
+            return Err(MppError::InvalidConfig(
+                "Tempo relay API key must not be empty".to_string(),
+            ));
+        }
+
+        let mut api_base_url = Url::parse(&config.api_base_url).map_err(|error| {
+            MppError::InvalidConfig(format!("invalid Tempo relay API base URL: {error}"))
+        })?;
+        if !api_base_url.path().ends_with('/') {
+            let path = format!("{}/", api_base_url.path());
+            api_base_url.set_path(&path);
+        }
+
+        Ok(Self {
+            api_key: config.api_key,
+            api_base_url,
+            client: config.client,
+        })
+    }
+
+    pub(crate) async fn validate(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> Result<ChargeValidation, VerificationError> {
+        let input = RelayInput::try_from(credential)?;
+        let response = self.post("v1/mpp/validate", &input, None).await?;
+        if !is_success(&response) {
+            return Err(failure(Some(&response)));
+        }
+
+        Ok(ChargeValidation::new(
+            credential,
+            request,
+            serde_json::json!({}),
+        ))
+    }
+
+    pub(crate) async fn broadcast(
+        &self,
+        credential: &PaymentCredential,
+        expected_method: &str,
+    ) -> Result<Receipt, VerificationError> {
+        let input = RelayInput::try_from(credential)?;
+        let key = idempotency_key(&input)?;
+        let broadcast = self.post("v1/mpp/broadcast", &input, Some(&key)).await?;
+        let response: BroadcastSuccess =
+            serde_json::from_value(broadcast.clone()).map_err(|_| failure(Some(&broadcast)))?;
+        if !response.success || response.receipt.method != expected_method {
+            return Err(failure(Some(&broadcast)));
+        }
+        time::OffsetDateTime::parse(&response.receipt.timestamp, &Rfc3339)
+            .map_err(|_| failure(Some(&broadcast)))?;
+
+        Ok(Receipt {
+            status: ReceiptStatus::Success,
+            method: response.receipt.method.into(),
+            timestamp: response.receipt.timestamp,
+            reference: response.receipt.reference,
+            external_id: response.receipt.external_id,
+            subscription_id: None,
+            extensions: serde_json::Map::new(),
+        })
+    }
+
+    async fn post(
+        &self,
+        path: &str,
+        input: &RelayInput<'_>,
+        idempotency_key: Option<&str>,
+    ) -> Result<serde_json::Value, VerificationError> {
+        let url = self.api_base_url.join(path).map_err(|_| failure(None))?;
+        let mut request = self
+            .client
+            .post(url)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header("tempo-api-key", &self.api_key)
+            .json(input);
+        if let Some(idempotency_key) = idempotency_key {
+            request = request.header("idempotency-key", idempotency_key);
+        }
+
+        let response = request.send().await.map_err(|_| failure(None))?;
+        if !response.status().is_success() {
+            return Err(failure(None));
+        }
+        response
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|_| failure(None))
+    }
+}
+
+#[derive(Serialize)]
+struct RelayInput<'a> {
+    challenge: RelayChallenge<'a>,
+    payload: &'a serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct RelayChallenge<'a> {
+    id: &'a str,
+    realm: &'a str,
+    method: &'a crate::protocol::core::MethodName,
+    intent: &'a crate::protocol::core::IntentName,
+    request: serde_json::Map<String, serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    digest: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opaque: Option<&'a str>,
+}
+
+impl<'a> TryFrom<&'a PaymentCredential> for RelayInput<'a> {
+    type Error = VerificationError;
+
+    fn try_from(credential: &'a PaymentCredential) -> Result<Self, Self::Error> {
+        let request = credential
+            .challenge
+            .request
+            .decode_value()
+            .map_err(|_| failure(None))?
+            .as_object()
+            .cloned()
+            .ok_or_else(|| failure(None))?;
+
+        Ok(Self {
+            challenge: RelayChallenge {
+                id: &credential.challenge.id,
+                realm: &credential.challenge.realm,
+                method: &credential.challenge.method,
+                intent: &credential.challenge.intent,
+                request,
+                expires: credential.challenge.expires.as_deref(),
+                digest: credential.challenge.digest.as_deref(),
+                opaque: credential
+                    .challenge
+                    .opaque
+                    .as_ref()
+                    .map(|value| value.raw()),
+            },
+            payload: &credential.payload,
+            source: credential.source.as_deref(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct BroadcastSuccess {
+    success: bool,
+    receipt: RelayReceipt,
+}
+
+#[derive(Deserialize)]
+struct RelayReceipt {
+    #[serde(rename = "externalId")]
+    external_id: Option<String>,
+    method: String,
+    reference: String,
+    timestamp: String,
+}
+
+fn is_success(value: &serde_json::Value) -> bool {
+    value.get("success").and_then(serde_json::Value::as_bool) == Some(true)
+}
+
+fn relay_error_code(value: &serde_json::Value) -> Option<RelayErrorCode> {
+    value
+        .get("error")?
+        .get("code")?
+        .as_str()
+        .and_then(RelayErrorCode::parse)
+}
+
+fn failure(value: Option<&serde_json::Value>) -> VerificationError {
+    let code = value.and_then(relay_error_code);
+    match code {
+        Some(RelayErrorCode::Expired) => VerificationError::expired("Payment has expired."),
+        Some(RelayErrorCode::TemporarilyUnavailable) => {
+            VerificationError::network_error("Tempo API relay temporarily unavailable")
+        }
+        Some(code) if code.is_safe() => VerificationError::new(format!(
+            "Tempo API relay rejected credential ({})",
+            code.as_str()
+        )),
+        _ => VerificationError::new("Tempo API relay rejected credential"),
+    }
+}
+
+fn idempotency_key(input: &RelayInput<'_>) -> Result<String, VerificationError> {
+    if input
+        .payload
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        == Some("transaction")
+    {
+        if let Some(signature) = input
+            .payload
+            .get("signature")
+            .and_then(serde_json::Value::as_str)
+        {
+            if let Ok(bytes) = hex::decode(signature.strip_prefix("0x").unwrap_or(signature)) {
+                return Ok(format!("mppx_{:#x}", keccak256(bytes)));
+            }
+        }
+    }
+
+    let canonical = serde_json_canonicalizer::to_string(input).map_err(|_| failure(None))?;
+    let digest = Sha256::digest(canonical.as_bytes());
+    Ok(format!("mppx_0x{}", hex::encode(digest)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::core::{Base64UrlJson, ChallengeEcho, PaymentPayload};
+    use crate::protocol::methods::tempo::ChargeMethod as TempoChargeMethod;
+    use crate::protocol::traits::ChargeMethod as _;
+    use crate::server::Mpp;
+    use axum::{
+        extract::{OriginalUri, State},
+        http::{HeaderMap, StatusCode},
+        routing::post,
+        Json, Router,
+    };
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[derive(Clone)]
+    struct MockState {
+        calls: Arc<Mutex<Vec<MockCall>>>,
+        responses: Arc<Mutex<VecDeque<(StatusCode, serde_json::Value)>>>,
+    }
+
+    struct MockCall {
+        body: serde_json::Value,
+        headers: HeaderMap,
+        path: String,
+    }
+
+    fn credential(payload: PaymentPayload) -> PaymentCredential {
+        PaymentCredential::new(
+            ChallengeEcho {
+                id: "challenge-id".into(),
+                realm: "relay.example".into(),
+                method: "tempo".into(),
+                intent: "charge".into(),
+                request: Base64UrlJson::from_raw("e30"),
+                expires: Some("2099-01-01T00:00:00Z".into()),
+                digest: None,
+                opaque: None,
+            },
+            payload,
+        )
+    }
+
+    fn bound_credential(secret_key: &str, payload: PaymentPayload) -> PaymentCredential {
+        let request = ChargeRequest {
+            amount: "1".into(),
+            currency: "0x1".into(),
+            ..Default::default()
+        };
+        let encoded = Base64UrlJson::from_typed(&request).unwrap();
+        let expires = "2099-01-01T00:00:00Z";
+        let id = crate::protocol::core::compute_challenge_id(
+            secret_key,
+            "relay.example",
+            "tempo",
+            "charge",
+            encoded.raw(),
+            Some(expires),
+            None,
+            None,
+        );
+        PaymentCredential::new(
+            ChallengeEcho {
+                id,
+                realm: "relay.example".into(),
+                method: "tempo".into(),
+                intent: "charge".into(),
+                request: encoded,
+                expires: Some(expires.into()),
+                digest: None,
+                opaque: None,
+            },
+            payload,
+        )
+    }
+
+    #[test]
+    fn transaction_idempotency_key_uses_transaction_hash() {
+        let credential = credential(PaymentPayload::transaction("0x1234"));
+        let input = RelayInput::try_from(&credential).unwrap();
+        assert_eq!(
+            idempotency_key(&input).unwrap(),
+            format!("mppx_{:#x}", keccak256([0x12, 0x34]))
+        );
+    }
+
+    #[test]
+    fn non_transaction_idempotency_key_is_canonical_and_deterministic() {
+        let credential = credential(PaymentPayload::hash("0x1234"));
+        let input = RelayInput::try_from(&credential).unwrap();
+        let first = idempotency_key(&input).unwrap();
+        let second = idempotency_key(&input).unwrap();
+        assert_eq!(first, second);
+        assert!(first.starts_with("mppx_0x"));
+        assert_eq!(first.len(), "mppx_0x".len() + 64);
+    }
+
+    #[test]
+    fn invalid_transaction_signature_uses_canonical_idempotency_fallback() {
+        let credential = credential(PaymentPayload::transaction("not-hex"));
+        let input = RelayInput::try_from(&credential).unwrap();
+        let key = idempotency_key(&input).unwrap();
+
+        assert!(key.starts_with("mppx_0x"));
+        assert_eq!(key.len(), "mppx_0x".len() + 64);
+    }
+
+    #[test]
+    fn relay_input_rejects_invalid_or_non_object_challenge_requests() {
+        for request in ["not-base64", "W10"] {
+            let mut credential = credential(PaymentPayload::hash("0x1234"));
+            credential.challenge.request = Base64UrlJson::from_raw(request);
+
+            assert!(RelayInput::try_from(&credential).is_err(), "{request}");
+        }
+    }
+
+    #[test]
+    fn relay_configuration_redacts_api_key() {
+        let debug = format!("{:?}", RelayConfig::new("top-secret"));
+        assert!(!debug.contains("top-secret"));
+        assert!(debug.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn relay_configuration_accepts_custom_client() {
+        let config = RelayConfig::new("key").client(Client::new());
+
+        assert!(Relay::new(config).is_ok());
+    }
+
+    #[test]
+    fn relay_error_codes_round_trip_through_public_strings() {
+        let cases = [
+            (RelayErrorCode::AlreadyUsed, "already_used"),
+            (RelayErrorCode::BroadcastFailed, "broadcast_failed"),
+            (RelayErrorCode::Expired, "expired"),
+            (RelayErrorCode::InvalidPayment, "invalid_payment"),
+            (RelayErrorCode::InsufficientFunds, "insufficient_funds"),
+            (RelayErrorCode::PolicyDenied, "policy_denied"),
+            (RelayErrorCode::ScreenRejected, "screen_rejected"),
+            (RelayErrorCode::SimulationFailed, "simulation_failed"),
+            (
+                RelayErrorCode::TemporarilyUnavailable,
+                "temporarily_unavailable",
+            ),
+            (RelayErrorCode::Unsupported, "unsupported"),
+            (RelayErrorCode::Unknown, "unknown"),
+        ];
+
+        for (code, wire) in cases {
+            assert_eq!(code.as_str(), wire);
+            assert_eq!(code.to_string(), wire);
+            assert_eq!(RelayErrorCode::parse(wire), Some(code));
+        }
+        assert_eq!(RelayErrorCode::parse("future_code"), None);
+    }
+
+    #[test]
+    fn relay_input_normalizes_a_valid_credential() {
+        let credential = credential(PaymentPayload::hash("0x1234"));
+
+        let input = RelayInput::try_from(&credential).unwrap();
+
+        assert_eq!(input.challenge.id, "challenge-id");
+        assert!(input.challenge.request.is_empty());
+        assert_eq!(input.payload["type"], "hash");
+        assert!(input.source.is_none());
+    }
+
+    #[test]
+    fn relay_configuration_rejects_invalid_values() {
+        for config in [
+            RelayConfig::new(""),
+            RelayConfig::new("key").api_base_url("://bad"),
+        ] {
+            assert!(Relay::new(config).is_err());
+        }
+    }
+
+    #[test]
+    fn relay_error_mapping_hides_private_messages() {
+        let cases = [
+            ("already_used", true, false),
+            ("broadcast_failed", true, false),
+            ("expired", true, false),
+            ("invalid_payment", true, false),
+            ("insufficient_funds", true, false),
+            ("policy_denied", false, false),
+            ("screen_rejected", false, false),
+            ("simulation_failed", true, false),
+            ("temporarily_unavailable", false, true),
+            ("unsupported", true, false),
+            ("unknown", false, false),
+            ("future_private_code", false, false),
+        ];
+
+        for (code, exposes_code, retryable) in cases {
+            let value = serde_json::json!({
+                "success": false,
+                "error": { "code": code, "message": "private detail" }
+            });
+            let error = failure(Some(&value));
+
+            assert_eq!(error.retryable, retryable, "{code}");
+            assert_eq!(error.message.contains(code), exposes_code, "{code}");
+            assert!(!error.message.contains("private detail"), "{code}");
+            if code == "expired" {
+                assert_eq!(
+                    error.code,
+                    Some(crate::protocol::traits::ErrorCode::Expired)
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn relay_validate_and_broadcast_are_separate() {
+        let (base_url, calls) = spawn_relay([
+            (StatusCode::OK, serde_json::json!({ "success": true })),
+            (
+                StatusCode::OK,
+                serde_json::json!({
+                    "success": true,
+                    "receipt": {
+                        "externalId": "invoice-1",
+                        "method": "tempo",
+                        "reference": "0xreceipt",
+                        "timestamp": "2026-08-03T12:00:00Z"
+                    }
+                }),
+            ),
+        ])
+        .await;
+        let relay =
+            Relay::new(RelayConfig::new("test-api-key").api_base_url(format!("{base_url}/prefix")))
+                .unwrap();
+        let mut credential = credential(PaymentPayload::transaction("0x1234"));
+        credential.source = Some("did:pkh:eip155:42431:0x1234".into());
+
+        let request = ChargeRequest {
+            amount: "1".into(),
+            currency: "0x1".into(),
+            ..Default::default()
+        };
+        relay.validate(&credential, &request).await.unwrap();
+        {
+            let calls = calls.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].path, "/prefix/v1/mpp/validate");
+        }
+        let receipt = relay.broadcast(&credential, "tempo").await.unwrap();
+        assert_eq!(receipt.reference, "0xreceipt");
+        assert_eq!(receipt.external_id.as_deref(), Some("invoice-1"));
+
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path, "/prefix/v1/mpp/validate");
+        assert_eq!(calls[1].path, "/prefix/v1/mpp/broadcast");
+        for call in calls.iter() {
+            assert_eq!(call.headers["tempo-api-key"], "test-api-key");
+            assert_eq!(call.body["challenge"]["id"], "challenge-id");
+            assert!(call.body["challenge"]["request"].is_object());
+            assert_eq!(call.body["payload"]["type"], "transaction");
+            assert_eq!(call.body["source"], "did:pkh:eip155:42431:0x1234");
+        }
+        assert!(calls[0].headers.get("idempotency-key").is_none());
+        assert_eq!(
+            calls[1].headers["idempotency-key"],
+            format!("mppx_{:#x}", keccak256([0x12, 0x34]))
+        );
+    }
+
+    #[tokio::test]
+    async fn relay_omits_absent_source_and_forwards_all_challenge_bindings() {
+        let (base_url, calls) =
+            spawn_relay([(StatusCode::OK, serde_json::json!({ "success": true }))]).await;
+        let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+        let mut credential = credential(PaymentPayload::proof("0x1234"));
+        credential.challenge.digest = Some("sha-256=:digest:".into());
+        credential.challenge.opaque = Some(Base64UrlJson::from_raw("eyJyb3V0ZSI6MX0"));
+
+        relay
+            .validate(&credential, &ChargeRequest::default())
+            .await
+            .unwrap();
+
+        let calls = calls.lock().unwrap();
+        let body = &calls[0].body;
+        assert!(body.get("source").is_none());
+        assert_eq!(body["challenge"]["expires"], "2099-01-01T00:00:00Z");
+        assert_eq!(body["challenge"]["digest"], "sha-256=:digest:");
+        assert_eq!(body["challenge"]["opaque"], "eyJyb3V0ZSI6MX0");
+    }
+
+    #[tokio::test]
+    async fn relay_legacy_verify_preserves_combined_lifecycle() {
+        let (base_url, calls) = spawn_relay([
+            (StatusCode::OK, serde_json::json!({ "success": true })),
+            (
+                StatusCode::OK,
+                serde_json::json!({
+                    "success": true,
+                    "receipt": {
+                        "method": "tempo",
+                        "reference": "0xreceipt",
+                        "timestamp": "2026-08-03T12:00:00Z"
+                    }
+                }),
+            ),
+        ])
+        .await;
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = TempoChargeMethod::new(provider)
+            .with_relay(RelayConfig::new("test-key").api_base_url(base_url))
+            .unwrap();
+        let credential = credential(PaymentPayload::transaction("0x1234"));
+
+        let receipt = method
+            .verify(&credential, &ChargeRequest::default())
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.reference, "0xreceipt");
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path, "/v1/mpp/validate");
+        assert_eq!(calls[1].path, "/v1/mpp/broadcast");
+    }
+
+    #[tokio::test]
+    async fn mpp_broadcast_validates_through_relay_before_finalizing() {
+        let (base_url, calls) = spawn_relay([
+            (StatusCode::OK, serde_json::json!({ "success": true })),
+            (
+                StatusCode::OK,
+                serde_json::json!({
+                    "success": true,
+                    "receipt": {
+                        "method": "tempo",
+                        "reference": "0xreceipt",
+                        "timestamp": "2026-08-03T12:00:00Z"
+                    }
+                }),
+            ),
+        ])
+        .await;
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = TempoChargeMethod::new(provider)
+            .with_relay(RelayConfig::new("test-key").api_base_url(base_url))
+            .unwrap();
+        let payment = Mpp::new(method, "relay.example", "test-secret");
+        let credential = bound_credential("test-secret", PaymentPayload::transaction("0x1234"));
+
+        let receipt = payment.broadcast_credential(&credential).await.unwrap();
+
+        assert_eq!(receipt.reference, "0xreceipt");
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].path, "/v1/mpp/validate");
+        assert_eq!(calls[1].path, "/v1/mpp/broadcast");
+    }
+
+    #[tokio::test]
+    async fn mpp_broadcast_does_not_finalize_when_relay_validation_fails() {
+        let (base_url, calls) = spawn_relay([(
+            StatusCode::OK,
+            serde_json::json!({
+                "success": false,
+                "error": { "code": "policy_denied", "message": "private detail" }
+            }),
+        )])
+        .await;
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = TempoChargeMethod::new(provider)
+            .with_relay(RelayConfig::new("test-key").api_base_url(base_url))
+            .unwrap();
+        let payment = Mpp::new(method, "relay.example", "test-secret");
+        let credential = bound_credential("test-secret", PaymentPayload::transaction("0x1234"));
+
+        let error = payment.broadcast_credential(&credential).await.unwrap_err();
+
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+        let calls = calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].path, "/v1/mpp/validate");
+    }
+
+    #[tokio::test]
+    async fn relay_stops_after_validation_failure_and_hides_details() {
+        let (base_url, calls) = spawn_relay([(
+            StatusCode::OK,
+            serde_json::json!({
+                "success": false,
+                "error": { "code": "policy_denied", "message": "private detail" }
+            }),
+        )])
+        .await;
+        let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+
+        let error = relay
+            .validate(
+                &credential(PaymentPayload::transaction("0x1234")),
+                &ChargeRequest::default(),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn relay_non_success_http_status_keeps_response_body_opaque() {
+        let (base_url, calls) = spawn_relay([(
+            StatusCode::FORBIDDEN,
+            serde_json::json!({
+                "success": false,
+                "error": { "code": "insufficient_funds", "message": "private detail" }
+            }),
+        )])
+        .await;
+        let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+
+        let error = relay
+            .validate(
+                &credential(PaymentPayload::transaction("0x1234")),
+                &ChargeRequest::default(),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+        assert!(!error.message.contains("insufficient_funds"));
+        assert!(!error.message.contains("private detail"));
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn relay_malformed_json_response_is_opaque() {
+        let base_url = spawn_raw_relay("not-json").await;
+        let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+
+        let error = relay
+            .validate(
+                &credential(PaymentPayload::transaction("0x1234")),
+                &ChargeRequest::default(),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+    }
+
+    #[tokio::test]
+    async fn relay_network_failure_is_opaque_and_does_not_leak_configuration() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        let relay =
+            Relay::new(RelayConfig::new("top-secret-key").api_base_url(base_url.clone())).unwrap();
+
+        let error = relay
+            .validate(
+                &credential(PaymentPayload::transaction("0x1234")),
+                &ChargeRequest::default(),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+        assert!(!error.message.contains("top-secret-key"));
+        assert!(!error.message.contains(&base_url));
+    }
+
+    #[tokio::test]
+    async fn relay_rejects_invalid_receipts() {
+        for receipt in [
+            serde_json::json!({
+                "method": "tempo",
+                "timestamp": "2026-08-03T12:00:00Z"
+            }),
+            serde_json::json!({
+                "method": "stripe",
+                "reference": "0xreceipt",
+                "timestamp": "2026-08-03T12:00:00Z"
+            }),
+            serde_json::json!({
+                "method": "tempo",
+                "reference": "0xreceipt",
+                "timestamp": "not-a-timestamp"
+            }),
+        ] {
+            let (base_url, calls) = spawn_relay([(
+                StatusCode::OK,
+                serde_json::json!({ "success": true, "receipt": receipt }),
+            )])
+            .await;
+            let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+            let error = relay
+                .broadcast(&credential(PaymentPayload::transaction("0x1234")), "tempo")
+                .await
+                .unwrap_err();
+            assert_eq!(error.message, "Tempo API relay rejected credential");
+            let calls = calls.lock().unwrap();
+            assert_eq!(calls.len(), 1);
+            assert_eq!(calls[0].path, "/v1/mpp/broadcast");
+        }
+    }
+
+    #[tokio::test]
+    async fn relay_rejects_false_success_even_with_a_valid_receipt() {
+        let (base_url, calls) = spawn_relay([(
+            StatusCode::OK,
+            serde_json::json!({
+                "success": false,
+                "receipt": {
+                    "method": "tempo",
+                    "reference": "0xreceipt",
+                    "timestamp": "2026-08-03T12:00:00Z"
+                }
+            }),
+        )])
+        .await;
+        let relay = Relay::new(RelayConfig::new("key").api_base_url(base_url)).unwrap();
+
+        let error = relay
+            .broadcast(&credential(PaymentPayload::transaction("0x1234")), "tempo")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, "Tempo API relay rejected credential");
+        assert_eq!(calls.lock().unwrap().len(), 1);
+    }
+
+    async fn spawn_relay(
+        responses: impl IntoIterator<Item = (StatusCode, serde_json::Value)>,
+    ) -> (String, Arc<Mutex<Vec<MockCall>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let state = MockState {
+            calls: Arc::clone(&calls),
+            responses: Arc::new(Mutex::new(responses.into_iter().collect())),
+        };
+        let app = Router::new()
+            .route("/{*path}", post(relay_endpoint))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (format!("http://{address}"), calls)
+    }
+
+    async fn spawn_raw_relay(body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    async fn relay_endpoint(
+        State(state): State<MockState>,
+        OriginalUri(uri): OriginalUri,
+        headers: HeaderMap,
+        Json(body): Json<serde_json::Value>,
+    ) -> (StatusCode, Json<serde_json::Value>) {
+        state.calls.lock().unwrap().push(MockCall {
+            body,
+            headers,
+            path: uri.path().to_string(),
+        });
+        let (status, body) = state.responses.lock().unwrap().pop_front().unwrap();
+        (status, Json(body))
+    }
+}

--- a/src/protocol/traits/charge.rs
+++ b/src/protocol/traits/charge.rs
@@ -4,10 +4,52 @@
 //! ensuring consistent field names (amount, currency, recipient) across all
 //! payment methods.
 
-use crate::protocol::core::{PaymentCredential, Receipt};
+use crate::protocol::core::{ChallengeEcho, IntentName, MethodName, PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
 use crate::protocol::traits::VerificationError;
 use std::future::Future;
+
+/// Result of non-mutating charge credential validation.
+///
+/// Validation proves that the credential is structurally and method-specifically
+/// acceptable without consuming replay state or performing the terminal payment
+/// operation. Use the server acceptance APIs to re-validate and accept payment.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChargeValidation {
+    /// Challenge echoed by the credential.
+    pub challenge: ChallengeEcho,
+    /// Validated credential.
+    pub credential: PaymentCredential,
+    /// Method-specific validation details.
+    pub details: serde_json::Value,
+    /// Validated payment intent.
+    pub intent: IntentName,
+    /// Validated payment method.
+    pub method: MethodName,
+    /// Parsed charge request.
+    pub request: ChargeRequest,
+    /// Optional payer identity.
+    pub source: Option<String>,
+}
+
+impl ChargeValidation {
+    /// Build a validation result from a credential and parsed request.
+    pub fn new(
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+        details: serde_json::Value,
+    ) -> Self {
+        Self {
+            challenge: credential.challenge.clone(),
+            credential: credential.clone(),
+            details,
+            intent: credential.challenge.intent.clone(),
+            method: credential.challenge.method.clone(),
+            request: request.clone(),
+            source: credential.source.clone(),
+        }
+    }
+}
 
 /// Trait for payment methods that implement the "charge" intent.
 ///
@@ -90,7 +132,7 @@ pub trait ChargeMethod: Clone + Send + Sync {
     ///
     /// **Important**: This must be a fast, synchronous, deterministic operation.
     /// Do not perform network I/O here. Any async operations should happen in
-    /// the method constructor or in `verify()`.
+    /// the method constructor or in validation/broadcast hooks.
     ///
     /// # Arguments
     ///
@@ -127,7 +169,51 @@ pub trait ChargeMethod: Clone + Send + Sync {
         request
     }
 
-    /// Verify a charge credential against the typed request.
+    /// Whether this method supports non-mutating validation.
+    ///
+    /// Existing implementations default to the legacy combined verification
+    /// lifecycle. Methods overriding [`Self::validate`] must return `true` so
+    /// server acceptance paths validate before broadcasting.
+    fn supports_validation(&self) -> bool {
+        false
+    }
+
+    /// Validate a credential without consuming or broadcasting it.
+    ///
+    /// This is an advisory pre-check. Implementations must not reserve replay
+    /// keys, sign fee-payer transactions, broadcast, or otherwise mutate payment
+    /// state. The default reports that validation is unsupported.
+    fn validate(
+        &self,
+        _credential: &PaymentCredential,
+        _request: &ChargeRequest,
+    ) -> impl Future<Output = Result<ChargeValidation, VerificationError>> + Send {
+        let method = self.method().to_string();
+        async move {
+            Err(VerificationError::new(format!(
+                "{method}/charge does not support non-mutating credential validation"
+            )))
+        }
+    }
+
+    /// Perform the terminal payment operation.
+    ///
+    /// [`crate::server::Mpp`] calls [`Self::validate`] first for split-lifecycle
+    /// methods. New methods should override this hook. The compatibility default
+    /// invokes the legacy combined [`Self::verify`] hook.
+    fn broadcast(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> impl Future<Output = Result<Receipt, VerificationError>> + Send {
+        self.verify(credential, request)
+    }
+
+    /// Legacy combined verification hook.
+    ///
+    /// Existing methods may implement only this hook. Split-lifecycle methods
+    /// should preserve it for direct consumers by calling validation followed
+    /// by broadcast, while server acceptance paths use those hooks directly.
     ///
     /// # Arguments
     ///
@@ -174,6 +260,21 @@ mod tests {
         assert_eq!(method.method(), "test");
     }
 
+    #[test]
+    fn test_charge_method_prepare_request_defaults_to_identity() {
+        let method = TestChargeMethod;
+        let request = ChargeRequest {
+            amount: "100".into(),
+            currency: "USD".into(),
+            ..Default::default()
+        };
+
+        let prepared = method.prepare_request(request.clone(), None);
+
+        assert_eq!(prepared.amount, request.amount);
+        assert_eq!(prepared.currency, request.currency);
+    }
+
     #[tokio::test]
     async fn test_charge_method_verify() {
         let method = TestChargeMethod;
@@ -198,5 +299,90 @@ mod tests {
         assert!(result.is_ok());
         let receipt = result.unwrap();
         assert_eq!(receipt.reference, "test_ref");
+    }
+
+    #[tokio::test]
+    async fn test_charge_method_broadcast_falls_back_to_legacy_verify() {
+        let method = TestChargeMethod;
+        let echo = ChallengeEcho {
+            id: "test".into(),
+            realm: "test.com".into(),
+            method: "test".into(),
+            intent: "charge".into(),
+            request: crate::protocol::core::Base64UrlJson::from_raw("e30"),
+            expires: None,
+            digest: None,
+            opaque: None,
+        };
+        let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
+
+        let receipt = method
+            .broadcast(&credential, &ChargeRequest::default())
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.reference, "test_ref");
+    }
+
+    #[tokio::test]
+    async fn test_legacy_charge_method_reports_validation_unsupported() {
+        let method = TestChargeMethod;
+        let echo = ChallengeEcho {
+            id: "test".into(),
+            realm: "test.com".into(),
+            method: "test".into(),
+            intent: "charge".into(),
+            request: crate::protocol::core::Base64UrlJson::from_raw("e30"),
+            expires: None,
+            digest: None,
+            opaque: None,
+        };
+        let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
+
+        let error = method
+            .validate(&credential, &ChargeRequest::default())
+            .await
+            .unwrap_err();
+
+        assert!(error.message.contains("test/charge"));
+        assert!(error.message.contains("does not support non-mutating"));
+    }
+
+    #[test]
+    fn test_charge_validation_serializes_public_contract() {
+        let request = ChargeRequest {
+            amount: "100".into(),
+            currency: "USD".into(),
+            ..Default::default()
+        };
+        let credential = PaymentCredential::with_source(
+            ChallengeEcho {
+                id: "challenge".into(),
+                realm: "test.com".into(),
+                method: "test".into(),
+                intent: "charge".into(),
+                request: crate::protocol::core::Base64UrlJson::from_typed(&request).unwrap(),
+                expires: None,
+                digest: None,
+                opaque: None,
+            },
+            "did:example:payer",
+            PaymentPayload::hash("0x123"),
+        );
+
+        let value = serde_json::to_value(ChargeValidation::new(
+            &credential,
+            &request,
+            serde_json::json!({ "mode": "test" }),
+        ))
+        .unwrap();
+
+        assert_eq!(value["challenge"]["id"], "challenge");
+        assert_eq!(value["credential"]["source"], "did:example:payer");
+        assert_eq!(value["details"]["mode"], "test");
+        assert_eq!(value["intent"], "charge");
+        assert_eq!(value["method"], "test");
+        assert_eq!(value["request"]["amount"], "100");
+        assert_eq!(value["source"], "did:example:payer");
     }
 }

--- a/src/protocol/traits/mod.rs
+++ b/src/protocol/traits/mod.rs
@@ -11,7 +11,7 @@
 mod charge;
 mod session;
 
-pub use charge::ChargeMethod;
+pub use charge::{ChargeMethod, ChargeValidation};
 pub use session::SessionMethod;
 
 use std::fmt;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -51,7 +51,9 @@ mod tempo;
 #[cfg(feature = "stripe")]
 mod stripe;
 
-pub use crate::protocol::traits::{ChargeMethod, ErrorCode, SessionMethod, VerificationError};
+pub use crate::protocol::traits::{
+    ChargeMethod, ChargeValidation, ErrorCode, SessionMethod, VerificationError,
+};
 pub use amount::{parse_dollar_amount, AmountError};
 pub use compose::{compose, compose_verify, ChargeVerifier};
 pub use events::{
@@ -63,8 +65,8 @@ pub use mpp::{Mpp, SessionVerifyResult};
 #[cfg(feature = "tempo")]
 pub use tempo::{
     tempo, tempo_provider, SessionChannelStore, SessionMethodConfig, TempoBuilder, TempoChargeExt,
-    TempoChargeMethod, TempoConfig, TempoMethodDetails, TempoProvider, TempoSessionMethod,
-    CHAIN_ID, METHOD_NAME,
+    TempoChargeMethod, TempoConfig, TempoMethodDetails, TempoProvider, TempoRelayConfig,
+    TempoRelayErrorCode, TempoSessionMethod, CHAIN_ID, METHOD_NAME,
 };
 
 // Re-export stripe types at server level for backward compatibility
@@ -102,6 +104,8 @@ pub struct ChargeOptions<'a> {
     pub expires: Option<&'a str>,
     /// Enable fee sponsorship.
     pub fee_payer: bool,
+    /// Credential modes advertised to clients (for example, `&["pull"]`).
+    pub supported_modes: Option<&'a [&'a str]>,
     /// Framework adapter route/resource/query scope.
     pub mppx_scope: Option<&'a serde_json::Value>,
 }

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -21,7 +21,7 @@ use crate::error::Result;
 use crate::protocol::core::PaymentChallenge;
 use crate::protocol::core::{Base64UrlJson, PaymentCredential, Receipt};
 use crate::protocol::intents::ChargeRequest;
-use crate::protocol::traits::{ChargeMethod, VerificationError};
+use crate::protocol::traits::{ChargeMethod, ChargeValidation, VerificationError};
 use crate::server::events::{
     PaymentSuccessContext, ServerEvent, ServerEventKind, ServerEventSubscription, ServerEvents,
 };
@@ -517,6 +517,9 @@ where
             if let Some(chain_id) = self.chain_id {
                 details.insert("chainId".into(), serde_json::json!(chain_id));
             }
+            if let Some(supported_modes) = options.supported_modes {
+                details.insert("supportedModes".into(), serde_json::json!(supported_modes));
+            }
             if !details.is_empty() {
                 request.method_details = Some(serde_json::Value::Object(details));
             }
@@ -583,83 +586,146 @@ where
         Ok(self.apply_pinned_opaque(challenge))
     }
 
-    /// Verify a payment credential (simple API).
-    ///
-    /// Decodes the charge request from the echoed challenge automatically.
-    /// No need to reconstruct the request manually.
+    fn decode_credential_request(
+        credential: &PaymentCredential,
+    ) -> std::result::Result<ChargeRequest, VerificationError> {
+        credential
+            .challenge
+            .request
+            .decode()
+            .map_err(|e| VerificationError::new(format!("Failed to decode request: {e}")))
+    }
+
+    /// Validate a payment credential without consuming or broadcasting it.
+    pub async fn validate_credential(
+        &self,
+        credential: &PaymentCredential,
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.validate(credential, &request).await
+    }
+
+    /// Validate a credential against the actual request body without accepting payment.
+    pub async fn validate_credential_with_body(
+        &self,
+        credential: &PaymentCredential,
+        body: &[u8],
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.validate_with_body(credential, &request, Some(body))
+            .await
+    }
+
+    /// Validate a credential against expected route values without accepting payment.
+    pub async fn validate_credential_with_expected_request(
+        &self,
+        credential: &PaymentCredential,
+        expected: &ChargeRequest,
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.verify_expected_request_matches(credential, &request, expected)?;
+        self.validate(credential, &request).await
+    }
+
+    /// Validate a credential against expected route values and body bytes.
+    pub async fn validate_credential_with_expected_request_and_body(
+        &self,
+        credential: &PaymentCredential,
+        expected: &ChargeRequest,
+        body: &[u8],
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.verify_expected_request_matches(credential, &request, expected)?;
+        self.validate_with_body(credential, &request, Some(body))
+            .await
+    }
+
+    /// Re-validate and accept a payment credential.
+    pub async fn broadcast_credential(
+        &self,
+        credential: &PaymentCredential,
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.broadcast(credential, &request).await
+    }
+
+    /// Re-validate and accept a credential bound to the actual request body.
+    pub async fn broadcast_credential_with_body(
+        &self,
+        credential: &PaymentCredential,
+        body: &[u8],
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.broadcast_with_body(credential, &request, Some(body))
+            .await
+    }
+
+    /// Re-validate and accept a credential matching expected route values.
+    pub async fn broadcast_credential_with_expected_request(
+        &self,
+        credential: &PaymentCredential,
+        expected: &ChargeRequest,
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.verify_expected_request_matches(credential, &request, expected)?;
+        self.broadcast(credential, &request).await
+    }
+
+    /// Re-validate and accept a credential matching expected route values and body bytes.
+    pub async fn broadcast_credential_with_expected_request_and_body(
+        &self,
+        credential: &PaymentCredential,
+        expected: &ChargeRequest,
+        body: &[u8],
+    ) -> std::result::Result<Receipt, VerificationError> {
+        let request = Self::decode_credential_request(credential)?;
+        self.verify_expected_request_matches(credential, &request, expected)?;
+        self.broadcast_with_body(credential, &request, Some(body))
+            .await
+    }
+
+    /// Backwards-compatible alias for [`Self::broadcast_credential`].
     pub async fn verify_credential(
         &self,
         credential: &PaymentCredential,
     ) -> std::result::Result<Receipt, VerificationError> {
-        let request: ChargeRequest = credential
-            .challenge
-            .request
-            .decode()
-            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
-        self.verify(credential, &request).await
+        self.broadcast_credential(credential).await
     }
 
-    /// Verify a payment credential against the actual request body bytes.
-    ///
-    /// Use this when the echoed challenge contains a body digest. The digest is
-    /// recomputed over `body` before method-specific payment verification runs.
+    /// Backwards-compatible alias for [`Self::broadcast_credential_with_body`].
     pub async fn verify_credential_with_body(
         &self,
         credential: &PaymentCredential,
         body: &[u8],
     ) -> std::result::Result<Receipt, VerificationError> {
-        let request: ChargeRequest = credential
-            .challenge
-            .request
-            .decode()
-            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
-        self.verify_with_body(credential, &request, Some(body))
-            .await
+        self.broadcast_credential_with_body(credential, body).await
     }
 
-    /// Verify a payment credential, ensuring the charge request matches the server's expected values.
-    ///
-    /// This prevents cross-route credential replay attacks where a credential
-    /// obtained from a cheaper endpoint (or different recipient/currency) is
-    /// replayed on another.
+    /// Backwards-compatible alias for [`Self::broadcast_credential_with_expected_request`].
     pub async fn verify_credential_with_expected_request(
         &self,
         credential: &PaymentCredential,
         expected: &ChargeRequest,
     ) -> std::result::Result<Receipt, VerificationError> {
-        let request: ChargeRequest = credential
-            .challenge
-            .request
-            .decode()
-            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
-
-        self.verify_expected_request_matches(credential, &request, expected)?;
-
-        self.verify(credential, &request).await
+        self.broadcast_credential_with_expected_request(credential, expected)
+            .await
     }
 
-    /// Verify a payment credential against expected route values and actual body bytes.
+    /// Backwards-compatible alias for
+    /// [`Self::broadcast_credential_with_expected_request_and_body`].
     pub async fn verify_credential_with_expected_request_and_body(
         &self,
         credential: &PaymentCredential,
         expected: &ChargeRequest,
         body: &[u8],
     ) -> std::result::Result<Receipt, VerificationError> {
-        let request: ChargeRequest = credential
-            .challenge
-            .request
-            .decode()
-            .map_err(|e| VerificationError::new(format!("Failed to decode request: {}", e)))?;
-
-        self.verify_expected_request_matches(credential, &request, expected)?;
-
-        self.verify_with_body(credential, &request, Some(body))
+        self.broadcast_credential_with_expected_request_and_body(credential, expected, body)
             .await
     }
 
     fn verify_expected_request_matches(
         &self,
-        credential: &PaymentCredential,
+        _credential: &PaymentCredential,
         request: &ChargeRequest,
         expected: &ChargeRequest,
     ) -> std::result::Result<(), VerificationError> {
@@ -698,7 +764,7 @@ where
         }
 
         #[cfg(feature = "tempo")]
-        if credential.challenge.method.as_str() == crate::protocol::methods::tempo::METHOD_NAME {
+        if _credential.challenge.method.as_str() == crate::protocol::methods::tempo::METHOD_NAME {
             let req_transfers =
                 crate::protocol::methods::tempo::transfers::get_request_transfers(request)
                     .map_err(|e| {
@@ -716,7 +782,16 @@ where
                         )
                     })?;
 
-            if req_transfers != expected_transfers {
+            let mut unmatched = req_transfers;
+            let same_transfers = unmatched.len() == expected_transfers.len()
+                && expected_transfers.into_iter().all(|expected| {
+                    unmatched
+                        .iter()
+                        .position(|actual| *actual == expected)
+                        .map(|index| unmatched.swap_remove(index))
+                        .is_some()
+                });
+            if !same_transfers {
                 return Err(VerificationError::with_code(
                     "Tempo transfer routing mismatch: credential was issued with different memo or splits",
                     crate::protocol::traits::ErrorCode::CredentialMismatch,
@@ -727,16 +802,48 @@ where
         Ok(())
     }
 
-    /// Verify a charge credential with an explicit request.
-    pub async fn verify(
+    /// Validate a charge credential with an explicit request without accepting payment.
+    pub async fn validate(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        self.validate_with_body(credential, request, None).await
+    }
+
+    async fn validate_with_body(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+        body: Option<&[u8]>,
+    ) -> std::result::Result<ChargeValidation, VerificationError> {
+        self.verify_hmac_and_expiry(credential)?;
+        self.verify_body_digest(credential, body)?;
+        self.verify_pinned_fields(credential, request)?;
+        self.method.validate(credential, request).await
+    }
+
+    async fn validate_before_broadcast(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> std::result::Result<(), VerificationError> {
+        if self.method.supports_validation() {
+            self.method.validate(credential, request).await?;
+        }
+        Ok(())
+    }
+
+    /// Re-validate and perform the terminal payment operation.
+    pub async fn broadcast(
         &self,
         credential: &PaymentCredential,
         request: &ChargeRequest,
     ) -> std::result::Result<Receipt, VerificationError> {
-        self.verify_with_body(credential, request, None).await
+        self.broadcast_with_body(credential, request, None).await
     }
 
-    async fn verify_with_body(
+    async fn broadcast_with_body(
         &self,
         credential: &PaymentCredential,
         request: &ChargeRequest,
@@ -747,7 +854,8 @@ where
         self.verify_body_digest(credential, body)?;
         // Tier 2: Pinned field safety net
         self.verify_pinned_fields(credential, request)?;
-        let receipt = self.method.verify(credential, request).await?;
+        self.validate_before_broadcast(credential, request).await?;
+        let receipt = self.method.broadcast(credential, request).await?;
         self.events
             .emit_payment_success(PaymentSuccessContext {
                 credential: credential.clone(),
@@ -759,6 +867,15 @@ where
             })
             .await;
         Ok(receipt)
+    }
+
+    /// Backwards-compatible alias for [`Self::broadcast`].
+    pub async fn verify(
+        &self,
+        credential: &PaymentCredential,
+        request: &ChargeRequest,
+    ) -> std::result::Result<Receipt, VerificationError> {
+        self.broadcast(credential, request).await
     }
 
     fn verify_body_digest(
@@ -1108,6 +1225,9 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
         if let Some(store) = builder.store {
             method = method.with_store(store);
         }
+        if let Some(relay) = builder.relay {
+            method = method.with_relay(relay)?;
+        }
 
         // Resolve currency from chain_id when not explicitly set
         let currency = if builder.currency_explicit {
@@ -1315,7 +1435,10 @@ mod tests {
     use alloy::primitives::Address;
     use std::{
         future::Future,
-        sync::{Arc, Mutex},
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
     };
 
     #[derive(Clone)]
@@ -1383,6 +1506,74 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct LifecycleMethod {
+        calls: Arc<Mutex<Vec<&'static str>>>,
+        reject_broadcast: bool,
+        reject_validation: bool,
+    }
+
+    impl ChargeMethod for LifecycleMethod {
+        fn method(&self) -> &str {
+            "mock"
+        }
+
+        fn supports_validation(&self) -> bool {
+            true
+        }
+
+        fn validate(
+            &self,
+            credential: &PaymentCredential,
+            request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<ChargeValidation, VerificationError>> + Send
+        {
+            let calls = Arc::clone(&self.calls);
+            let reject_validation = self.reject_validation;
+            let credential = credential.clone();
+            let request = request.clone();
+            async move {
+                calls.lock().unwrap().push("validate");
+                if reject_validation {
+                    return Err(VerificationError::new("validation rejected"));
+                }
+                Ok(ChargeValidation::new(
+                    &credential,
+                    &request,
+                    serde_json::json!({ "mode": "test" }),
+                ))
+            }
+        }
+
+        fn broadcast(
+            &self,
+            _credential: &PaymentCredential,
+            _request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
+            let calls = Arc::clone(&self.calls);
+            let reject_broadcast = self.reject_broadcast;
+            async move {
+                calls.lock().unwrap().push("broadcast");
+                if reject_broadcast {
+                    return Err(VerificationError::new("broadcast rejected"));
+                }
+                Ok(Receipt::success("mock", "broadcast_ref"))
+            }
+        }
+
+        fn verify(
+            &self,
+            _credential: &PaymentCredential,
+            _request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
+            let calls = Arc::clone(&self.calls);
+            async move {
+                calls.lock().unwrap().push("verify");
+                Err(VerificationError::new("legacy verify must stay inert"))
+            }
+        }
+    }
+
     fn test_credential(secret_key: &str) -> PaymentCredential {
         let request = "eyJ0ZXN0IjoidmFsdWUifQ";
         let expires = (time::OffsetDateTime::now_utc() + time::Duration::minutes(5))
@@ -1422,12 +1613,16 @@ mod tests {
     }
 
     fn test_credential_with_body_digest(secret_key: &str, body: &[u8]) -> PaymentCredential {
+        test_lifecycle_credential(secret_key, Some(body))
+    }
+
+    fn test_lifecycle_credential(secret_key: &str, body: Option<&[u8]>) -> PaymentCredential {
         let request = test_request();
         let encoded = Base64UrlJson::from_typed(&request).unwrap();
         let expires = (time::OffsetDateTime::now_utc() + time::Duration::minutes(5))
             .format(&time::format_description::well_known::Rfc3339)
             .unwrap();
-        let digest = crate::body_digest::compute(body);
+        let digest = body.map(crate::body_digest::compute);
         let id = crate::protocol::core::compute_challenge_id(
             secret_key,
             "api.example.com",
@@ -1435,7 +1630,7 @@ mod tests {
             "charge",
             encoded.raw(),
             Some(&expires),
-            Some(&digest),
+            digest.as_deref(),
             None,
         );
 
@@ -1446,10 +1641,395 @@ mod tests {
             intent: "charge".into(),
             request: encoded,
             expires: Some(expires),
-            digest: Some(digest),
+            digest,
             opaque: None,
         };
         PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
+    }
+
+    fn lifecycle_payment(
+        reject_validation: bool,
+    ) -> (Mpp<LifecycleMethod>, Arc<Mutex<Vec<&'static str>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        (
+            Mpp::new(
+                LifecycleMethod {
+                    calls: Arc::clone(&calls),
+                    reject_broadcast: false,
+                    reject_validation,
+                },
+                "api.example.com",
+                "test-secret",
+            ),
+            calls,
+        )
+    }
+
+    fn lifecycle_payment_rejecting_broadcast(
+    ) -> (Mpp<LifecycleMethod>, Arc<Mutex<Vec<&'static str>>>) {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        (
+            Mpp::new(
+                LifecycleMethod {
+                    calls: Arc::clone(&calls),
+                    reject_broadcast: true,
+                    reject_validation: false,
+                },
+                "api.example.com",
+                "test-secret",
+            ),
+            calls,
+        )
+    }
+
+    #[derive(Clone)]
+    struct LegacyLifecycleMethod {
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl ChargeMethod for LegacyLifecycleMethod {
+        fn method(&self) -> &str {
+            "mock"
+        }
+
+        fn verify(
+            &self,
+            _credential: &PaymentCredential,
+            _request: &ChargeRequest,
+        ) -> impl Future<Output = std::result::Result<Receipt, VerificationError>> + Send {
+            let calls = Arc::clone(&self.calls);
+            async move {
+                calls.lock().unwrap().push("verify");
+                Ok(Receipt::success("mock", "legacy_ref"))
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_credential_is_non_mutating() {
+        let (payment, calls) = lifecycle_payment(false);
+        let credential = test_credential_with_body_digest("test-secret", b"body");
+
+        let validation = payment
+            .validate_credential_with_body(&credential, b"body")
+            .await
+            .unwrap();
+
+        assert_eq!(validation.details, serde_json::json!({ "mode": "test" }));
+        assert_eq!(*calls.lock().unwrap(), ["validate"]);
+    }
+
+    #[tokio::test]
+    async fn every_validation_entry_point_only_validates() {
+        #[derive(Clone, Copy, Debug)]
+        enum EntryPoint {
+            ValidateCredential,
+            ValidateCredentialWithBody,
+            ValidateCredentialWithExpectedRequest,
+            ValidateCredentialWithExpectedRequestAndBody,
+            Validate,
+        }
+
+        let entry_points = [
+            EntryPoint::ValidateCredential,
+            EntryPoint::ValidateCredentialWithBody,
+            EntryPoint::ValidateCredentialWithExpectedRequest,
+            EntryPoint::ValidateCredentialWithExpectedRequestAndBody,
+            EntryPoint::Validate,
+        ];
+
+        for entry_point in entry_points {
+            let (payment, calls) = lifecycle_payment(false);
+            let uses_body = matches!(
+                entry_point,
+                EntryPoint::ValidateCredentialWithBody
+                    | EntryPoint::ValidateCredentialWithExpectedRequestAndBody
+            );
+            let credential =
+                test_lifecycle_credential("test-secret", uses_body.then_some(b"body".as_slice()));
+            let expected = test_request();
+
+            let validation = match entry_point {
+                EntryPoint::ValidateCredential => payment.validate_credential(&credential).await,
+                EntryPoint::ValidateCredentialWithBody => {
+                    payment
+                        .validate_credential_with_body(&credential, b"body")
+                        .await
+                }
+                EntryPoint::ValidateCredentialWithExpectedRequest => {
+                    payment
+                        .validate_credential_with_expected_request(&credential, &expected)
+                        .await
+                }
+                EntryPoint::ValidateCredentialWithExpectedRequestAndBody => {
+                    payment
+                        .validate_credential_with_expected_request_and_body(
+                            &credential,
+                            &expected,
+                            b"body",
+                        )
+                        .await
+                }
+                EntryPoint::Validate => payment.validate(&credential, &expected).await,
+            }
+            .unwrap_or_else(|error| panic!("{entry_point:?} failed: {error}"));
+
+            assert_eq!(
+                validation.details,
+                serde_json::json!({ "mode": "test" }),
+                "{entry_point:?}"
+            );
+            assert_eq!(*calls.lock().unwrap(), ["validate"], "{entry_point:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_credential_validates_then_broadcasts_without_legacy_verify() {
+        let (payment, calls) = lifecycle_payment(false);
+        let credential = test_credential_with_body_digest("test-secret", b"body");
+
+        let receipt = payment
+            .broadcast_credential_with_body(&credential, b"body")
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.reference, "broadcast_ref");
+        assert_eq!(*calls.lock().unwrap(), ["validate", "broadcast"]);
+    }
+
+    #[tokio::test]
+    async fn verify_credential_is_broadcast_compatibility_alias() {
+        let (payment, calls) = lifecycle_payment(false);
+        let credential = test_credential_with_body_digest("test-secret", b"body");
+
+        let receipt = payment
+            .verify_credential_with_body(&credential, b"body")
+            .await
+            .unwrap();
+
+        assert_eq!(receipt.reference, "broadcast_ref");
+        assert_eq!(*calls.lock().unwrap(), ["validate", "broadcast"]);
+    }
+
+    #[tokio::test]
+    async fn broadcast_credential_stops_when_validation_fails() {
+        let (payment, calls) = lifecycle_payment(true);
+        let credential = test_credential_with_body_digest("test-secret", b"body");
+
+        let error = payment
+            .broadcast_credential_with_body(&credential, b"body")
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, "validation rejected");
+        assert_eq!(*calls.lock().unwrap(), ["validate"]);
+    }
+
+    #[tokio::test]
+    async fn every_broadcast_and_verify_entry_point_validates_before_broadcast() {
+        #[derive(Clone, Copy, Debug)]
+        enum EntryPoint {
+            BroadcastCredential,
+            BroadcastCredentialWithBody,
+            BroadcastCredentialWithExpectedRequest,
+            BroadcastCredentialWithExpectedRequestAndBody,
+            VerifyCredential,
+            VerifyCredentialWithBody,
+            VerifyCredentialWithExpectedRequest,
+            VerifyCredentialWithExpectedRequestAndBody,
+            Broadcast,
+            Verify,
+        }
+
+        let entry_points = [
+            EntryPoint::BroadcastCredential,
+            EntryPoint::BroadcastCredentialWithBody,
+            EntryPoint::BroadcastCredentialWithExpectedRequest,
+            EntryPoint::BroadcastCredentialWithExpectedRequestAndBody,
+            EntryPoint::VerifyCredential,
+            EntryPoint::VerifyCredentialWithBody,
+            EntryPoint::VerifyCredentialWithExpectedRequest,
+            EntryPoint::VerifyCredentialWithExpectedRequestAndBody,
+            EntryPoint::Broadcast,
+            EntryPoint::Verify,
+        ];
+
+        for entry_point in entry_points {
+            let (payment, calls) = lifecycle_payment(false);
+            let uses_body = matches!(
+                entry_point,
+                EntryPoint::BroadcastCredentialWithBody
+                    | EntryPoint::BroadcastCredentialWithExpectedRequestAndBody
+                    | EntryPoint::VerifyCredentialWithBody
+                    | EntryPoint::VerifyCredentialWithExpectedRequestAndBody
+            );
+            let credential =
+                test_lifecycle_credential("test-secret", uses_body.then_some(b"body".as_slice()));
+            let expected = test_request();
+
+            let receipt = match entry_point {
+                EntryPoint::BroadcastCredential => payment.broadcast_credential(&credential).await,
+                EntryPoint::BroadcastCredentialWithBody => {
+                    payment
+                        .broadcast_credential_with_body(&credential, b"body")
+                        .await
+                }
+                EntryPoint::BroadcastCredentialWithExpectedRequest => {
+                    payment
+                        .broadcast_credential_with_expected_request(&credential, &expected)
+                        .await
+                }
+                EntryPoint::BroadcastCredentialWithExpectedRequestAndBody => {
+                    payment
+                        .broadcast_credential_with_expected_request_and_body(
+                            &credential,
+                            &expected,
+                            b"body",
+                        )
+                        .await
+                }
+                EntryPoint::VerifyCredential => payment.verify_credential(&credential).await,
+                EntryPoint::VerifyCredentialWithBody => {
+                    payment
+                        .verify_credential_with_body(&credential, b"body")
+                        .await
+                }
+                EntryPoint::VerifyCredentialWithExpectedRequest => {
+                    payment
+                        .verify_credential_with_expected_request(&credential, &expected)
+                        .await
+                }
+                EntryPoint::VerifyCredentialWithExpectedRequestAndBody => {
+                    payment
+                        .verify_credential_with_expected_request_and_body(
+                            &credential,
+                            &expected,
+                            b"body",
+                        )
+                        .await
+                }
+                EntryPoint::Broadcast => payment.broadcast(&credential, &expected).await,
+                EntryPoint::Verify => payment.verify(&credential, &expected).await,
+            }
+            .unwrap_or_else(|error| panic!("{entry_point:?} failed: {error}"));
+
+            assert_eq!(receipt.reference, "broadcast_ref", "{entry_point:?}");
+            assert_eq!(
+                *calls.lock().unwrap(),
+                ["validate", "broadcast"],
+                "{entry_point:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_reports_terminal_failure_after_validation() {
+        let (payment, calls) = lifecycle_payment_rejecting_broadcast();
+        let credential = test_lifecycle_credential("test-secret", None);
+
+        let error = payment.broadcast_credential(&credential).await.unwrap_err();
+
+        assert_eq!(error.message, "broadcast rejected");
+        assert_eq!(*calls.lock().unwrap(), ["validate", "broadcast"]);
+    }
+
+    #[tokio::test]
+    async fn failed_validation_or_broadcast_never_emits_payment_success() {
+        for reject_validation in [true, false] {
+            let (payment, _) = if reject_validation {
+                lifecycle_payment(true)
+            } else {
+                lifecycle_payment_rejecting_broadcast()
+            };
+            let success_count = Arc::new(AtomicUsize::new(0));
+            let _subscription = payment.on_payment_success({
+                let success_count = Arc::clone(&success_count);
+                move |_| {
+                    let success_count = Arc::clone(&success_count);
+                    async move {
+                        success_count.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            });
+            let credential = test_lifecycle_credential("test-secret", None);
+
+            assert!(payment.broadcast_credential(&credential).await.is_err());
+            assert_eq!(success_count.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_prechecks_run_before_method_validation() {
+        let cases = ["invalid-hmac", "body-mismatch", "route-mismatch"];
+
+        for case in cases {
+            let (payment, calls) = lifecycle_payment(false);
+            let mut credential = test_lifecycle_credential("test-secret", Some(b"body"));
+            let result = match case {
+                "invalid-hmac" => {
+                    credential.challenge.id = "invalid".into();
+                    payment
+                        .broadcast_credential_with_body(&credential, b"body")
+                        .await
+                }
+                "body-mismatch" => {
+                    payment
+                        .broadcast_credential_with_body(&credential, b"different")
+                        .await
+                }
+                "route-mismatch" => {
+                    let mut expected = test_request();
+                    expected.amount = "9999".into();
+                    payment
+                        .broadcast_credential_with_expected_request_and_body(
+                            &credential,
+                            &expected,
+                            b"body",
+                        )
+                        .await
+                }
+                _ => unreachable!(),
+            };
+
+            assert!(result.is_err(), "{case}");
+            assert!(calls.lock().unwrap().is_empty(), "{case}");
+        }
+    }
+
+    #[tokio::test]
+    async fn legacy_broadcast_falls_back_to_verify_without_validation() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let payment = Mpp::new(
+            LegacyLifecycleMethod {
+                calls: Arc::clone(&calls),
+            },
+            "api.example.com",
+            "test-secret",
+        );
+        let credential = test_lifecycle_credential("test-secret", None);
+
+        let receipt = payment.broadcast_credential(&credential).await.unwrap();
+
+        assert_eq!(receipt.reference, "legacy_ref");
+        assert_eq!(*calls.lock().unwrap(), ["verify"]);
+    }
+
+    #[tokio::test]
+    async fn validation_only_api_rejects_legacy_method_without_verifying() {
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let payment = Mpp::new(
+            LegacyLifecycleMethod {
+                calls: Arc::clone(&calls),
+            },
+            "api.example.com",
+            "test-secret",
+        );
+        let credential = test_lifecycle_credential("test-secret", None);
+
+        let error = payment.validate_credential(&credential).await.unwrap_err();
+
+        assert!(error.message.contains("does not support non-mutating"));
+        assert!(calls.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1919,6 +2499,7 @@ mod tests {
                 "5.50",
                 ChargeOptions {
                     description: Some("API access fee"),
+                    supported_modes: Some(&["pull"]),
                     ..Default::default()
                 },
             )
@@ -1927,6 +2508,10 @@ mod tests {
         let request: ChargeRequest = challenge.request.decode().unwrap();
         assert_eq!(request.amount, "5500000");
         assert_eq!(challenge.description, Some("API access fee".to_string()));
+        assert_eq!(
+            request.method_details.unwrap()["supportedModes"],
+            serde_json::json!(["pull"])
+        );
     }
 
     #[cfg(feature = "tempo")]
@@ -3103,6 +3688,44 @@ mod tests {
             "expected split routing mismatch error, got: {}",
             err.message
         );
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn test_verify_credential_accepts_equivalent_reordered_splits() {
+        let mpp = create_hmac_test_mpp();
+        let split_a = serde_json::json!({
+            "amount": "10000",
+            "recipient": "0x0000000000000000000000000000000000000003",
+            "memo": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+        let split_b = serde_json::json!({
+            "amount": "20000",
+            "recipient": "0x0000000000000000000000000000000000000004",
+            "memo": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        });
+        let request = |splits| ChargeRequest {
+            amount: "100000".into(),
+            currency: "0x20c0000000000000000000000000000000000000".into(),
+            recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
+            method_details: Some(serde_json::json!({ "splits": splits })),
+            ..Default::default()
+        };
+        let challenge = mpp
+            .charge_challenge_with_options(
+                &request(vec![split_a.clone(), split_b.clone()]),
+                None,
+                None,
+            )
+            .unwrap();
+        let credential =
+            PaymentCredential::new(challenge.to_echo(), PaymentPayload::hash("0xdeadbeef"));
+
+        let result = mpp
+            .verify_credential_with_expected_request(&credential, &request(vec![split_b, split_a]))
+            .await;
+
+        assert!(result.is_ok(), "equivalent split routes should match");
     }
 
     #[cfg(feature = "tempo")]

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -10,7 +10,8 @@ pub use crate::protocol::methods::tempo::session_method::{
 };
 pub use crate::protocol::methods::tempo::ChargeMethod as TempoChargeMethod;
 pub use crate::protocol::methods::tempo::{
-    TempoChargeExt, TempoMethodDetails, CHAIN_ID, METHOD_NAME,
+    RelayConfig as TempoRelayConfig, RelayErrorCode as TempoRelayErrorCode, TempoChargeExt,
+    TempoMethodDetails, CHAIN_ID, METHOD_NAME,
 };
 
 /// Configuration for the Tempo payment method.
@@ -38,6 +39,7 @@ pub struct TempoBuilder {
     pub(crate) fee_payer_signer: Option<alloy::signers::local::PrivateKeySigner>,
     pub(crate) fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
     pub(crate) store: Option<std::sync::Arc<dyn crate::store::Store>>,
+    pub(crate) relay: Option<TempoRelayConfig>,
 }
 
 impl TempoBuilder {
@@ -139,6 +141,12 @@ impl TempoBuilder {
         self.store = None;
         self
     }
+
+    /// Delegate Tempo charge validation and finalization to an MPP relay.
+    pub fn relay(mut self, config: TempoRelayConfig) -> Self {
+        self.relay = Some(config);
+        self
+    }
 }
 
 /// Create a Tempo payment method configuration with smart defaults.
@@ -196,6 +204,7 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         fee_payer_allowed_fee_tokens: None,
         // Default in-memory store; replay protection on by default.
         store: Some(std::sync::Arc::new(crate::store::MemoryStore::new())),
+        relay: None,
     }
 }
 


### PR DESCRIPTION
## Motivation

Servers need a non-mutating credential pre-check before terminal settlement and a supported path for delegating Tempo charge finalization to the Tempo API.

## Summary

- add separate charge validation and broadcast APIs while preserving legacy verification compatibility
- add local Tempo validation and a configurable Tempo API relay adapter
- add supported credential-mode advertisement and an Axum relay example
- harden relay idempotency, receipt validation, replay handling, and failure privacy

## Key design considerations

- broadcast acceptance always re-validates split-lifecycle methods before the terminal hook
- validation does not reserve replay state, sign fee-payer transactions, or broadcast payments
- legacy verify-only implementations continue through the compatibility fallback
- relay API keys and private relay failure details are not exposed