### PR TITLE
feat(mcp): add paid client wrapper

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -20,7 +20,7 @@
 #[cfg(feature = "client")]
 mod accept_payment_policy;
 #[cfg(feature = "client")]
-mod challenge_selection;
+pub(crate) mod challenge_selection;
 mod error;
 mod events;
 mod provider;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -9,6 +9,7 @@
 //! - [`PAYMENT_REQUIRED_CODE`]: JSON-RPC error code for payment required (-32042)
 //! - [`PAYMENT_VERIFICATION_FAILED_CODE`]: JSON-RPC error code for verification failed (-32043)
 //! - [`CREDENTIAL_META_KEY`]: Metadata key for credentials in `_meta`
+//! - [`PAYMENT_REQUIRED_META_KEY`]: Metadata key for payment-required tool results
 //! - [`RECEIPT_META_KEY`]: Metadata key for receipts in `_meta`
 //!
 //! # Server-side
@@ -22,7 +23,9 @@
 //!
 //! - [`is_payment_required`]: Check if a JSON-RPC error indicates payment required
 //! - [`extract_challenges`]: Extract challenges from a payment-required error
+//! - [`extract_challenges_from_data`]: Extract challenges from a payment-required payload
 //! - [`attach_credential`]: Attach a credential to MCP request params `_meta`
+//! - [`client::McpClient`]: Wrap an MCP SDK adapter with automatic payment handling
 //!
 //! # Example (server)
 //!
@@ -47,7 +50,16 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::core::challenge::{PaymentChallenge, PaymentCredential, Receipt};
+use crate::{
+    protocol::core::{
+        challenge::{PaymentChallenge, PaymentCredential, Receipt},
+        Base64UrlJson,
+    },
+    MppError,
+};
+
+#[cfg(feature = "client")]
+pub mod client;
 
 // ==================== Constants ====================
 
@@ -59,6 +71,9 @@ pub const PAYMENT_VERIFICATION_FAILED_CODE: i32 = -32043;
 
 /// MCP metadata key for credentials.
 pub const CREDENTIAL_META_KEY: &str = "org.paymentauth/credential";
+
+/// MCP metadata key for payment-required tool results.
+pub const PAYMENT_REQUIRED_META_KEY: &str = "org.paymentauth/payment-required";
 
 /// MCP metadata key for receipts.
 pub const RECEIPT_META_KEY: &str = "org.paymentauth/receipt";
