### PR TITLE
fix: Invalid challenge expiration timestamps survive parsing

### DIFF
--- a/.changelog/invalid-challenge-expiration.md
+++ b/.changelog/invalid-challenge-expiration.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Reject payment challenges containing malformed RFC 3339 `expires` timestamps during header parsing.

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@02aaff0c239b4a3f2d5ad6ea9dd6f59be4ddc016 # main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@c172db38a86bbf3344ffa3390dbed7d81b17dad6 # main
     with:
       protocol-paths: |
         src/**
@@ -32,7 +32,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@02aaff0c239b4a3f2d5ad6ea9dd6f59be4ddc016 # main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@c172db38a86bbf3344ffa3390dbed7d81b17dad6 # main
     with:
       adapter: rust
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Patch Changes
 
-- Rejected payment challenges containing malformed RFC 3339 `expires` timestamps during header parsing. (by @brendanjryan, [#100](https://github.com/tempoxyz/mpp-tools/issues/100))
 - Added configurable incremental 402 challenge retries for HTTP clients. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))
 - Rejected oversized `WWW-Authenticate` `request` parameters before decoding payment challenges. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))
 - Updated README documentation with an expanded protocol description, added an MPP SDKs table listing official implementations in multiple languages, and cleaned up URLs and prose throughout. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Patch Changes
 
+- Rejected payment challenges containing malformed RFC 3339 `expires` timestamps during header parsing. (by @brendanjryan, [#100](https://github.com/tempoxyz/mpp-tools/issues/100))
 - Added configurable incremental 402 challenge retries for HTTP clients. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))
 - Rejected oversized `WWW-Authenticate` `request` parameters before decoding payment challenges. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))
 - Updated README documentation with an expanded protocol description, added an MPP SDKs table listing official implementations in multiple languages, and cleaned up URLs and prose throughout. (by @DerekCofausper, [#315](https://github.com/tempoxyz/mpp-rs/pull/315))

--- a/crates/alloy-transport-mpp/Cargo.toml
+++ b/crates/alloy-transport-mpp/Cargo.toml
@@ -42,17 +42,17 @@ url = "2"
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 http = "1"
 tokio = { version = "1", features = ["sync", "rt", "time", "macros"] }
-# Pinned to match the version used by alloy-transport-ws 2.0.x.
-tokio-tungstenite = "0.28"
+# Pinned to match the version used by alloy-transport-ws 2.x.
+tokio-tungstenite = "0.29"
 rustls = { version = "0.23", default-features = false, optional = true }
 
 [dev-dependencies]
 axum = { version = "0.8", features = ["ws"] }
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "time"] }
-# Pinned to match the version used by alloy-transport-ws 2.0.x so the
+# Pinned to match the version used by alloy-transport-ws 2.x so the
 # WebSocketConfig types align between the integration tests and the crate.
-tokio-tungstenite = "0.28"
+tokio-tungstenite = "0.29"
 
 [features]
 # Ring is the lightweight default. Consumers that require a different TLS

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -276,13 +276,22 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
         }
     }
 
+    let expires = params.get("expires").cloned();
+    if let Some(ref timestamp) = expires {
+        if !is_iso8601_timestamp(timestamp) {
+            return Err(MppError::invalid_challenge_reason(
+                "Invalid expires timestamp",
+            ));
+        }
+    }
+
     Ok(PaymentChallenge {
         id,
         realm,
         method,
         intent,
         request,
-        expires: params.get("expires").cloned(),
+        expires,
         description: params.get("description").cloned(),
         digest,
         opaque: params.get("opaque").map(Base64UrlJson::from_raw),
@@ -607,6 +616,15 @@ mod tests {
         // Verify request decodes correctly
         let request: serde_json::Value = parsed.request.decode_value().unwrap();
         assert_eq!(request["amount"], "10000");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_rejects_invalid_expires_timestamp() {
+        let header = r#"Payment id="abc", realm="api", method="tempo", intent="charge", request="e30", expires="not-a-date""#;
+
+        let err = parse_www_authenticate(header).unwrap_err();
+
+        assert!(err.to_string().contains("Invalid expires timestamp"));
     }
 
     #[test]


### PR DESCRIPTION
<!-- agricola:audit-finding=AGR-2026-025 target=rust -->
## Motivation

Agricola found that `tempoxyz/mpp-rs` accepts invalid challenge expiration timestamps that the canonical implementation rejects.

The [Agricola ticket #100](https://github.com/tempoxyz/mpp-tools/issues/100) contains the audit evidence, affected SDKs, and remediation lifecycle.

## Summary

- validate challenge `expires` values as RFC 3339 timestamps during header parsing
- add regression coverage for malformed expiration values and a native release-note fragment
- update the shared conformance workflow pin so the runner installs its locked Python dependencies
- align the Alloy transport WebSocket dependency with the version used by Alloy 2.x

## Key design considerations

- validate at the protocol parsing boundary before constructing `PaymentChallenge`
- reuse the existing timestamp validator and the target SDK's error conventions
- keep transitive WebSocket types on one compatible version
- retain the stable `agricola/agr-2026-025` automation branch