### PR TITLE
chore(deps): align Tempo and WebSocket revisions with revm 42

### DIFF
--- a/.changelog/rare-lakes-run.md
+++ b/.changelog/rare-lakes-run.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Updated the pinned `tempo-alloy` git revision.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -43,7 +43,7 @@ url = "2"
 http = "1"
 tokio = { version = "1", features = ["sync", "rt", "time", "macros"] }
 # Pinned to match the version used by alloy-transport-ws 2.0.x.
-tokio-tungstenite = "0.28"
+tokio-tungstenite = "0.29"
 rustls = { version = "0.23", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -52,7 +52,7 @@ futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
 # Pinned to match the version used by alloy-transport-ws 2.0.x so the
 # WebSocketConfig types align between the integration tests and the crate.
-tokio-tungstenite = "0.28"
+tokio-tungstenite = "0.29"
 
 [features]
 # Ring is the lightweight default. Consumers that require a different TLS


### PR DESCRIPTION
Aligns the Tempo dependency and WebSocket transport pin with the revm 42 Foundry integration.

- updates the Tempo revision to the revm 42-compatible commit
- updates `alloy-transport-mpp` to `tokio-tungstenite` 0.29 to match Alloy 2.3

Prompted by: @klkvr