### PR TITLE
test: use bootstrapped Tempo localnet

### DIFF
--- a/.changelog/tempo-localnet-integration.md
+++ b/.changelog/tempo-localnet-integration.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Use the bootstrapped Tempo localnet image for reproducible integration tests.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -67,7 +67,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -101,7 +101,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-    env:
-      TEMPO_TAG: latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -109,36 +107,13 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo update -p native-tls
 
-      - name: Resolve Tempo image digest
-        id: tempo-digest
-        run: |
-          digest=$(docker buildx imagetools inspect "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" --raw | sha256sum | cut -d' ' -f1)
-          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Tempo Docker image
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: docker-cache
-        with:
-          path: /tmp/tempo-image.tar
-          key: tempo-image-${{ steps.tempo-digest.outputs.digest }}
-
-      - name: Load cached Tempo image
-        if: steps.docker-cache.outputs.cache-hit == 'true'
-        run: docker load -i /tmp/tempo-image.tar
-
-      - name: Pull and cache Tempo image
-        if: steps.docker-cache.outputs.cache-hit != 'true'
-        run: |
-          docker pull "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}"
-          docker save "ghcr.io/tempoxyz/tempo:${TEMPO_TAG}" -o /tmp/tempo-image.tar
-
-      - name: Start Tempo devnet
+      - name: Start Tempo localnet
         run: docker compose up -d --wait
 
       - name: Run integration tests
         run: cargo test --features integration --test integration_charge -- --nocapture
 
-      - name: Stop Tempo devnet
+      - name: Stop Tempo localnet
         if: always()
         run: docker compose down
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/smoke-cross-sdk.yml
+++ b/.github/workflows/smoke-cross-sdk.yml
@@ -31,62 +31,13 @@ jobs:
         with:
           node-version: 22
 
-      - name: Start Tempo node
-        run: docker compose up -d
-
-      - name: Wait for Tempo node
-        run: |
-          echo "Waiting for Tempo node to be ready..."
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:8545 -X POST \
-              -H 'Content-Type: application/json' \
-              -d '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' > /dev/null 2>&1; then
-              echo "Tempo node ready after ${i}s"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "Tempo node failed to start"
-          docker compose logs
-          exit 1
+      - name: Start Tempo localnet
+        run: docker compose up -d --wait
 
       - name: Run integration tests
         run: cargo test --features integration --test integration_charge -- --nocapture
         env:
           TEMPO_RPC_URL: http://localhost:8545
-
-      - name: Provision AMM liquidity
-        run: |
-          cd .github/smoke-cross-sdk
-          npm ci --no-audit --no-fund
-          node --input-type=module <<'EOF'
-          import { createClient, http, parseUnits } from 'viem'
-          import { privateKeyToAccount } from 'viem/accounts'
-          import { tempoLocalnet } from 'viem/chains'
-          import { Actions, Addresses } from 'viem/tempo'
-
-          // well-known Hardhat dev account[0] (faucet key)
-          const account = privateKeyToAccount(
-            '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
-          )
-          const client = createClient({
-            account,
-            chain: { ...tempoLocalnet, rpcUrls: { default: { http: ['http://localhost:8545'] } } },
-            transport: http('http://localhost:8545'),
-          })
-
-          for (const id of [1n, 2n, 3n]) {
-            await Actions.amm.mintSync(client, {
-              account,
-              feeToken: Addresses.pathUsd,
-              userTokenAddress: id,
-              validatorTokenAddress: Addresses.pathUsd,
-              validatorTokenAmount: parseUnits('1000', 6),
-              to: account.address,
-            })
-          }
-          console.log('AMM liquidity provisioned')
-          EOF
 
       - name: Fund client account # well-known Hardhat dev account[1]
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,32 +1,7 @@
 services:
   tempo-node:
-    image: ghcr.io/tempoxyz/tempo:1.8.1
-    container_name: tempo-dev-node
-    command: >
-      node --dev
-      --dev.block-time 200ms
-      --http
-      --http.addr 0.0.0.0
-      --http.port 8545
-      --http.api all
-      --http.corsdomain '*'
-      --faucet.enabled
-      --faucet.private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-      --faucet.address 0x20c0000000000000000000000000000000000000
-      --faucet.address 0x20c0000000000000000000000000000000000001
-      --faucet.address 0x20c0000000000000000000000000000000000002
-      --faucet.address 0x20c0000000000000000000000000000000000003
-      --faucet.amount 1000000000000
-      --engine.legacy-state-root
-      --engine.disable-precompile-cache
+    image: ${TEMPO_LOCALNET_IMAGE:-ghcr.io/tempoxyz/tempo-localnet@sha256:86f199f161be85d3610d990e5bc2653ece29de3ee9c91e8c8e768cf2b8c05c3b}
+    command: ["--block-time", "1ms"]
     ports:
-      - "8545:8545"
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "bash -lc 'body=\"{\\\"jsonrpc\\\":\\\"2.0\\\",\\\"method\\\":\\\"eth_chainId\\\",\\\"params\\\":[],\\\"id\\\":1}\"; exec 3<>/dev/tcp/127.0.0.1/8545; printf \"POST / HTTP/1.1\\r\\nHost: localhost\\r\\nContent-Type: application/json\\r\\nContent-Length: $${#body}\\r\\nConnection: close\\r\\n\\r\\n%s\" \"$$body\" >&3; timeout 2 grep -q \"result\" <&3'",
-        ]
-      interval: 2s
-      timeout: 5s
-      retries: 15
+      - "127.0.0.1:8545:8545"
+    stop_grace_period: 10s

