### PR TITLE
chore(deps): bump Tempo revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
-tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
+tempo-alloy = { version = "1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "0f87fa6b42c86665142432337865d1adc04238e7", default-features = false }
 
 [features]
 default = ["reqwest-default-tls"]


### PR DESCRIPTION
## Summary

Bump `tempo-alloy` to Tempo `0f87fa6b`, which includes T11 hardfork support. This keeps MPP aligned with Foundry’s Tempo dependency revision.

## Validation

- `cargo check --all-features`
- `cargo +nightly fmt --all -- --check`

This PR was authored by OpenAI Codex with human direction and review requested.

Prompted by: @0xrusowsky