### PR TITLE
fix: restrict payment receipts to successful responses

### DIFF
--- a/.changelog/receipt-success-only.md
+++ b/.changelog/receipt-success-only.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Only attach payment receipts to successful responses from Tower middleware and Axum handlers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Pin pnpm for Tempo Lints
         run: corepack prepare pnpm@11.17.0 --activate
       - name: Run Tempo Lints
-        uses: tempoxyz/lints@8c451f192339242ef42dd5801ea67fac3d99666f # @tempoxyz/lints@0.1.1
+        uses: tempoxyz/lints@f9268eb2b828dbacf9f4b5d4bf6ad4541826567f # main
         with:
           language: rust
           path: "."
@@ -118,7 +118,7 @@ jobs:
         run: docker compose down
 
   deny:
-    uses: tempoxyz/ci/.github/workflows/deny.yml@934b6a6317ac26272eaecf0d265472f4105c99d6 # main
+    uses: tempoxyz/ci/.github/workflows/deny.yml@09f481293feb726bcd5c94853063b224a9b2ff24 # main
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           node-version: 22
       - name: Pin pnpm for Tempo Lints
-        run: corepack prepare pnpm@11.17.0 --activate
+        run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
         uses: tempoxyz/lints@f9268eb2b828dbacf9f4b5d4bf6ad4541826567f # main
         with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   conformance-policy:
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@2c6ea56f98eefcdc52b6dee28b6bf5a8da1b7ea9 # main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance-policy.yml@b6b07aac36973ca6cf2c7dc9d4e43696cee0bfc5 # main
     with:
       protocol-paths: |
         src/**
@@ -32,7 +32,7 @@ jobs:
 
   conformance:
     needs: conformance-policy
-    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@2c6ea56f98eefcdc52b6dee28b6bf5a8da1b7ea9 # main
+    uses: tempoxyz/mpp-tools/.github/workflows/sdk-conformance.yml@b6b07aac36973ca6cf2c7dc9d4e43696cee0bfc5 # main
     with:
       adapter: rust
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -1082,23 +1082,28 @@ pub struct WithReceipt<T> {
 impl<T: IntoResponse> IntoResponse for WithReceipt<T> {
     fn into_response(self) -> axum_core::response::Response {
         let mut resp = self.body.into_response();
-        if let Ok(header_val) = format_receipt(&self.receipt) {
-            if let Ok(val) = HeaderValue::from_str(&header_val) {
-                resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
+        if !resp.status().is_success() {
+            return resp;
+        }
+        let Ok(header_val) = format_receipt(&self.receipt) else {
+            return resp;
+        };
+        let Ok(val) = HeaderValue::from_str(&header_val) else {
+            return resp;
+        };
+        resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
 
-                // Receipt responses MUST be Cache-Control: private (spec §11.10).
-                let existing_cc = resp
-                    .headers()
-                    .get_all(header::CACHE_CONTROL)
-                    .iter()
-                    .filter_map(|v| v.to_str().ok())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
-                if let Ok(cc) = HeaderValue::from_str(&cache_control) {
-                    resp.headers_mut().insert(header::CACHE_CONTROL, cc);
-                }
-            }
+        // Receipt responses MUST be Cache-Control: private (spec §11.10).
+        let existing_cc = resp
+            .headers()
+            .get_all(header::CACHE_CONTROL)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
+        if let Ok(cc) = HeaderValue::from_str(&cache_control) {
+            resp.headers_mut().insert(header::CACHE_CONTROL, cc);
         }
         resp
     }
@@ -1354,6 +1359,66 @@ mod tests {
         assert_eq!(
             resp.headers().get(header::CACHE_CONTROL).unwrap(),
             "private"
+        );
+    }
+
+    #[test]
+    fn test_with_receipt_does_not_attach_header_to_error_response() {
+        use crate::protocol::core::{MethodName, ReceiptStatus};
+
+        for status in [
+            StatusCode::FOUND,
+            StatusCode::FORBIDDEN,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let receipt = Receipt {
+                status: ReceiptStatus::Success,
+                method: MethodName::new("tempo"),
+                timestamp: "2025-01-01T00:00:00Z".into(),
+                reference: "0xabc".into(),
+                external_id: None,
+                subscription_id: None,
+                extensions: serde_json::Map::new(),
+            };
+            let resp = WithReceipt {
+                receipt,
+                body: (status, "error"),
+            }
+            .into_response();
+
+            assert_eq!(resp.status(), status);
+            assert!(!resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+            assert!(!resp.headers().contains_key(header::CACHE_CONTROL));
+        }
+    }
+
+    #[test]
+    fn test_with_receipt_preserves_existing_cache_control() {
+        use crate::protocol::core::{MethodName, ReceiptStatus};
+
+        let receipt = Receipt {
+            status: ReceiptStatus::Success,
+            method: MethodName::new("tempo"),
+            timestamp: "2025-01-01T00:00:00Z".into(),
+            reference: "0xabc".into(),
+            external_id: None,
+            subscription_id: None,
+            extensions: serde_json::Map::new(),
+        };
+        let mut body = "ok".into_response();
+        body.headers_mut()
+            .append(header::CACHE_CONTROL, HeaderValue::from_static("public"));
+        body.headers_mut().append(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("max-age=60"),
+        );
+
+        let resp = WithReceipt { receipt, body }.into_response();
+
+        assert!(resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=60, private"
         );
     }
 

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -250,24 +250,7 @@ where
 
             // Call the inner service.
             let mut resp = inner.call(req).await?;
-
-            // Receipt responses MUST be Cache-Control: private (spec §11.10).
-            let existing_cc = resp
-                .headers()
-                .get_all(header::CACHE_CONTROL)
-                .iter()
-                .filter_map(|v| v.to_str().ok())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
-            if let Ok(val) = HeaderValue::from_str(&cache_control) {
-                resp.headers_mut().insert(header::CACHE_CONTROL, val);
-            }
-
-            // Attach the receipt header.
-            if let Ok(val) = HeaderValue::from_str(&receipt_header) {
-                resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
-            }
+            attach_receipt(&mut resp, &receipt_header);
 
             Ok(resp)
         })
@@ -388,23 +371,7 @@ where
 
             let req = Request::from_parts(parts, http_body_util::Full::new(body));
             let mut resp = inner.call(req).await?;
-
-            // Receipt responses MUST be Cache-Control: private (spec §11.10).
-            let existing_cc = resp
-                .headers()
-                .get_all(header::CACHE_CONTROL)
-                .iter()
-                .filter_map(|v| v.to_str().ok())
-                .collect::<Vec<_>>()
-                .join(", ");
-            let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
-            if let Ok(val) = HeaderValue::from_str(&cache_control) {
-                resp.headers_mut().insert(header::CACHE_CONTROL, val);
-            }
-
-            if let Ok(val) = HeaderValue::from_str(&receipt_header) {
-                resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, val);
-            }
+            attach_receipt(&mut resp, &receipt_header);
 
             Ok(resp)
         })
@@ -416,6 +383,30 @@ fn error_response<B: Default>(status: StatusCode, _message: &str) -> Response<B>
     let mut resp = Response::new(B::default());
     *resp.status_mut() = status;
     resp
+}
+
+/// Attach a receipt only to successful responses and prevent shared caching.
+fn attach_receipt<B>(resp: &mut Response<B>, receipt_header: &str) {
+    if !resp.status().is_success() {
+        return;
+    }
+
+    let Ok(receipt) = HeaderValue::from_str(receipt_header) else {
+        return;
+    };
+
+    let existing_cc = resp
+        .headers()
+        .get_all(header::CACHE_CONTROL)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let cache_control = with_private_cache_control(Some(existing_cc.as_str()));
+    if let Ok(value) = HeaderValue::from_str(&cache_control) {
+        resp.headers_mut().insert(header::CACHE_CONTROL, value);
+    }
+    resp.headers_mut().insert(PAYMENT_RECEIPT_HEADER, receipt);
 }
 
 /// Build a retryable `402 Payment Required` response carrying a fresh
@@ -637,6 +628,28 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct StatusService(StatusCode);
+
+    impl<B: Send + 'static> tower_service::Service<Request<B>> for StatusService {
+        type Response = Response<()>;
+        type Error = std::convert::Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Response<()>, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Request<B>) -> Self::Future {
+            let status = self.0;
+            Box::pin(async move {
+                let mut resp = Response::new(());
+                *resp.status_mut() = status;
+                Ok(resp)
+            })
+        }
+    }
+
     #[test]
     fn test_payment_verifier_challenge() {
         let v = MockVerifier {
@@ -776,6 +789,72 @@ mod tests {
         assert_eq!(
             resp.headers().get(header::CACHE_CONTROL).unwrap(),
             "private"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_service_does_not_attach_receipt_to_error_response() {
+        use tower_service::Service;
+
+        for status in [
+            StatusCode::FOUND,
+            StatusCode::FORBIDDEN,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let layer = PaymentLayer::new(MockVerifier {
+                challenge_value: "Payment id=\"challenge\"".to_string(),
+                accept: true,
+            });
+            let mut svc = layer.layer(StatusService(status));
+            let req = Request::builder()
+                .uri("/premium")
+                .header(header::AUTHORIZATION, "Payment eyJmYWtlIjp0cnVlfQ")
+                .body(())
+                .unwrap();
+
+            let resp = svc.call(req).await.unwrap();
+            assert_eq!(resp.status(), status);
+            assert!(!resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+            assert!(!resp.headers().contains_key(header::CACHE_CONTROL));
+        }
+    }
+
+    #[test]
+    fn test_attach_receipt_preserves_existing_cache_control() {
+        let mut resp = Response::new(());
+        resp.headers_mut()
+            .append(header::CACHE_CONTROL, HeaderValue::from_static("public"));
+        resp.headers_mut().append(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("max-age=60"),
+        );
+
+        attach_receipt(&mut resp, "mock-receipt-token");
+
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=60, private"
+        );
+        assert_eq!(
+            resp.headers().get(PAYMENT_RECEIPT_HEADER).unwrap(),
+            "mock-receipt-token"
+        );
+    }
+
+    #[test]
+    fn test_attach_receipt_rejects_invalid_header_without_changing_cache_control() {
+        let mut resp = Response::new(());
+        resp.headers_mut().insert(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static("public, max-age=60"),
+        );
+
+        attach_receipt(&mut resp, "invalid\nreceipt");
+
+        assert!(!resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+        assert_eq!(
+            resp.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=60"
         );
     }
 
@@ -1016,6 +1095,33 @@ mod tests {
             resp.headers().get(header::CACHE_CONTROL).unwrap(),
             "no-store"
         );
+    }
+
+    #[tokio::test]
+    async fn test_body_service_does_not_attach_receipt_to_error_response() {
+        use tower_service::Service;
+
+        for status in [
+            StatusCode::FOUND,
+            StatusCode::FORBIDDEN,
+            StatusCode::INTERNAL_SERVER_ERROR,
+        ] {
+            let layer = PaymentBodyLayer::new(BodyAwareVerifier {
+                challenge_body: Arc::new(std::sync::Mutex::new(None)),
+                verify_body: Arc::new(std::sync::Mutex::new(None)),
+            });
+            let mut svc = layer.layer(StatusService(status));
+            let req = Request::builder()
+                .uri("/premium")
+                .header(header::AUTHORIZATION, "Payment eyJmYWtlIjp0cnVlfQ")
+                .body(http_body_util::Full::new(Bytes::from_static(b"paid")))
+                .unwrap();
+
+            let resp = svc.call(req).await.unwrap();
+            assert_eq!(resp.status(), status);
+            assert!(!resp.headers().contains_key(PAYMENT_RECEIPT_HEADER));
+            assert!(!resp.headers().contains_key(header::CACHE_CONTROL));
+        }
     }
 
     // ==================== Real ChargeVerifier tests ====================


### PR DESCRIPTION
## Motivation

Payment receipts on non-success responses can incorrectly signal that the requested resource was successfully delivered and can expose receipt data through cache policy changes.

## Summary

- Attach receipts only to 2xx responses in Tower middleware and Axum response wrappers
- Share receipt and private-cache handling across regular and body-aware middleware
- Add regression coverage for redirects, errors, existing cache directives, and malformed receipt headers

## Key design considerations

- Preserve downstream Cache-Control directives when adding private to successful receipt responses
- Leave non-success responses and invalid receipt values unchanged