### PR TITLE
feat(tempo): support machine-token charge payments

### DIFF
--- a/src/client/tempo/accounts_provider.rs
+++ b/src/client/tempo/accounts_provider.rs
@@ -272,7 +272,7 @@ impl TempoAccountsProvider {
 
         let rpc_provider = super::rpc_provider(self.settlement_rpc_url(charge.chain_id())?);
         let charge =
-            super::provider::apply_autoswap(charge, self.autoswap.as_ref(), &rpc_provider, from)
+            super::provider::apply_funding(charge, self.autoswap.as_ref(), &rpc_provider, from)
                 .await?;
         let request = charge.accounts_request(from)?;
         self.wallet
@@ -392,7 +392,7 @@ impl PaymentProvider for TempoAccountsProvider {
         )?;
         let rpc_provider = super::rpc_provider(self.settlement_rpc_url(charge.chain_id())?);
         let charge =
-            super::provider::apply_autoswap(charge, self.autoswap.as_ref(), &rpc_provider, from)
+            super::provider::apply_funding(charge, self.autoswap.as_ref(), &rpc_provider, from)
                 .await?;
 
         let signed = charge

--- a/src/client/tempo/charge/mod.rs
+++ b/src/client/tempo/charge/mod.rs
@@ -119,6 +119,7 @@ pub struct TempoCharge {
     memo: Option<[u8; 32]>,
     chain_id: u64,
     fee_payer: bool,
+    machine_token_enabled: bool,
     splits: Option<Vec<Split>>,
     calls: Option<Vec<Call>>,
 }
@@ -140,6 +141,7 @@ impl TempoCharge {
         let memo = parse_memo_bytes_checked(details.memo.as_deref())?;
         let chain_id = details.chain_id.unwrap_or(CHAIN_ID);
         let fee_payer = details.fee_payer();
+        let machine_token_enabled = details.machine_token_enabled();
         let splits = details.splits;
 
         get_transfers(amount, recipient, memo, splits.as_deref())?;
@@ -152,6 +154,7 @@ impl TempoCharge {
             memo,
             chain_id,
             fee_payer,
+            machine_token_enabled,
             splits,
             calls: None,
         })
@@ -198,6 +201,11 @@ impl TempoCharge {
     /// Whether fee sponsorship is requested.
     pub fn fee_payer(&self) -> bool {
         self.fee_payer
+    }
+
+    /// Whether the challenge enables canonical machine-token funding.
+    pub fn machine_token_enabled(&self) -> bool {
+        self.machine_token_enabled
     }
 
     /// Get the splits, if present.
@@ -251,6 +259,12 @@ impl TempoCharge {
         }
         self.calls.as_mut().unwrap().insert(0, call);
         Ok(self)
+    }
+
+    /// Replace the payment calls with one exact atomic route.
+    pub(crate) fn with_calls(mut self, calls: Vec<Call>) -> Self {
+        self.calls = Some(calls);
+        self
     }
 
     /// Sign the charge with default options.

--- a/src/client/tempo/provider.rs
+++ b/src/client/tempo/provider.rs
@@ -50,15 +50,35 @@ pub(super) async fn prepare_charge(
     from: alloy::primitives::Address,
 ) -> Result<TempoCharge, MppError> {
     let charge = prepare_charge_request(challenge, expected_chain_id, client_id)?;
-    apply_autoswap(charge, autoswap, provider, from).await
+    apply_funding(charge, autoswap, provider, from).await
 }
 
-pub(super) async fn apply_autoswap(
+pub(super) async fn apply_funding(
     mut charge: TempoCharge,
     autoswap: Option<&AutoswapConfig>,
     provider: &impl alloy::providers::Provider<tempo_alloy::TempoNetwork>,
     from: alloy::primitives::Address,
 ) -> Result<TempoCharge, MppError> {
+    if charge.machine_token_enabled() {
+        let transfers = crate::protocol::methods::tempo::transfers::get_transfers(
+            charge.amount(),
+            charge.recipient(),
+            charge.memo(),
+            charge.splits(),
+        )?;
+        if let Some(route) = crate::protocol::methods::tempo::machine_token::find_route(
+            provider,
+            from,
+            charge.chain_id(),
+            charge.currency(),
+            &transfers,
+        )
+        .await
+        {
+            return Ok(charge.with_calls(route.calls.to_vec()));
+        }
+    }
+
     if let Some(config) = autoswap {
         if let Some(calls) = super::autoswap::resolve_autoswap_calls(
             provider,

--- a/src/protocol/methods/tempo/charge.rs
+++ b/src/protocol/methods/tempo/charge.rs
@@ -40,6 +40,9 @@ pub trait TempoChargeExt {
     /// Check if fee sponsorship is enabled.
     fn fee_payer(&self) -> bool;
 
+    /// Check whether the canonical first-party machine token is enabled.
+    fn machine_token_enabled(&self) -> bool;
+
     /// Get the memo from methodDetails, if present.
     fn memo(&self) -> Option<String>;
 
@@ -89,6 +92,14 @@ impl TempoChargeExt for ChargeRequest {
         self.method_details
             .as_ref()
             .and_then(|v| v.get("feePayer"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+    }
+
+    fn machine_token_enabled(&self) -> bool {
+        self.method_details
+            .as_ref()
+            .and_then(|v| v.get("machineTokenEnabled"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
     }

--- a/src/protocol/methods/tempo/machine_token.rs
+++ b/src/protocol/methods/tempo/machine_token.rs
@@ -1,0 +1,287 @@
+//! Canonical first-party machine-token settlement routes.
+//!
+//! A machine-token payment approves the canonical swapper and calls `swapTo`
+//! atomically. The merchant continues to receive the challenge currency while
+//! the payer spends machineUSD.
+
+use alloy::primitives::{address, Address, Bytes, TxKind, U256};
+use alloy::providers::Provider;
+use alloy::sol_types::SolCall;
+use tempo_alloy::contracts::precompiles::ITIP20;
+use tempo_alloy::primitives::transaction::Call;
+use tempo_alloy::rpc::TempoTransactionRequest;
+
+use super::{transfers::Transfer, CHAIN_ID, MODERATO_CHAIN_ID};
+
+alloy::sol! {
+    interface IMachineTokenSwapper {
+        function swapTo(
+            address inputToken,
+            uint256 amount,
+            address targetToken,
+            address recipient,
+            bytes32 memo
+        ) external;
+    }
+}
+
+/// machineUSD on Tempo mainnet.
+pub const MACHINE_TOKEN_MAINNET: Address = address!("20C0000000000000000000003793c39601711f19");
+/// Canonical machineUSD swapper on Tempo mainnet.
+pub const MACHINE_TOKEN_SWAPPER_MAINNET: Address =
+    address!("C6D32f013E0fA3e83B63Dc680E99826761595732");
+/// machineUSD on Tempo Moderato.
+pub const MACHINE_TOKEN_TESTNET: Address = address!("20c000000000000000000000f85bbCa724044De0");
+/// Canonical machineUSD swapper on Tempo Moderato.
+pub const MACHINE_TOKEN_SWAPPER_TESTNET: Address =
+    address!("07f1FE0467Ae01DE340024aa4b7DD9729b1c169b");
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Deployment {
+    token: Address,
+    swapper: Address,
+}
+
+/// The exact canonical calls and settlement sender for a machine-token payment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MachineTokenRoute {
+    /// `approve` followed by `swapTo`.
+    pub calls: [Call; 2],
+    /// The swapper that emits the merchant-facing TIP-20 transfer.
+    pub settlement_sender: Address,
+    /// The single merchant transfer settled by the route.
+    pub transfer: Transfer,
+}
+
+fn deployment(chain_id: u64) -> Option<Deployment> {
+    match chain_id {
+        CHAIN_ID => Some(Deployment {
+            token: MACHINE_TOKEN_MAINNET,
+            swapper: MACHINE_TOKEN_SWAPPER_MAINNET,
+        }),
+        MODERATO_CHAIN_ID => Some(Deployment {
+            token: MACHINE_TOKEN_TESTNET,
+            swapper: MACHINE_TOKEN_SWAPPER_TESTNET,
+        }),
+        _ => None,
+    }
+}
+
+/// Returns whether a canonical machine-token route exists on `chain_id`.
+pub fn is_supported(chain_id: u64) -> bool {
+    deployment(chain_id).is_some()
+}
+
+/// Returns the trusted settlement sender for a supported chain.
+pub fn settlement_sender(chain_id: u64) -> Option<Address> {
+    deployment(chain_id).map(|deployment| deployment.swapper)
+}
+
+/// Build the canonical route for a compatible charge.
+///
+/// The route intentionally supports exactly one memo-bearing transfer. Split
+/// payments and unbound transfers fall back to ordinary funding behavior.
+pub fn route(
+    chain_id: u64,
+    currency: Address,
+    transfers: &[Transfer],
+) -> Option<MachineTokenRoute> {
+    let deployment = deployment(chain_id)?;
+    let transfer = match transfers {
+        [transfer] if transfer.memo.is_some() => transfer.clone(),
+        _ => return None,
+    };
+    let memo = transfer.memo?;
+    let approve = Call {
+        to: TxKind::Call(deployment.token),
+        value: U256::ZERO,
+        input: Bytes::from(
+            ITIP20::approveCall {
+                spender: deployment.swapper,
+                amount: transfer.amount,
+            }
+            .abi_encode(),
+        ),
+    };
+    let swap = Call {
+        to: TxKind::Call(deployment.swapper),
+        value: U256::ZERO,
+        input: Bytes::from(
+            IMachineTokenSwapper::swapToCall {
+                inputToken: deployment.token,
+                amount: transfer.amount,
+                targetToken: currency,
+                recipient: transfer.recipient,
+                memo: memo.into(),
+            }
+            .abi_encode(),
+        ),
+    };
+
+    Some(MachineTokenRoute {
+        calls: [approve, swap],
+        settlement_sender: deployment.swapper,
+        transfer,
+    })
+}
+
+/// Match only the exact canonical route for a charge.
+pub fn match_route(
+    calls: &[Call],
+    chain_id: u64,
+    currency: Address,
+    transfers: &[Transfer],
+) -> Option<MachineTokenRoute> {
+    let transfer = match transfers {
+        [transfer] => transfer.clone(),
+        _ => return None,
+    };
+    let swap = calls.get(1)?;
+    let decoded = IMachineTokenSwapper::swapToCall::abi_decode_raw(swap.input.get(4..)?).ok()?;
+    let mut transfer_with_memo = transfer;
+    if transfer_with_memo.memo.is_none() {
+        transfer_with_memo.memo = Some(decoded.memo.0);
+    }
+    let expected = route(chain_id, currency, &[transfer_with_memo])?;
+    if calls == expected.calls.as_slice() {
+        Some(expected)
+    } else {
+        None
+    }
+}
+
+/// Prefer machine-token funding when the payer has sufficient balance and the
+/// complete route simulates successfully. Any failure falls back to the
+/// client's existing funding behavior.
+pub async fn find_route<P: Provider<tempo_alloy::TempoNetwork>>(
+    provider: &P,
+    account: Address,
+    chain_id: u64,
+    currency: Address,
+    transfers: &[Transfer],
+) -> Option<MachineTokenRoute> {
+    let route = route(chain_id, currency, transfers)?;
+    let token = match route.calls[0].to {
+        TxKind::Call(token) => token,
+        TxKind::Create => return None,
+    };
+    let balance = ITIP20::new(token, provider)
+        .balanceOf(account)
+        .call()
+        .await
+        .ok()?;
+    if balance < route.transfer.amount {
+        return None;
+    }
+
+    let mut request = TempoTransactionRequest {
+        calls: route.calls.to_vec(),
+        ..Default::default()
+    };
+    request.inner.from = Some(account);
+    request.inner.chain_id = Some(chain_id);
+    provider.call(request).await.ok()?;
+    Some(route)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::sol_types::SolCall;
+
+    fn transfer() -> Transfer {
+        Transfer {
+            amount: U256::from(1_000_000),
+            recipient: Address::repeat_byte(0x22),
+            memo: Some([0xab; 32]),
+        }
+    }
+
+    #[test]
+    fn builds_and_matches_exact_canonical_route() {
+        let currency = Address::repeat_byte(0x33);
+        let route = route(MODERATO_CHAIN_ID, currency, &[transfer()]).unwrap();
+
+        assert_eq!(route.calls[0].to, TxKind::Call(MACHINE_TOKEN_TESTNET));
+        assert_eq!(
+            route.calls[1].to,
+            TxKind::Call(MACHINE_TOKEN_SWAPPER_TESTNET)
+        );
+        assert_eq!(
+            match_route(&route.calls, MODERATO_CHAIN_ID, currency, &[transfer()]),
+            Some(route.clone())
+        );
+
+        let approve = ITIP20::approveCall::abi_decode_raw(&route.calls[0].input[4..]).unwrap();
+        assert_eq!(approve.spender, MACHINE_TOKEN_SWAPPER_TESTNET);
+        assert_eq!(approve.amount, U256::from(1_000_000));
+        let swap =
+            IMachineTokenSwapper::swapToCall::abi_decode_raw(&route.calls[1].input[4..]).unwrap();
+        assert_eq!(swap.inputToken, MACHINE_TOKEN_TESTNET);
+        assert_eq!(swap.targetToken, currency);
+        assert_eq!(swap.recipient, Address::repeat_byte(0x22));
+    }
+
+    #[test]
+    fn rejects_mutated_and_incompatible_routes() {
+        let currency = Address::repeat_byte(0x33);
+        let canonical = route(MODERATO_CHAIN_ID, currency, &[transfer()]).unwrap();
+        let mut mutated = canonical.calls.to_vec();
+        mutated[0].value = U256::from(1);
+
+        assert!(match_route(&mutated, MODERATO_CHAIN_ID, currency, &[transfer()]).is_none());
+        assert!(route(1, currency, &[transfer()]).is_none());
+        assert!(route(MODERATO_CHAIN_ID, currency, &[]).is_none());
+        let mut without_memo = transfer();
+        without_memo.memo = None;
+        assert!(route(MODERATO_CHAIN_ID, currency, &[without_memo]).is_none());
+        assert!(route(MODERATO_CHAIN_ID, currency, &[transfer(), transfer()]).is_none());
+    }
+
+    #[tokio::test]
+    async fn finds_a_funded_route_after_successful_simulation() {
+        use alloy::providers::{mock::Asserter, ProviderBuilder};
+
+        let asserter = Asserter::new();
+        asserter.push_success(&Bytes::from(ITIP20::balanceOfCall::abi_encode_returns(
+            &U256::from(1_000_000),
+        )));
+        asserter.push_success(&Bytes::new());
+        let provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+            .connect_mocked_client(asserter);
+
+        let found = find_route(
+            &provider,
+            Address::repeat_byte(0x11),
+            MODERATO_CHAIN_ID,
+            Address::repeat_byte(0x33),
+            &[transfer()],
+        )
+        .await;
+
+        assert!(found.is_some());
+    }
+
+    #[tokio::test]
+    async fn falls_back_when_machine_token_balance_is_insufficient() {
+        use alloy::providers::{mock::Asserter, ProviderBuilder};
+
+        let asserter = Asserter::new();
+        asserter.push_success(&Bytes::from(ITIP20::balanceOfCall::abi_encode_returns(
+            &U256::from(999_999),
+        )));
+        let provider = ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+            .connect_mocked_client(asserter);
+
+        let found = find_route(
+            &provider,
+            Address::repeat_byte(0x11),
+            MODERATO_CHAIN_ID,
+            Address::repeat_byte(0x33),
+            &[transfer()],
+        )
+        .await;
+
+        assert!(found.is_none());
+    }
+}

--- a/src/protocol/methods/tempo/method.rs
+++ b/src/protocol/methods/tempo/method.rs
@@ -236,6 +236,14 @@ enum ParsedTransferLog {
     },
 }
 
+struct ReceiptSenderPolicy<'a> {
+    expected_sender: Address,
+    source: Option<&'a str>,
+    validate_sender: Option<&'a ValidateSenderCallback>,
+    transaction_sender: Address,
+    settlement_senders: &'a [Address],
+}
+
 impl ParsedTransferLog {
     fn address(&self) -> Address {
         match self {
@@ -354,6 +362,7 @@ fn parse_hash_credential_source(
     Ok(Some(parsed.address))
 }
 
+#[cfg(test)]
 fn match_receipt_transfer_logs(
     logs: &[serde_json::Value],
     expected_sender: Address,
@@ -361,6 +370,26 @@ fn match_receipt_transfer_logs(
     expected: &[Transfer],
     source: Option<&str>,
     validate_sender: Option<&ValidateSenderCallback>,
+) -> Result<Vec<MatchedTransferLog>, VerificationError> {
+    match_receipt_transfer_logs_with_settlement(
+        logs,
+        currency,
+        expected,
+        ReceiptSenderPolicy {
+            expected_sender,
+            source,
+            validate_sender,
+            transaction_sender: expected_sender,
+            settlement_senders: &[],
+        },
+    )
+}
+
+fn match_receipt_transfer_logs_with_settlement(
+    logs: &[serde_json::Value],
+    currency: Address,
+    expected: &[Transfer],
+    sender_policy: ReceiptSenderPolicy<'_>,
 ) -> Result<Vec<MatchedTransferLog>, VerificationError> {
     let mut sorted_expected: Vec<(usize, &Transfer)> = expected.iter().enumerate().collect();
     sorted_expected.sort_by_key(|(_, t)| if t.memo.is_some() { 0 } else { 1 });
@@ -409,14 +438,17 @@ fn match_receipt_transfer_logs(
 
                 // On a sender mismatch, validate_sender may authorize the log.
                 let sender = parsed.from();
-                if sender != expected_sender {
-                    let authorized = validate_sender.is_some_and(|cb| {
-                        cb(SenderValidation {
-                            expected_sender,
-                            sender,
-                            source,
-                        })
-                    });
+                if sender != sender_policy.expected_sender {
+                    let authorized = (sender_policy.transaction_sender
+                        == sender_policy.expected_sender
+                        && sender_policy.settlement_senders.contains(&sender))
+                        || sender_policy.validate_sender.is_some_and(|cb| {
+                            cb(SenderValidation {
+                                expected_sender: sender_policy.expected_sender,
+                                sender,
+                                source: sender_policy.source,
+                            })
+                        });
                     if !authorized {
                         continue;
                     }
@@ -491,6 +523,16 @@ pub struct SenderValidation<'a> {
 /// return `true` to accept.
 pub type ValidateSenderCallback =
     dyn for<'a> Fn(SenderValidation<'a>) -> bool + Send + Sync + 'static;
+
+fn request_settlement_senders(charge: &ChargeRequest, chain_id: u64) -> Vec<Address> {
+    if charge.machine_token_enabled() {
+        super::machine_token::settlement_sender(chain_id)
+            .into_iter()
+            .collect()
+    } else {
+        Vec::new()
+    }
+}
 
 /// Tempo charge method for one-time payment verification.
 ///
@@ -775,11 +817,15 @@ where
         // Tempo uses TIP-20 tokens exclusively (no native token transfers)
         let matched_logs = self.verify_tip20_transfers(
             &receipt,
-            expected_sender,
             currency,
             &expected,
-            source,
-            self.validate_sender.as_deref(),
+            ReceiptSenderPolicy {
+                expected_sender,
+                source,
+                validate_sender: self.validate_sender.as_deref(),
+                transaction_sender: receipt.from(),
+                settlement_senders: &request_settlement_senders(charge, expected_chain_id),
+            },
         )?;
 
         if charge.memo().is_none() {
@@ -809,11 +855,9 @@ where
     fn verify_tip20_transfers(
         &self,
         receipt: &<TempoNetwork as alloy::network::Network>::ReceiptResponse,
-        expected_sender: Address,
         currency: Address,
         expected: &[Transfer],
-        source: Option<&str>,
-        validate_sender: Option<&ValidateSenderCallback>,
+        sender_policy: ReceiptSenderPolicy<'_>,
     ) -> Result<Vec<MatchedTransferLog>, VerificationError> {
         let receipt_json = serde_json::to_value(receipt)
             .map_err(|e| VerificationError::new(format!("Failed to serialize receipt: {}", e)))?;
@@ -823,19 +867,13 @@ where
             .and_then(|v| v.as_array())
             .ok_or_else(|| VerificationError::new("Receipt has no logs".to_string()))?;
 
-        match_receipt_transfer_logs(
-            logs,
-            expected_sender,
-            currency,
-            expected,
-            source,
-            validate_sender,
-        )
+        match_receipt_transfer_logs_with_settlement(logs, currency, expected, sender_policy)
     }
 
     /// Validate that a transaction contains all expected payment calls (supports splits).
     ///
     /// Uses order-insensitive matching with memo-specificity sorting.
+    #[cfg(test)]
     fn validate_transaction_transfers(
         &self,
         tx_bytes: &[u8],
@@ -844,6 +882,26 @@ where
         expected_chain_id: u64,
         require_exact_calls: bool,
     ) -> Result<(), VerificationError> {
+        self.validate_transaction_transfers_with_machine_token(
+            tx_bytes,
+            currency,
+            expected,
+            expected_chain_id,
+            require_exact_calls,
+            false,
+        )
+        .map(|_| ())
+    }
+
+    fn validate_transaction_transfers_with_machine_token(
+        &self,
+        tx_bytes: &[u8],
+        currency: Address,
+        expected: &[Transfer],
+        expected_chain_id: u64,
+        require_exact_calls: bool,
+        machine_token_enabled: bool,
+    ) -> Result<Option<Address>, VerificationError> {
         if currency.is_zero() {
             return Err(VerificationError::new(
                 "Invalid currency: currency cannot be the zero address".to_string(),
@@ -878,6 +936,16 @@ where
                 "Fee-sponsored transaction gas limit {} exceeds maximum {}",
                 tx.gas_limit, policy.max_gas
             )));
+        }
+
+        let machine_token_route = machine_token_enabled
+            .then(|| {
+                super::machine_token::match_route(&tx.calls, expected_chain_id, currency, expected)
+            })
+            .flatten();
+
+        if let Some(route) = machine_token_route {
+            return Ok(Some(route.settlement_sender));
         }
 
         let transfer_calls = get_transfer_calls(&tx.calls)?;
@@ -994,7 +1062,7 @@ where
             ));
         }
 
-        Ok(())
+        Ok(None)
     }
 
     async fn broadcast_transaction(
@@ -1029,12 +1097,13 @@ where
             tx_bytes.to_vec()
         };
 
-        self.validate_transaction_transfers(
+        let settlement_sender = self.validate_transaction_transfers_with_machine_token(
             &final_tx_bytes,
             currency,
             &expected,
             expected_chain_id,
             charge.fee_payer(),
+            charge.machine_token_enabled(),
         )?;
 
         // The sponsor pays the gas here, so simulate first and bail if the tx
@@ -1080,8 +1149,19 @@ where
         }
 
         // Verify the receipt contains the expected TIP-20 transfer(s).
-        let matched_logs =
-            self.verify_tip20_transfers(&receipt, receipt.from(), currency, &expected, None, None)?;
+        let settlement_senders = settlement_sender.into_iter().collect::<Vec<_>>();
+        let matched_logs = self.verify_tip20_transfers(
+            &receipt,
+            currency,
+            &expected,
+            ReceiptSenderPolicy {
+                expected_sender: receipt.from(),
+                source: None,
+                validate_sender: None,
+                transaction_sender: receipt.from(),
+                settlement_senders: &settlement_senders,
+            },
+        )?;
         if charge.memo().is_none() {
             assert_challenge_bound_memo(&matched_logs, challenge_id, realm)?;
         }
@@ -2016,6 +2096,71 @@ mod tests {
         assert!(matched.contains(&MatchedTransferLog::Transfer));
     }
 
+    #[test]
+    fn test_match_receipt_transfer_logs_accepts_canonical_settlement_sender() {
+        let currency = Address::repeat_byte(0x20);
+        let payer = Address::repeat_byte(0x11);
+        let recipient = Address::repeat_byte(0x33);
+        let amount = U256::from(100u64);
+        let memo = attribution::encode("challenge-123", "api.example.com", None);
+        let swapper = super::super::machine_token::MACHINE_TOKEN_SWAPPER_MAINNET;
+        let logs = vec![make_transfer_with_memo_log(
+            currency, recipient, recipient, amount, memo,
+        )];
+        let expected = vec![Transfer {
+            amount,
+            recipient,
+            memo: Some(memo),
+        }];
+
+        let rejected = match_receipt_transfer_logs_with_settlement(
+            &logs,
+            currency,
+            &expected,
+            ReceiptSenderPolicy {
+                expected_sender: payer,
+                source: None,
+                validate_sender: None,
+                transaction_sender: payer,
+                settlement_senders: &[swapper],
+            },
+        );
+        assert!(rejected.is_err());
+
+        let logs = vec![make_transfer_with_memo_log(
+            currency, swapper, recipient, amount, memo,
+        )];
+        let matched = match_receipt_transfer_logs_with_settlement(
+            &logs,
+            currency,
+            &expected,
+            ReceiptSenderPolicy {
+                expected_sender: payer,
+                source: None,
+                validate_sender: None,
+                transaction_sender: payer,
+                settlement_senders: &[swapper],
+            },
+        )
+        .unwrap();
+        assert_eq!(matched, vec![MatchedTransferLog::Memo(memo)]);
+
+        let wrong_transaction_sender = Address::repeat_byte(0x44);
+        assert!(match_receipt_transfer_logs_with_settlement(
+            &logs,
+            currency,
+            &expected,
+            ReceiptSenderPolicy {
+                expected_sender: payer,
+                source: None,
+                validate_sender: None,
+                transaction_sender: wrong_transaction_sender,
+                settlement_senders: &[swapper],
+            },
+        )
+        .is_err());
+    }
+
     // ==================== Hash credential source validation ====================
 
     const HASH_SOURCE_INVALID: &str = "Hash credential source is invalid.";
@@ -2476,6 +2621,35 @@ mod tests {
         method
             .validate_transaction_transfers(&tx_bytes, currency, &expected, CHAIN_ID, true)
             .unwrap();
+    }
+
+    #[test]
+    fn test_validate_transaction_transfers_accepts_exact_machine_token_route() {
+        let provider =
+            alloy::providers::ProviderBuilder::new_with_network::<tempo_alloy::TempoNetwork>()
+                .connect_http("http://127.0.0.1:1".parse().unwrap());
+        let method = ChargeMethod::new(provider);
+        let currency = Address::repeat_byte(0x20);
+        let expected = vec![Transfer {
+            amount: U256::from(100u64),
+            recipient: Address::repeat_byte(0x33),
+            memo: Some([0xab; 32]),
+        }];
+        let route = super::super::machine_token::route(CHAIN_ID, currency, &expected).unwrap();
+        let tx_bytes = encode_signed_tx(route.calls.to_vec(), MAX_FEE_PAYER_GAS_LIMIT);
+
+        let settlement_sender = method
+            .validate_transaction_transfers_with_machine_token(
+                &tx_bytes, currency, &expected, CHAIN_ID, true, true,
+            )
+            .unwrap();
+        assert_eq!(settlement_sender, Some(route.settlement_sender));
+
+        assert!(method
+            .validate_transaction_transfers_with_machine_token(
+                &tx_bytes, currency, &expected, CHAIN_ID, true, false,
+            )
+            .is_err());
     }
 
     #[test]

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -99,6 +99,7 @@
 
 pub mod charge;
 pub mod fee_payer_envelope;
+pub mod machine_token;
 pub mod network;
 #[cfg(feature = "tempo")]
 pub mod precompile_voucher;

--- a/src/protocol/methods/tempo/types.rs
+++ b/src/protocol/methods/tempo/types.rs
@@ -53,6 +53,7 @@ pub struct Split {
 /// use mpp::protocol::methods::tempo::TempoMethodDetails;
 ///
 /// let details = TempoMethodDetails {
+///     machine_token_enabled: None,
 ///     chain_id: Some(42431),
 ///     fee_payer: Some(true),
 ///     memo: None,
@@ -62,6 +63,13 @@ pub struct Split {
 /// ```
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TempoMethodDetails {
+    /// Whether clients should prefer the canonical first-party machine token.
+    #[serde(
+        rename = "machineTokenEnabled",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub machine_token_enabled: Option<bool>,
+
     /// Chain ID (42431 for Tempo Moderato)
     #[serde(rename = "chainId", skip_serializing_if = "Option::is_none")]
     pub chain_id: Option<u64>,
@@ -90,6 +98,11 @@ pub struct TempoMethodDetails {
 }
 
 impl TempoMethodDetails {
+    /// Check whether first-party machine-token funding is enabled.
+    pub fn machine_token_enabled(&self) -> bool {
+        self.machine_token_enabled.unwrap_or(false)
+    }
+
     /// Check if fee sponsorship is enabled.
     pub fn fee_payer(&self) -> bool {
         self.fee_payer.unwrap_or(false)
@@ -113,6 +126,7 @@ mod tests {
     #[test]
     fn test_tempo_method_details_serialization() {
         let details = TempoMethodDetails {
+            machine_token_enabled: Some(true),
             chain_id: Some(42431),
             fee_payer: Some(true),
             memo: None,
@@ -122,10 +136,12 @@ mod tests {
         let json = serde_json::to_string(&details).unwrap();
         assert!(json.contains("\"chainId\":42431"));
         assert!(json.contains("\"feePayer\":true"));
+        assert!(json.contains("\"machineTokenEnabled\":true"));
 
         let parsed: TempoMethodDetails = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.chain_id, Some(42431));
         assert!(parsed.fee_payer());
+        assert!(parsed.machine_token_enabled());
         assert!(parsed.is_tempo_moderato());
     }
 
@@ -176,6 +192,7 @@ mod tests {
     #[test]
     fn test_serialization_with_memo() {
         let details = TempoMethodDetails {
+            machine_token_enabled: None,
             chain_id: Some(42431),
             fee_payer: Some(true),
             memo: Some("0xabcdef".to_string()),

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -109,6 +109,7 @@ pub struct Mpp<M, S = ()> {
     recipient: Option<String>,
     decimals: u32,
     fee_payer: bool,
+    machine_token_enabled: bool,
     chain_id: Option<u64>,
     opaque: Option<Base64UrlJson>,
     events: ServerEvents,
@@ -131,6 +132,7 @@ where
             recipient: None,
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -154,6 +156,7 @@ where
             recipient: Some(recipient.into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -176,6 +179,7 @@ where
             recipient: self.recipient,
             decimals: self.decimals,
             fee_payer: self.fee_payer,
+            machine_token_enabled: self.machine_token_enabled,
             chain_id: self.chain_id,
             opaque: self.opaque,
             events: self.events,
@@ -275,6 +279,11 @@ where
     /// Get whether fee sponsorship is enabled.
     pub fn fee_payer(&self) -> bool {
         self.fee_payer
+    }
+
+    /// Get whether canonical first-party machine-token funding is advertised.
+    pub fn machine_token_enabled(&self) -> bool {
+        self.machine_token_enabled
     }
 
     /// Get the configured chain ID, if set.
@@ -501,6 +510,9 @@ where
             let mut details = serde_json::Map::new();
             if options.fee_payer || self.fee_payer {
                 details.insert("feePayer".into(), serde_json::json!(true));
+            }
+            if self.machine_token_enabled {
+                details.insert("machineTokenEnabled".into(), serde_json::json!(true));
             }
             if let Some(chain_id) = self.chain_id {
                 details.insert("chainId".into(), serde_json::json!(chain_id));
@@ -1041,6 +1053,16 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
     /// let challenge = mpp.charge("1.00")?;
     /// ```
     pub fn create(builder: super::TempoBuilder) -> Result<Self> {
+        if builder.machine_token_enabled {
+            let chain_id = builder
+                .chain_id
+                .unwrap_or(crate::protocol::methods::tempo::CHAIN_ID);
+            if !crate::protocol::methods::tempo::machine_token::is_supported(chain_id) {
+                return Err(crate::error::MppError::InvalidConfig(format!(
+                    "machine tokens are not supported on chain ID {chain_id}"
+                )));
+            }
+        }
         let secret_key = builder
             .secret_key
             .or_else(|| std::env::var(SECRET_KEY_ENV_VAR).ok())
@@ -1085,6 +1107,7 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
             recipient: Some(builder.recipient),
             decimals: builder.decimals,
             fee_payer: builder.fee_payer,
+            machine_token_enabled: builder.machine_token_enabled,
             chain_id: builder.chain_id,
             opaque: None,
             events: ServerEvents::default(),
@@ -1245,6 +1268,7 @@ impl Mpp<crate::protocol::methods::stripe::method::ChargeMethod> {
             recipient: None,
             decimals: builder.decimals as u32,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -1811,6 +1835,44 @@ mod tests {
 
     #[cfg(feature = "tempo")]
     #[test]
+    fn test_machine_token_charge_hint() {
+        let mpp = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .chain_id(CHAIN_ID)
+            .machine_token_enabled(true)
+            .secret_key("test-secret"),
+        )
+        .unwrap();
+
+        let challenge = mpp.charge("1").unwrap();
+        let request: ChargeRequest = challenge.request.decode().unwrap();
+        assert!(mpp.machine_token_enabled());
+        assert!(request.machine_token_enabled());
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
+    fn test_machine_token_rejects_unsupported_chain() {
+        let result = Mpp::create(
+            tempo(TempoConfig {
+                recipient: "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2",
+            })
+            .chain_id(1)
+            .machine_token_enabled(true)
+            .secret_key("test-secret"),
+        );
+        match result {
+            Ok(_) => panic!("unsupported machine-token chain should fail"),
+            Err(error) => assert!(error
+                .to_string()
+                .contains("machine tokens are not supported")),
+        }
+    }
+
+    #[cfg(feature = "tempo")]
+    #[test]
     fn test_charge_default_expires() {
         let mpp = create_test_mpp();
         let challenge = mpp.charge("1").unwrap();
@@ -1899,6 +1961,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -2505,6 +2568,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -2582,6 +2646,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -2626,6 +2691,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),
@@ -2728,6 +2794,7 @@ mod tests {
             recipient: Some("0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2".into()),
             decimals: DEFAULT_DECIMALS,
             fee_payer: false,
+            machine_token_enabled: false,
             chain_id: None,
             opaque: None,
             events: ServerEvents::default(),

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -33,6 +33,7 @@ pub struct TempoBuilder {
     pub(crate) secret_key: Option<String>,
     pub(crate) decimals: u32,
     pub(crate) fee_payer: bool,
+    pub(crate) machine_token_enabled: bool,
     pub(crate) chain_id: Option<u64>,
     pub(crate) fee_payer_signer: Option<alloy::signers::local::PrivateKeySigner>,
     pub(crate) fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
@@ -92,6 +93,15 @@ impl TempoBuilder {
     /// that will sponsor transaction fees.
     pub fn fee_payer(mut self, enabled: bool) -> Self {
         self.fee_payer = enabled;
+        self
+    }
+
+    /// Advertise canonical first-party machine-token funding for charges.
+    ///
+    /// Clients that support this hint prefer machineUSD and atomically settle
+    /// the configured challenge currency through the canonical swapper.
+    pub fn machine_token_enabled(mut self, enabled: bool) -> Self {
+        self.machine_token_enabled = enabled;
         self
     }
 
@@ -180,6 +190,7 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         secret_key: None,
         decimals: 6,
         fee_payer: false,
+        machine_token_enabled: false,
         chain_id: None,
         fee_payer_signer: None,
         fee_payer_allowed_fee_tokens: None,


### PR DESCRIPTION
## Summary
- add canonical machineUSD deployments and exact approve + swapTo routing for Tempo mainnet and Moderato
- prefer funded, successfully simulated machine-token routes before autoswap on charge clients
- advertise machineTokenEnabled from server builders and verify canonical calls and swapper settlement logs

Ports the behavior merged in https://github.com/wevm/mppx/pull/784.

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
- cargo test --all-features --lib machine_token

The external Tempo localnet suite was not run because localhost:8545 was not running.