@@ -101,8 +116,9 @@ pub struct McpPaymentErrorData {
 /// Expects the `_meta` object (not the full params). Returns `None` if the
 /// credential key is missing or the value cannot be deserialized.
 pub fn extract_credential(meta: &serde_json::Value) -> Option<PaymentCredential> {
-    let cred_value = meta.get(CREDENTIAL_META_KEY)?;
-    serde_json::from_value(cred_value.clone()).ok()
+    let mut credential = meta.get(CREDENTIAL_META_KEY)?.clone();
+    normalize_wire_challenge(credential.get_mut("challenge")?)?;
+    serde_json::from_value(credential).ok()
 }
 
 /// Create an MCP payment-required error response.
@@ -178,8 +194,81 @@ pub fn is_payment_required(error: &serde_json::Value) -> bool {
 /// Returns `None` if the error has no `data.challenges` array or
 /// if deserialization fails.
 pub fn extract_challenges(error: &serde_json::Value) -> Option<Vec<PaymentChallenge>> {
-    let challenges_value = error.get("data")?.get("challenges")?;
-    serde_json::from_value(challenges_value.clone()).ok()
+    extract_challenges_from_data(error.get("data")?)
+}
+
+/// Extracts challenges from an MCP payment-required data payload.
+///
+/// Accepts MCP's expanded JSON `request` object and normalizes it to the
+/// base64url representation retained by the core protocol types.
+pub fn extract_challenges_from_data(
+    payment_required: &serde_json::Value,
+) -> Option<Vec<PaymentChallenge>> {
+    let challenges_value = payment_required.get("challenges")?;
+    extract_wire_challenges(challenges_value)
+}
+
+/// Extract challenges from an MCP tool result's payment-required metadata.
+///
+/// Expects the result `_meta` object (not the complete tool result). Returns
+/// `None` when the metadata key is absent or its challenge list is invalid.
+pub fn extract_result_challenges(meta: &serde_json::Value) -> Option<Vec<PaymentChallenge>> {
+    extract_challenges_from_data(meta.get(PAYMENT_REQUIRED_META_KEY)?)
+}
+
+fn extract_wire_challenges(value: &serde_json::Value) -> Option<Vec<PaymentChallenge>> {
+    value
+        .as_array()?
+        .iter()
+        .map(|challenge| {
+            let mut challenge = challenge.clone();
+            normalize_wire_challenge(&mut challenge)?;
+            serde_json::from_value(challenge).ok()
+        })
+        .collect()
+}
+
+fn normalize_wire_challenge(challenge: &mut serde_json::Value) -> Option<()> {
+    let object = challenge.as_object_mut()?;
+    let request = object.get("request")?;
+    if !request.is_string() {
+        let request = Base64UrlJson::from_value(request).ok()?;
+        object.insert(
+            "request".to_owned(),
+            serde_json::Value::String(request.raw().to_owned()),
+        );
+    }
+    if !object.contains_key("opaque") {
+        if let Some(meta) = object.get("meta") {
+            let opaque = Base64UrlJson::from_value(meta).ok()?;
+            object.insert(
+                "opaque".to_owned(),
+                serde_json::Value::String(opaque.raw().to_owned()),
+            );
+        }
+    }
+    Some(())
+}
+
+/// Encodes a credential for MCP request metadata.
+///
+/// MCP carries the challenge request as expanded JSON, unlike the base64url
+/// representation used by HTTP Payment authentication.
+pub fn credential_value(credential: &PaymentCredential) -> Result<serde_json::Value, MppError> {
+    let mut value = serde_json::to_value(credential)
+        .map_err(|error| MppError::InvalidConfig(error.to_string()))?;
+    let challenge = value
+        .get_mut("challenge")
+        .and_then(serde_json::Value::as_object_mut)
+        .ok_or_else(|| MppError::InvalidConfig("credential challenge is invalid".to_owned()))?;
+    challenge.insert(
+        "request".to_owned(),
+        credential.challenge.request.decode_value()?,
+    );
+    if let Some(opaque) = &credential.challenge.opaque {
+        challenge.insert("meta".to_owned(), opaque.decode_value()?);
+    }
+    Ok(value)
 }
 
 /// Attach a credential to MCP request `params._meta`.
@@ -187,8 +276,8 @@ pub fn extract_challenges(error: &serde_json::Value) -> Option<Vec<PaymentChalle
 /// Inserts (or creates) `params._meta` and sets the credential
 /// under [`CREDENTIAL_META_KEY`].
 pub fn attach_credential(params: &mut serde_json::Value, credential: &PaymentCredential) {
-    let cred_value =
-        serde_json::to_value(credential).expect("PaymentCredential must be serializable");
+    let cred_value = credential_value(credential)
+        .expect("PaymentCredential challenge must contain valid base64url JSON");
 
     let meta = params
         .as_object_mut()
@@ -462,6 +551,46 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_challenges_accepts_expanded_mcp_request() {
+        let error = json!({
+            "code": PAYMENT_REQUIRED_CODE,
+            "message": "Payment Required",
+            "data": {
+                "httpStatus": 402,
+                "challenges": [{
+                    "id": "mercator-challenge",
+                    "realm": "mercator.example",
+                    "method": "tempo",
+                    "intent": "charge",
+                    "request": {
+                        "amount": "6000",
+                        "currency": "0x20c000000000000000000000b9537d11c60e8b50",
+                        "methodDetails": {"chainId": 4217}
+                    },
+                    "meta": {"scope": "job:123"}
+                }]
+            }
+        });
+
+        let challenges = extract_challenges(&error).unwrap();
+
+        assert_eq!(challenges[0].id, "mercator-challenge");
+        assert_eq!(
+            challenges[0].request.decode_value().unwrap()["amount"],
+            "6000"
+        );
+        assert_eq!(
+            challenges[0]
+                .opaque
+                .as_ref()
+                .unwrap()
+                .decode_value()
+                .unwrap()["scope"],
+            "job:123"
+        );
+    }
+
+    #[test]
     fn test_extract_challenges_rejects_invalid_method_name() {
         let mut challenge = serde_json::to_value(test_challenge()).unwrap();
         challenge["method"] = json!("123");
@@ -525,6 +654,27 @@ mod tests {
         let meta = params.get("_meta").unwrap();
         let cred_value = meta.get(CREDENTIAL_META_KEY).unwrap();
         assert_eq!(cred_value["challenge"]["id"], "ch_test_123");
+        assert_eq!(cred_value["challenge"]["request"]["amount"], "1000");
+    }
+
+    #[test]
+    fn test_mcp_credential_wire_roundtrip_preserves_opaque_meta() {
+        let mut credential = test_credential();
+        credential.challenge.opaque =
+            Some(Base64UrlJson::from_value(&json!({"scope": "job:123"})).unwrap());
+        let encoded = credential_value(&credential).unwrap();
+        assert_eq!(encoded["challenge"]["request"]["amount"], "1000");
+        assert_eq!(encoded["challenge"]["meta"]["scope"], "job:123");
+
+        let decoded = extract_credential(&json!({CREDENTIAL_META_KEY: encoded})).unwrap();
+        assert_eq!(
+            decoded.challenge.request.raw(),
+            credential.challenge.request.raw()
+        );
+        assert_eq!(
+            decoded.challenge.opaque.unwrap().raw(),
+            credential.challenge.opaque.unwrap().raw()
+        );
     }
 
     #[test]

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1,0 +1,654 @@
+//! Automatic client-side payments for MCP tool calls.
+//!
+//! [`McpClient`] owns the payment retry and provider lifecycle while
+//! [`ToolCaller`] adapts a concrete MCP SDK. The wrapper deliberately knows
+//! nothing about one SDK's request, result, or error types.
+
+use std::future::Future;
+
+use thiserror::Error;
+
+use crate::{
+    client::{
+        challenge_selection::{
+            expired_payment_error, select_supported_challenge, ChallengeSelectionError,
+        },
+        PaymentContext, PaymentProvider,
+    },
+    MppError, PaymentChallenge, PaymentCredential,
+};
+
+/// Adapts one concrete MCP SDK's tool-call boundary.
+///
+/// Implementations identify payment challenges in both JSON-RPC errors and
+/// successful tool results, attach a typed credential to request metadata,
+/// and distinguish definitive server rejection from ambiguous delivery
+/// failure. Ambiguous failures are never rolled back.
+pub trait ToolCaller: Send + Sync {
+    /// SDK-specific tool-call parameters.
+    type Params: Clone + Send;
+    /// SDK-specific successful tool result.
+    type Output: Send;
+    /// SDK-specific tool-call error.
+    type Error: Send;
+
+    /// Calls one MCP tool exactly once.
+    fn call_tool(
+        &self,
+        params: Self::Params,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+
+    /// Extracts valid payment challenges from a JSON-RPC error.
+    fn payment_challenges_from_error(&self, error: &Self::Error) -> Option<Vec<PaymentChallenge>>;
+
+    /// Extracts valid payment challenges from tool-result metadata.
+    fn payment_challenges_from_output(
+        &self,
+        _output: &Self::Output,
+    ) -> Option<Vec<PaymentChallenge>> {
+        None
+    }
+
+    /// Adds a payment credential to the outgoing request metadata.
+    fn attach_credential(
+        &self,
+        params: &mut Self::Params,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError>;
+
+    /// Returns whether the server definitively rejected the paid retry.
+    ///
+    /// Transport errors and cancellation must return `false`: the server may
+    /// have accepted the credential even when the response was lost.
+    fn is_definitive_error(&self, _error: &Self::Error) -> bool {
+        false
+    }
+}
+
+/// Failure from an automatic paid MCP tool call.
+#[derive(Debug, Error)]
+pub enum McpClientError<E> {
+    /// The underlying MCP SDK failed.
+    #[error("MCP tool call failed: {0}")]
+    Transport(E),
+    /// Payment challenge selection, credential creation, or reconciliation failed.
+    #[error(transparent)]
+    Payment(#[from] MppError),
+}
+
+/// Provider-backed payment preparation for an MCP transport.
+///
+/// This lower-level API lets an MCP SDK adapter own its native request and
+/// retry types while MPP owns challenge selection and payment lifecycle.
+#[derive(Clone)]
+pub struct McpPayment<P> {
+    provider: P,
+    context: PaymentContext,
+}
+
+impl<P> McpPayment<P> {
+    /// Creates payment state for one MCP resource.
+    pub fn new(provider: P, context: PaymentContext) -> Self {
+        Self { provider, context }
+    }
+
+    /// Returns the payment provider.
+    pub fn provider(&self) -> &P {
+        &self.provider
+    }
+
+    /// Returns the challenged resource context.
+    pub fn context(&self) -> &PaymentContext {
+        &self.context
+    }
+}
+
+impl<P> McpPayment<P>
+where
+    P: PaymentProvider,
+{
+    /// Selects and pays one supported challenge.
+    ///
+    /// Returns `Ok(None)` when the provider supports none of the challenges,
+    /// so the caller can preserve the original MCP result or error.
+    pub async fn prepare(
+        &self,
+        challenges: &[PaymentChallenge],
+    ) -> Result<Option<PendingPayment<P>>, MppError> {
+        let ranking = self.provider.accept_payment_header();
+        let challenge = match select_supported_challenge(
+            challenges,
+            ranking.as_deref(),
+            |challenge| {
+                self.provider
+                    .supports(challenge.method.as_str(), challenge.intent.as_str())
+            },
+            |candidates| self.provider.select_challenge(candidates),
+        ) {
+            Ok(challenge) => challenge.clone(),
+            Err(ChallengeSelectionError::Expired(challenge)) => {
+                return Err(expired_payment_error(&challenge));
+            }
+            Err(ChallengeSelectionError::NoSupportedChallenge(_)) => return Ok(None),
+        };
+
+        let credential = self
+            .provider
+            .pay_with_context(&challenge, self.context.clone())
+            .await?;
+        Ok(Some(PendingPayment {
+            provider: self.provider.clone(),
+            challenge,
+            credential,
+            active: true,
+        }))
+    }
+}
+
+/// A prepared MCP payment awaiting a definitive delivery outcome.
+///
+/// Dropping an active payment invokes [`PaymentProvider::abandon_payment`],
+/// which is the cancellation and ambiguous-delivery path. Call [`Self::commit`]
+/// after acceptance or [`Self::rollback`] when the credential was not sent or
+/// was definitively rejected.
+pub struct PendingPayment<P: PaymentProvider> {
+    provider: P,
+    challenge: PaymentChallenge,
+    credential: PaymentCredential,
+    active: bool,
+}
+
+impl<P: PaymentProvider> PendingPayment<P> {
+    /// Returns the selected challenge.
+    pub fn challenge(&self) -> &PaymentChallenge {
+        &self.challenge
+    }
+
+    /// Returns the credential to attach to MCP request metadata.
+    pub fn credential(&self) -> &PaymentCredential {
+        &self.credential
+    }
+
+    /// Commits provider state after the server accepts the credential.
+    pub async fn commit(mut self) -> Result<(), MppError> {
+        self.provider
+            .commit_payment(&self.challenge, &self.credential)
+            .await?;
+        self.active = false;
+        Ok(())
+    }
+
+    /// Rolls back provider state after definitive non-delivery or rejection.
+    pub async fn rollback(mut self) -> Result<(), MppError> {
+        self.provider
+            .rollback_payment(&self.challenge, &self.credential)
+            .await?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl<P: PaymentProvider> Drop for PendingPayment<P> {
+    fn drop(&mut self) {
+        if self.active {
+            self.provider
+                .abandon_payment(&self.challenge, &self.credential);
+        }
+    }
+}
+
+/// An MCP tool caller wrapped with automatic MPP payment handling.
+#[derive(Clone)]
+pub struct McpClient<C, P> {
+    caller: C,
+    payment: McpPayment<P>,
+}
+
+/// Wraps an MCP SDK adapter with automatic MPP payment handling.
+pub fn wrap<C, P>(caller: C, provider: P, context: PaymentContext) -> McpClient<C, P> {
+    McpClient::new(caller, provider, context)
+}
+
+impl<C, P> McpClient<C, P> {
+    /// Wraps an MCP SDK adapter with the supplied payment provider and resource context.
+    pub fn new(caller: C, provider: P, context: PaymentContext) -> Self {
+        Self {
+            caller,
+            payment: McpPayment::new(provider, context),
+        }
+    }
+
+    /// Returns the wrapped MCP SDK adapter.
+    pub fn caller(&self) -> &C {
+        &self.caller
+    }
+
+    /// Consumes the wrapper and returns the MCP SDK adapter.
+    pub fn into_caller(self) -> C {
+        self.caller
+    }
+}
+
+impl<C, P> McpClient<C, P>
+where
+    C: ToolCaller,
+    P: PaymentProvider,
+{
+    /// Calls a tool, satisfying one MCP payment challenge when necessary.
+    ///
+    /// Free calls pass through unchanged. A supported, unexpired challenge is
+    /// paid once and the exact request is retried with its credential in
+    /// `_meta`. Successful retries commit provider state. Definitive rejection
+    /// rolls it back; cancellation and transport ambiguity invoke only the
+    /// provider's synchronous abandonment hook.
+    pub async fn call_tool(
+        &self,
+        params: C::Params,
+    ) -> Result<C::Output, McpClientError<C::Error>> {
+        let initial = self.caller.call_tool(params.clone()).await;
+        let challenges = match &initial {
+            Ok(output) => self.caller.payment_challenges_from_output(output),
+            Err(error) => self.caller.payment_challenges_from_error(error),
+        };
+        let Some(challenges) = challenges else {
+            return initial.map_err(McpClientError::Transport);
+        };
+
+        let Some(pending) = self.payment.prepare(&challenges).await? else {
+            return initial.map_err(McpClientError::Transport);
+        };
+
+        let mut paid = params;
+        if let Err(error) = self
+            .caller
+            .attach_credential(&mut paid, pending.credential())
+        {
+            pending.rollback().await?;
+            return Err(error.into());
+        }
+
+        match self.caller.call_tool(paid).await {
+            Ok(output) => {
+                if self
+                    .caller
+                    .payment_challenges_from_output(&output)
+                    .is_some()
+                {
+                    pending.rollback().await?;
+                } else {
+                    pending.commit().await?;
+                }
+                Ok(output)
+            }
+            Err(error) if self.caller.is_definitive_error(&error) => {
+                pending.rollback().await?;
+                Err(McpClientError::Transport(error))
+            }
+            Err(error) => Err(McpClientError::Transport(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::VecDeque,
+        future::pending,
+        sync::{
+            atomic::{AtomicBool, AtomicUsize, Ordering},
+            Arc, Mutex,
+        },
+    };
+
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::{
+        mcp::{extract_result_challenges, CREDENTIAL_META_KEY, PAYMENT_REQUIRED_META_KEY},
+        Base64UrlJson, PaymentPayload,
+    };
+
+    #[derive(Default)]
+    struct Lifecycle {
+        abandons: AtomicUsize,
+        commits: AtomicUsize,
+        fail_commit: AtomicBool,
+        pays: AtomicUsize,
+        rollbacks: AtomicUsize,
+    }
+
+    #[derive(Clone)]
+    struct TestProvider {
+        lifecycle: Arc<Lifecycle>,
+        supported: bool,
+    }
+
+    impl TestProvider {
+        fn new() -> Self {
+            Self {
+                lifecycle: Arc::new(Lifecycle::default()),
+                supported: true,
+            }
+        }
+
+        fn unsupported() -> Self {
+            Self {
+                lifecycle: Arc::new(Lifecycle::default()),
+                supported: false,
+            }
+        }
+    }
+
+    impl PaymentProvider for TestProvider {
+        fn supports(&self, method: &str, intent: &str) -> bool {
+            self.supported && method == "tempo" && intent == "charge"
+        }
+
+        async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.lifecycle.pays.fetch_add(1, Ordering::SeqCst);
+            Ok(PaymentCredential::new(
+                challenge.to_echo(),
+                PaymentPayload::hash("test-proof"),
+            ))
+        }
+
+        async fn commit_payment(
+            &self,
+            _challenge: &PaymentChallenge,
+            _credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.lifecycle.commits.fetch_add(1, Ordering::SeqCst);
+            if self.lifecycle.fail_commit.load(Ordering::SeqCst) {
+                Err(MppError::InvalidConfig(
+                    "injected commit failure".to_owned(),
+                ))
+            } else {
+                Ok(())
+            }
+        }
+
+        async fn rollback_payment(
+            &self,
+            _challenge: &PaymentChallenge,
+            _credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.lifecycle.rollbacks.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn abandon_payment(&self, _challenge: &PaymentChallenge, _credential: &PaymentCredential) {
+            self.lifecycle.abandons.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestError {
+        challenges: Option<Vec<PaymentChallenge>>,
+        definitive: bool,
+        message: &'static str,
+    }
+
+    impl std::fmt::Display for TestError {
+        fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str(self.message)
+        }
+    }
+
+    impl std::error::Error for TestError {}
+
+    #[derive(Clone)]
+    struct TestCaller {
+        calls: Arc<Mutex<Vec<Value>>>,
+        outcomes: Arc<Mutex<VecDeque<Result<Value, TestError>>>>,
+    }
+
+    impl TestCaller {
+        fn new(outcomes: impl IntoIterator<Item = Result<Value, TestError>>) -> Self {
+            Self {
+                calls: Arc::new(Mutex::new(Vec::new())),
+                outcomes: Arc::new(Mutex::new(outcomes.into_iter().collect())),
+            }
+        }
+    }
+
+    impl ToolCaller for TestCaller {
+        type Params = Value;
+        type Output = Value;
+        type Error = TestError;
+
+        async fn call_tool(&self, params: Self::Params) -> Result<Self::Output, Self::Error> {
+            self.calls.lock().unwrap().push(params);
+            self.outcomes
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("test outcome")
+        }
+
+        fn payment_challenges_from_error(
+            &self,
+            error: &Self::Error,
+        ) -> Option<Vec<PaymentChallenge>> {
+            error.challenges.clone()
+        }
+
+        fn payment_challenges_from_output(
+            &self,
+            output: &Self::Output,
+        ) -> Option<Vec<PaymentChallenge>> {
+            output.get("_meta").and_then(extract_result_challenges)
+        }
+
+        fn attach_credential(
+            &self,
+            params: &mut Self::Params,
+            credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            crate::mcp::attach_credential(params, credential);
+            Ok(())
+        }
+
+        fn is_definitive_error(&self, error: &Self::Error) -> bool {
+            error.definitive
+        }
+    }
+
+    fn challenge() -> PaymentChallenge {
+        PaymentChallenge::new(
+            "challenge-1",
+            "mcp.example.test",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&json!({"amount": "1"})).unwrap(),
+        )
+    }
+
+    fn payment_error(definitive: bool) -> TestError {
+        TestError {
+            challenges: Some(vec![challenge()]),
+            definitive,
+            message: "payment required",
+        }
+    }
+
+    fn transport_error(definitive: bool) -> TestError {
+        TestError {
+            challenges: None,
+            definitive,
+            message: "tool failed",
+        }
+    }
+
+    fn context() -> PaymentContext {
+        PaymentContext {
+            url: "https://mcp.example.test/mcp".parse().unwrap(),
+            headers: reqwest::header::HeaderMap::new(),
+        }
+    }
+
+    fn params() -> Value {
+        json!({"name": "paid_tool", "arguments": {}})
+    }
+
+    #[tokio::test]
+    async fn free_tool_calls_pass_through() {
+        let caller = TestCaller::new([Ok(json!({"content": "free"}))]);
+        let provider = TestProvider::new();
+        let client = McpClient::new(caller.clone(), provider.clone(), context());
+
+        let result = client.call_tool(params()).await.unwrap();
+
+        assert_eq!(result["content"], "free");
+        assert_eq!(caller.calls.lock().unwrap().len(), 1);
+        assert_eq!(provider.lifecycle.pays.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn payment_errors_retry_once_and_commit() {
+        let caller = TestCaller::new([Err(payment_error(true)), Ok(json!({"content": "paid"}))]);
+        let provider = TestProvider::new();
+        let client = McpClient::new(caller.clone(), provider.clone(), context());
+
+        let result = client.call_tool(params()).await.unwrap();
+
+        assert_eq!(result["content"], "paid");
+        let calls = caller.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        assert!(calls[1]["_meta"].get(CREDENTIAL_META_KEY).is_some());
+        assert_eq!(provider.lifecycle.pays.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.lifecycle.commits.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.lifecycle.rollbacks.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.lifecycle.abandons.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn payment_required_results_retry_once_and_commit() {
+        let caller = TestCaller::new([
+            Ok(json!({
+                "_meta": {
+                    PAYMENT_REQUIRED_META_KEY: {"challenges": [challenge()]}
+                },
+                "isError": true
+            })),
+            Ok(json!({"content": "paid"})),
+        ]);
+        let provider = TestProvider::new();
+        let client = McpClient::new(caller, provider.clone(), context());
+
+        let result = client.call_tool(params()).await.unwrap();
+
+        assert_eq!(result["content"], "paid");
+        assert_eq!(provider.lifecycle.commits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn unsupported_challenges_preserve_the_original_error() {
+        let caller = TestCaller::new([Err(payment_error(true))]);
+        let provider = TestProvider::unsupported();
+        let client = McpClient::new(caller, provider.clone(), context());
+
+        let error = client.call_tool(params()).await.unwrap_err();
+
+        assert!(matches!(error, McpClientError::Transport(_)));
+        assert_eq!(provider.lifecycle.pays.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn definitive_rejection_rolls_back() {
+        let caller = TestCaller::new([Err(payment_error(true)), Err(transport_error(true))]);
+        let provider = TestProvider::new();
+        let client = McpClient::new(caller, provider.clone(), context());
+
+        let error = client.call_tool(params()).await.unwrap_err();
+
+        assert!(matches!(error, McpClientError::Transport(_)));
+        assert_eq!(provider.lifecycle.rollbacks.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.lifecycle.abandons.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn ambiguous_delivery_only_abandons_transient_state() {
+        let caller = TestCaller::new([Err(payment_error(true)), Err(transport_error(false))]);
+        let provider = TestProvider::new();
+        let client = McpClient::new(caller, provider.clone(), context());
+
+        let error = client.call_tool(params()).await.unwrap_err();
+
+        assert!(matches!(error, McpClientError::Transport(_)));
+        assert_eq!(provider.lifecycle.rollbacks.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.lifecycle.abandons.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn commit_failure_preserves_ambiguous_payment_state() {
+        let caller = TestCaller::new([Err(payment_error(true)), Ok(json!({"content": "paid"}))]);
+        let provider = TestProvider::new();
+        provider.lifecycle.fail_commit.store(true, Ordering::SeqCst);
+        let client = McpClient::new(caller, provider.clone(), context());
+
+        let error = client.call_tool(params()).await.unwrap_err();
+
+        assert!(matches!(error, McpClientError::Payment(_)));
+        assert_eq!(provider.lifecycle.commits.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.lifecycle.rollbacks.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.lifecycle.abandons.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Clone)]
+    struct BlockingCaller {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ToolCaller for BlockingCaller {
+        type Params = Value;
+        type Output = Value;
+        type Error = TestError;
+
+        async fn call_tool(&self, _params: Self::Params) -> Result<Self::Output, Self::Error> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                Err(payment_error(true))
+            } else {
+                pending().await
+            }
+        }
+
+        fn payment_challenges_from_error(
+            &self,
+            error: &Self::Error,
+        ) -> Option<Vec<PaymentChallenge>> {
+            error.challenges.clone()
+        }
+
+        fn attach_credential(
+            &self,
+            params: &mut Self::Params,
+            credential: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            crate::mcp::attach_credential(params, credential);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_abandons_transient_state_without_rollback() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = TestProvider::new();
+        let client = wrap(
+            BlockingCaller {
+                calls: Arc::clone(&calls),
+            },
+            provider.clone(),
+            context(),
+        );
+        let task = tokio::spawn(async move { client.call_tool(params()).await });
+        while calls.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+
+        assert_eq!(provider.lifecycle.rollbacks.load(Ordering::SeqCst), 0);
+        assert_eq!(provider.lifecycle.abandons.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
Adds an SDK-neutral Rust equivalent of mppx MCP client wrapping.

- introduces McpPayment and cancellation-safe PendingPayment for MCP SDK adapters
- adds ToolCaller plus wrap/McpClient for automatic free pass-through and one paid retry
- recognizes both JSON-RPC -32042 errors and org.paymentauth/payment-required result metadata
- attaches org.paymentauth/credential and owns commit, rollback, and ambiguous-delivery abandonment semantics
- preserves the original result/error when no offered challenge is supported

Validation:
- cargo test --features client mcp::client
- cargo clippy --all-features --all-targets -- -D warnings