--- a/tests/integration_charge.rs
+++ b/tests/integration_charge.rs
@@ -29,7 +29,6 @@ use mpp::server::axum::{ChargeChallenger, ChargeConfig, MppCharge, WithReceipt};
 use mpp::server::{tempo, Mpp, TempoConfig};
 use reqwest::Client;
 use tempo_alloy::contracts::precompiles::tip20::ITIP20;
-use tempo_alloy::contracts::precompiles::ITIPFeeAMM;
 use tempo_alloy::primitives::transaction::Call;
 use tempo_alloy::primitives::TempoTransaction;
 use tempo_alloy::TempoNetwork;
@@ -40,9 +39,6 @@ const DEV_PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efca
 
 /// PathUSD token address.
 const PATH_USD: Address = address!("0x20c0000000000000000000000000000000000000");
-
-/// Fee manager precompile address.
-const FEE_MANAGER: Address = address!("0xfeec000000000000000000000000000000000000");
 
 /// Default localnet RPC URL (overridable via `TEMPO_RPC_URL` env var).
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
@@ -68,9 +64,6 @@ fn dev_signer() -> PrivateKeySigner {
 
 /// Serialize dev account transactions to avoid nonce conflicts across parallel tests.
 static DEV_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| Mutex::new(()));
-
-/// One-time setup: ensures AMM fee liquidity is minted.
-static SETUP: std::sync::LazyLock<Mutex<bool>> = std::sync::LazyLock::new(|| Mutex::new(false));
 
 /// Send a transaction from the dev account, optionally specifying a fee token.
 /// Acquires DEV_LOCK internally to serialize nonce usage.
@@ -139,58 +132,8 @@ async fn dev_send(rpc: &str, calls: Vec<Call>) -> B256 {
     dev_send_with_fee_token(rpc, calls, None).await
 }
 
-/// Mint AMM fee liquidity for token IDs 1, 2, 3 (matching mppx setup.ts).
-///
-/// Assumes a fresh localnet — if the chain already has liquidity, repeated
-/// mints should still succeed (additive).
-async fn setup_liquidity(rpc: &str) {
-    let mut done = SETUP.lock().await;
-    if *done {
-        return;
-    }
-
-    // Hold DEV_LOCK once for the entire batch of mints.
-    let _dev = DEV_LOCK.lock().await;
-
-    let dev_addr = dev_signer().address();
-
-    // Mint liquidity for fee tokens 1, 2, 3 with pathUSD as validator token.
-    // TokenId.toAddress(n) = 0x20c0 + hex(n, 18 bytes), matching mppx setup.ts.
-    let fee_tokens: [Address; 3] = [
-        address!("0x20c0000000000000000000000000000000000001"),
-        address!("0x20c0000000000000000000000000000000000002"),
-        address!("0x20c0000000000000000000000000000000000003"),
-    ];
-    for user_token in fee_tokens {
-        let mint_data = ITIPFeeAMM::mintCall::new((
-            user_token,
-            PATH_USD,
-            U256::from(1_000_000_000u64), // 1000 pathUSD
-            dev_addr,
-        ))
-        .abi_encode();
-
-        // Use pathUSD as fee token for the mint tx itself (no AMM needed yet).
-        // Use _unlocked variant since we already hold DEV_LOCK.
-        dev_send_with_fee_token_unlocked(
-            rpc,
-            vec![Call {
-                to: TxKind::Call(FEE_MANAGER),
-                value: U256::ZERO,
-                input: Bytes::from(mint_data),
-            }],
-            Some(PATH_USD),
-        )
-        .await;
-    }
-
-    *done = true;
-}
-
 /// Fund an account by transferring pathUSD from the dev account.
 async fn fund_account(rpc: &str, to: Address) {
-    setup_liquidity(rpc).await;
-
     let amount = U256::from(10_000_000_000u64); // 10,000 pathUSD
     let transfer_data = ITIP20::transferCall::new((to, amount)).abi_encode();
 
@@ -207,8 +150,6 @@ async fn fund_account(rpc: &str, to: Address) {
 
 /// Fund an account with an exact amount of pathUSD.
 async fn fund_account_amount(rpc: &str, to: Address, amount: U256) {
-    setup_liquidity(rpc).await;
-
     let transfer_data = ITIP20::transferCall::new((to, amount)).abi_encode();
 
     dev_send(


### PR DESCRIPTION
## Motivation

The Rust SDK integration suites should share Tempo’s canonical deterministic faucet and liquidity setup instead of maintaining raw node flags and duplicate AMM provisioning.

## Summary

- replace the hand-configured Tempo node with the digest-pinned localnet image
- remove redundant liquidity provisioning from Rust and cross-SDK tests
- simplify CI image startup and caching logic

## Key design considerations

- preserve TEMPO_LOCALNET_IMAGE overrides for testing newer images
- use health-based Compose readiness and a 1 ms block interval for reliable bootstrap
