### PR TITLE
ci: open the release PR via github-sts

### DIFF
--- a/.github/sts/release-pr.sts.yaml
+++ b/.github/sts/release-pr.sts.yaml
@@ -1,0 +1,11 @@
+# Allow the release workflow (push to main) to mint a short-lived token that
+# opens and updates the changelog-release version PR through the
+# tempoxyz/changelogs action, and pushes its branch, tags, and GitHub
+# releases. Replaces the built-in GITHUB_TOKEN so the org can turn off
+# "Allow GitHub Actions to create and approve pull requests".
+subject: repo:tempoxyz@211589300/mpp-rs@1141417139:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/mpp-rs/\.github/workflows/release\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,13 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# The changelog-release version PR, branch, tags, and GitHub releases are
+# created with a short-lived GitHub App token minted via the github-sts
+# action (authorized by .github/sts/release-pr.sts.yaml); the built-in
+# GITHUB_TOKEN is not allowed to create pull requests. id-token feeds the
+# STS exchange and crates.io trusted publishing.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   id-token: write
 
 jobs:
@@ -16,8 +20,16 @@ jobs:
     name: Version
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch GitHub token via STS
+        id: app-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: release-pr
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 # zizmor: ignore[artipacked]
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
@@ -29,5 +41,4 @@ jobs:
           ecosystem: rust
           conventional-commit: true
           crate-token: ${{ steps.auth.outputs.token }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: app-token
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
         with:
           policy: release-pr
 


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. This repo's `tempoxyz/changelogs` step opens and updates the changelog-release version PR with the built-in token, so it would stop working.

## Changes

- Mint a short-lived GitHub App token via the `tempoxyz/gh-actions/actions/github-sts` action (SHA-pinned) and pass it to `tempoxyz/changelogs` via its `github-token` input (and to checkout where credentials persist), following the pattern `tempo` and `wallet-rs` already use. The version PR, branch, tags, and GitHub releases are all created with that token.
- Drop the job's built-in token to `contents: read` and grant `id-token: write` (the OIDC exchange; also used by registry trusted publishing where applicable).
- Add `.github/sts/release-pr.sts.yaml` granting `contents: write` + `pull_requests: write`, with a `job_workflow_ref` claim check pinning minting to this workflow on `main`.

## Notes

- Bonus: version PRs opened by the STS App trigger `pull_request` workflows normally, so CI runs on them (built-in-token PRs never got checks).
- Requires the Tempo GitHub STS App to be installed on this repository.
- Verify on the next push to `main` with pending changelogs.
