### PR TITLE
feat: advertise Payment-Authorization when requires_auth is set

### DIFF
--- a/.changelog/requires-auth-payment-authorization.md
+++ b/.changelog/requires-auth-payment-authorization.md
@@ -1,0 +1,5 @@
+---
+"mpp": patch
+---
+
+Added a `requires_auth` server option that advertises `header="Payment-Authorization"` so Payment credentials do not collide with ordinary `Authorization`.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ let challenge = mpp.stripe_charge("1")?;
 let receipt = mpp.verify_credential(&credential).await?;
 ```
 
+If the endpoint already uses `Authorization` (API keys, Bearer tokens), create the server with `requires_auth(true)`. Challenges then advertise `header="Payment-Authorization"`, and clients send the Payment credential in that header instead of `Authorization`.
+
+```rust
+let mpp = Mpp::create(tempo(config).requires_auth(true))?;
+```
+
 ### Client (Tempo)
 
 ```rust

--- a/crates/alloy-transport-mpp/src/http.rs
+++ b/crates/alloy-transport-mpp/src/http.rs
@@ -334,6 +334,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 

--- a/src/client/fetch.rs
+++ b/src/client/fetch.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides `.send_with_payment()` method for opt-in per-request payment handling.
 
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, WWW_AUTHENTICATE};
+use reqwest::header::{HeaderMap, HeaderValue, WWW_AUTHENTICATE};
 use reqwest::{RequestBuilder, Response, StatusCode};
 
 use super::accept_payment_policy::AcceptPaymentPolicy;
@@ -504,7 +504,10 @@ async fn send_with_payment<P: PaymentProvider>(
             }
         };
         let mut payment_headers = HeaderMap::new();
-        payment_headers.insert(AUTHORIZATION, auth_header);
+        payment_headers.insert(
+            crate::client::payment_credential_header_name(&challenge),
+            auth_header,
+        );
         let retry = match retry_builder.try_clone() {
             Some(retry) => retry.headers(payment_headers),
             None => {
@@ -633,6 +636,7 @@ mod tests {
             format_www_authenticate, Base64UrlJson, PaymentChallenge, PaymentCredential,
             PaymentPayload,
         };
+        use reqwest::header::AUTHORIZATION;
 
         use axum::http::header::WWW_AUTHENTICATE as WWW_AUTH_NAME;
         use axum::http::StatusCode as AxumStatusCode;

--- a/src/client/middleware.rs
+++ b/src/client/middleware.rs
@@ -20,9 +20,7 @@ use crate::client::provider::{PaymentContext, PaymentProvider, PendingPayments};
 use crate::client::HttpError;
 use crate::client::DEFAULT_MAX_PAYMENT_RETRIES;
 use crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER;
-use crate::protocol::core::{
-    format_authorization, parse_www_authenticate_all, AUTHORIZATION_HEADER,
-};
+use crate::protocol::core::{format_authorization, parse_www_authenticate_all};
 
 async fn commit_middleware_payments<P: PaymentProvider>(
     payments: &mut PendingPayments<P>,
@@ -385,9 +383,10 @@ where
                     "request could not be cloned for payment retry"
                 )));
             };
-            retry_req
-                .headers_mut()
-                .insert(AUTHORIZATION_HEADER, auth_header_value);
+            retry_req.headers_mut().insert(
+                crate::client::payment_credential_header_name(&challenge),
+                auth_header_value,
+            );
 
             resp = match next.clone().run(retry_req, extensions).await {
                 Ok(resp) => resp,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -73,3 +73,10 @@ pub use tempo_alloy::TempoNetwork;
 pub mod stripe;
 #[cfg(feature = "stripe")]
 pub use stripe::StripeProvider;
+
+pub(crate) fn payment_credential_header_name(
+    challenge: &crate::protocol::core::PaymentChallenge,
+) -> reqwest::header::HeaderName {
+    reqwest::header::HeaderName::from_bytes(challenge.credential_header().as_bytes())
+        .unwrap_or(reqwest::header::AUTHORIZATION)
+}

--- a/src/client/tempo/charge/tx_builder.rs
+++ b/src/client/tempo/charge/tx_builder.rs
@@ -148,6 +148,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let tx_bytes = vec![0x76, 0xab, 0xcd];
@@ -179,6 +180,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let from: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2"
@@ -206,6 +208,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let tx_bytes = vec![0x76, 0xab, 0xcd, 0xef];
@@ -237,6 +240,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let cred = build_charge_credential(&challenge, &[0x76], 42431, Address::ZERO);
@@ -406,6 +410,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let cred = build_charge_credential(&challenge, &[], 42431, Address::ZERO);
@@ -431,6 +436,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let from: Address = "0x742d35Cc6634C0532925a3b844Bc9e7595f1B0F2"

--- a/src/client/tempo/session/channel_ops.rs
+++ b/src/client/tempo/session/channel_ops.rs
@@ -1570,6 +1570,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let override_addr: Address = "0x1111111111111111111111111111111111111111"
@@ -1598,6 +1599,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, None).unwrap();
@@ -1627,6 +1629,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, None).unwrap();
@@ -1653,6 +1656,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert_eq!(
@@ -1681,6 +1685,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert_eq!(resolve_escrow(&challenge, 4217, None).unwrap(), hinted);
@@ -1705,6 +1710,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let result = resolve_escrow(&challenge, 9999, None);
@@ -1730,6 +1736,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let payload = SessionCredentialPayload::Voucher {
@@ -1861,6 +1868,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert_eq!(resolve_chain_id(&challenge), 4217);
@@ -1885,6 +1893,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert_eq!(resolve_chain_id(&challenge), CHAIN_ID);
@@ -1907,6 +1916,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         // Match MPPx's default Tempo client: mainnet when no chain is advertised.
@@ -1936,6 +1946,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         // Invalid address in challenge should fall back to default
@@ -1962,6 +1973,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let override_addr: Address = "0x3333333333333333333333333333333333333333"
@@ -2019,6 +2031,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let payload = SessionCredentialPayload::Voucher {
@@ -2159,6 +2172,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let result = resolve_escrow(&challenge, 42431, Some(override_addr)).unwrap();

--- a/src/client/tempo/session/mod.rs
+++ b/src/client/tempo/session/mod.rs
@@ -745,7 +745,13 @@ impl TempoSessionProvider {
                     .parse()
                     .mpp_config("invalid Payment-Session header")?,
             );
-            headers.remove(AUTHORIZATION);
+            if headers
+                .get(AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .is_some_and(|value| value.starts_with("Payment "))
+            {
+                headers.remove(AUTHORIZATION);
+            }
             if let Ok(response) = client.get(url).headers(headers.clone()).send().await {
                 if response.status() == reqwest::StatusCode::PAYMENT_REQUIRED {
                     let refreshed = PaymentChallenge::from_headers(
@@ -789,7 +795,13 @@ impl TempoSessionProvider {
             crate::protocol::core::accept_payment::ACCEPT_PAYMENT_HEADER,
             HeaderValue::from_static("tempo/charge"),
         );
-        headers.remove(AUTHORIZATION);
+        if headers
+            .get(AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.starts_with("Payment "))
+        {
+            headers.remove(AUTHORIZATION);
+        }
 
         let challenge_response = client
             .head(url)
@@ -847,7 +859,7 @@ impl TempoSessionProvider {
                 crate::protocol::core::PaymentPayload::proof(signature),
             );
             headers.insert(
-                AUTHORIZATION,
+                crate::client::payment_credential_header_name(&challenge),
                 crate::protocol::core::format_authorization(&credential)?
                     .parse()
                     .mpp_config("invalid bootstrap authorization header")?,
@@ -1129,7 +1141,7 @@ impl TempoSessionProvider {
         channel_id_hex: &str,
         additional_deposit: u128,
     ) -> Result<Option<Receipt>, MppError> {
-        use reqwest::header::{AUTHORIZATION, WWW_AUTHENTICATE};
+        use reqwest::header::WWW_AUTHENTICATE;
 
         if additional_deposit == 0 {
             return Err(MppError::InvalidConfig(
@@ -1176,7 +1188,7 @@ impl TempoSessionProvider {
             .top_up_credential_for_challenge(challenge, &entry, additional_deposit)
             .await?;
         headers.insert(
-            AUTHORIZATION,
+            crate::client::payment_credential_header_name(challenge),
             crate::protocol::core::format_authorization(&credential)?
                 .parse()
                 .mpp_config("invalid top-up authorization header")?,
@@ -1212,7 +1224,7 @@ impl TempoSessionProvider {
                     .top_up_credential_for_challenge(&fresh_challenge, &entry, additional_deposit)
                     .await?;
                 headers.insert(
-                    AUTHORIZATION,
+                    crate::client::payment_credential_header_name(&fresh_challenge),
                     crate::protocol::core::format_authorization(&credential)?
                         .parse()
                         .mpp_config("invalid refreshed top-up authorization header")?,
@@ -1443,10 +1455,18 @@ impl TempoSessionProvider {
             .voucher_credential(channel_id_hex, required_cumulative)
             .await?;
         let auth_header = crate::protocol::core::format_authorization(&credential)?;
+        let header_name = self
+            .last_challenge
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .as_ref()
+            .map(crate::client::payment_credential_header_name)
+            .unwrap_or(reqwest::header::AUTHORIZATION);
 
         let resp = client
             .post(url)
-            .header("Authorization", auth_header)
+            .header(header_name, auth_header)
             .send()
             .await
             .mpp_http("voucher POST failed")?;
@@ -1517,7 +1537,10 @@ impl TempoSessionProvider {
 
         let resp = client
             .post(url)
-            .header("Authorization", auth_header)
+            .header(
+                crate::client::payment_credential_header_name(&challenge),
+                auth_header,
+            )
             .send()
             .await
             .mpp_http("close request failed")?;

--- a/src/client/transport.rs
+++ b/src/client/transport.rs
@@ -51,7 +51,16 @@ pub trait Transport: Send + Sync {
     fn get_challenge(&self, response: &Self::Response) -> Result<PaymentChallenge, MppError>;
 
     /// Attach a credential string to a request.
-    fn set_credential(&self, request: Self::Request, credential: &str) -> Self::Request;
+    ///
+    /// When `challenge` is provided, the credential is placed in the HTTP field
+    /// selected by that challenge (`Authorization` by default, or
+    /// `Payment-Authorization` when advertised).
+    fn set_credential(
+        &self,
+        request: Self::Request,
+        credential: &str,
+        challenge: Option<&PaymentChallenge>,
+    ) -> Self::Request;
 }
 
 /// Reqwest HTTP transport for client-side payment handling.
@@ -93,8 +102,16 @@ impl Transport for HttpTransport {
         crate::protocol::core::parse_www_authenticate(header_str)
     }
 
-    fn set_credential(&self, request: Self::Request, credential: &str) -> Self::Request {
-        request.header(reqwest::header::AUTHORIZATION, credential)
+    fn set_credential(
+        &self,
+        request: Self::Request,
+        credential: &str,
+        challenge: Option<&PaymentChallenge>,
+    ) -> Self::Request {
+        let header = challenge
+            .map(PaymentChallenge::credential_header)
+            .unwrap_or("Authorization");
+        request.header(header, credential)
     }
 }
 

--- a/src/client/ws.rs
+++ b/src/client/ws.rs
@@ -136,7 +136,12 @@ impl Transport for WsTransport {
         })
     }
 
-    fn set_credential(&self, _request: Self::Request, credential: &str) -> Self::Request {
+    fn set_credential(
+        &self,
+        _request: Self::Request,
+        credential: &str,
+        _challenge: Option<&PaymentChallenge>,
+    ) -> Self::Request {
         WsClientMessage::Credential {
             credential: credential.to_string(),
         }
@@ -233,7 +238,7 @@ mod tests {
             data: serde_json::json!({}),
         };
 
-        let result = transport.set_credential(dummy, "Payment id=\"abc\"");
+        let result = transport.set_credential(dummy, "Payment id=\"abc\"", None);
         match result {
             WsClientMessage::Credential { credential } => {
                 assert_eq!(credential, "Payment id=\"abc\"");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,8 @@ pub use error::STREAM_PROBLEM_TYPE_BASE;
 
 // Core protocol types
 pub use protocol::core::{
-    compute_challenge_id, ChallengeEcho, PaymentChallenge, PaymentCredential, PaymentPayload,
-    Receipt, ReceiptStatus,
+    compute_challenge_id, compute_challenge_id_with_header, ChallengeEcho, PaymentChallenge,
+    PaymentCredential, PaymentPayload, Receipt, ReceiptStatus,
 };
 
 // Header parsing/formatting
@@ -73,8 +73,8 @@ pub use protocol::core::{
 // Schema types
 pub use protocol::core::{
     base64url_decode, base64url_encode, Base64UrlJson, IntentName, MethodName, PayloadType,
-    PaymentProtocol, AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME,
-    WWW_AUTHENTICATE_HEADER,
+    PaymentProtocol, AUTHORIZATION_HEADER, PAYMENT_AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER,
+    PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
 };
 
 // Accept-Payment header

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -320,6 +320,7 @@ mod tests {
                 expires: None,
                 digest: None,
                 opaque: None,
+                header: None,
             },
             "did:pkh:eip155:42161:0xabc",
             PaymentPayload::transaction("0xdeadbeef"),
@@ -788,6 +789,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         assert!(echoed_challenge.verify(secret));
 

--- a/src/protocol/core/challenge.rs
+++ b/src/protocol/core/challenge.rs
@@ -64,6 +64,15 @@ pub struct PaymentChallenge {
     /// JCS-serialized JSON object. Clients MUST NOT modify.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opaque: Option<Base64UrlJson>,
+
+    /// HTTP field that must carry the Payment credential.
+    ///
+    /// When omitted, clients send the credential in `Authorization`. When
+    /// present, the value is `Payment-Authorization` so `Authorization` can
+    /// remain in use for ordinary application authentication.
+    /// `Authorization` is the implicit default and is never advertised.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
 }
 
 impl PaymentChallenge {
@@ -104,6 +113,7 @@ impl PaymentChallenge {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 
@@ -162,6 +172,7 @@ impl PaymentChallenge {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 
@@ -184,11 +195,13 @@ impl PaymentChallenge {
         digest: Option<&str>,
         description: Option<&str>,
         opaque: Option<Base64UrlJson>,
+        header: Option<&str>,
     ) -> Self {
         let realm = realm.into();
         let method = method.into();
         let intent = intent.into();
-        let id = compute_challenge_id(
+        let header = advertised_credential_header(header);
+        let id = compute_challenge_id_with_header(
             secret_key,
             &realm,
             method.as_str(),
@@ -197,6 +210,7 @@ impl PaymentChallenge {
             expires,
             digest,
             opaque.as_ref().map(|o| o.raw()),
+            header.as_deref(),
         );
         Self {
             id,
@@ -208,6 +222,7 @@ impl PaymentChallenge {
             description: description.map(String::from),
             digest: digest.map(String::from),
             opaque,
+            header,
         }
     }
 
@@ -243,6 +258,25 @@ impl PaymentChallenge {
         self
     }
 
+    /// Set the HTTP field that must carry the Payment credential.
+    ///
+    /// `Authorization` is the implicit default and is stored as `None`.
+    /// Note: When using `with_secret_key`, set header BEFORE creating the
+    /// challenge since it affects the HMAC. Use [`with_secret_key_full`]
+    /// instead if header is needed in the HMAC.
+    pub fn with_header(mut self, header: impl Into<String>) -> Self {
+        let header = header.into();
+        self.header = advertised_credential_header(Some(&header));
+        self
+    }
+
+    /// HTTP field a client must use for the payment credential.
+    ///
+    /// Returns `header` when advertised, otherwise `Authorization`.
+    pub fn credential_header(&self) -> &str {
+        self.header.as_deref().unwrap_or("Authorization")
+    }
+
     /// Get the effective expiration time for this payment challenge.
     ///
     /// Returns `challenge.expires` if set. Expiry is a property of
@@ -262,6 +296,7 @@ impl PaymentChallenge {
             expires: self.expires.clone(),
             digest: self.digest.clone(),
             opaque: self.opaque.clone(),
+            header: self.header.clone(),
         }
     }
 
@@ -305,7 +340,8 @@ impl PaymentChallenge {
 
     /// Verify that this challenge's ID matches the expected HMAC for the given secret key.
     ///
-    /// Recomputes HMAC-SHA256 over `realm|method|intent|request|expires|digest|opaque`
+    /// Recomputes HMAC-SHA256 over `realm|method|intent|request|expires|digest|opaque`,
+    /// inserting `header` immediately before `opaque` when advertised,
     /// and performs a constant-time comparison against the challenge ID.
     ///
     /// This is the Rust equivalent of `Challenge.verify(challenge, { secretKey })` in the TS SDK.
@@ -321,7 +357,7 @@ impl PaymentChallenge {
     /// let is_valid = challenge.verify("my-server-secret");
     /// ```
     pub fn verify(&self, secret_key: &str) -> bool {
-        let expected_id = compute_challenge_id(
+        let expected_id = compute_challenge_id_with_header(
             secret_key,
             &self.realm,
             self.method.as_str(),
@@ -330,6 +366,7 @@ impl PaymentChallenge {
             self.expires.as_deref(),
             self.digest.as_deref(),
             self.opaque.as_ref().map(|o| o.raw()),
+            self.header.as_deref(),
         );
         constant_time_eq(&self.id, &expected_id)
     }
@@ -424,8 +461,9 @@ impl PaymentChallenge {
 /// and challenge creation. The algorithm matches the TypeScript and Python SDKs:
 ///
 /// 1. Concatenate all fields `realm|method|intent|request|expires|digest|opaque` with `|` (empty string for absent optional fields)
-/// 2. Compute HMAC-SHA256 with the secret key
-/// 3. Base64url-encode the result (no padding)
+/// 2. When a credential header is advertised, insert it immediately before the final opaque slot
+/// 3. Compute HMAC-SHA256 with the secret key
+/// 4. Base64url-encode the result (no padding)
 ///
 /// # Examples
 ///
@@ -454,24 +492,51 @@ pub fn compute_challenge_id(
     digest: Option<&str>,
     opaque: Option<&str>,
 ) -> String {
+    compute_challenge_id_with_header(
+        secret_key, realm, method, intent, request, expires, digest, opaque, None,
+    )
+}
+
+/// Compute an HMAC-SHA256 challenge ID, including an advertised credential header.
+///
+/// `Authorization` is the implicit protocol default and is never included in the
+/// HMAC input, matching mppx. An advertised header (typically
+/// `Payment-Authorization`) is inserted immediately before the final opaque slot.
+#[allow(clippy::too_many_arguments)]
+pub fn compute_challenge_id_with_header(
+    secret_key: &str,
+    realm: &str,
+    method: &str,
+    intent: &str,
+    request: &str,
+    expires: Option<&str>,
+    digest: Option<&str>,
+    opaque: Option<&str>,
+    header: Option<&str>,
+) -> String {
     use hmac::{Hmac, KeyInit, Mac};
     use sha2::Sha256;
 
     type HmacSha256 = Hmac<Sha256>;
 
-    // All fields are always included in the pipe-delimited HMAC input,
-    // with empty string for absent optional fields. This ensures challenges
-    // with vs without expires/digest/opaque produce different HMACs.
-    let hmac_input = [
+    // Legacy slots: realm | method | intent | request | expires | digest | opaque.
+    // Challenges advertising a credential header insert it immediately before
+    // the final opaque slot. Authorization is the implicit default and is never
+    // included, preserving the legacy binding.
+    let mut hmac_input = vec![
         realm,
         method,
         intent,
         request,
         expires.unwrap_or(""),
         digest.unwrap_or(""),
-        opaque.unwrap_or(""),
-    ]
-    .join("|");
+    ];
+    let advertised = advertised_credential_header(header);
+    if let Some(ref header) = advertised {
+        hmac_input.push(header);
+    }
+    hmac_input.push(opaque.unwrap_or(""));
+    let hmac_input = hmac_input.join("|");
 
     let mut mac =
         HmacSha256::new_from_slice(secret_key.as_bytes()).expect("HMAC can take key of any size");
@@ -479,6 +544,70 @@ pub fn compute_challenge_id(
     let result = mac.finalize();
 
     super::base64url_encode(&result.into_bytes())
+}
+
+/// Returns whether a credential header is omitted or is the implicit Authorization default.
+pub fn is_default_credential_header(header: Option<&str>) -> bool {
+    match header {
+        None => true,
+        Some(h) => h.is_empty() || h.eq_ignore_ascii_case("Authorization"),
+    }
+}
+
+/// RFC 9110 token used as an HTTP field name.
+fn is_valid_http_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            matches!(
+                b,
+                b'0'..=b'9'
+                    | b'A'..=b'Z'
+                    | b'a'..=b'z'
+                    | b'!'
+                    | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+        })
+}
+
+/// Returns an advertised credential header, or `None` for the Authorization default.
+///
+/// Invalid HTTP header names are ignored and treated as absent so HMAC
+/// computation cannot panic; parsers reject them separately.
+pub fn advertised_credential_header(header: Option<&str>) -> Option<String> {
+    if is_default_credential_header(header) {
+        return None;
+    }
+    let name = header?;
+    is_valid_http_header_name(name).then(|| name.to_string())
+}
+
+/// Parse an advertised credential header from the wire, rejecting invalid names.
+pub fn parse_advertised_credential_header(
+    header: Option<&str>,
+) -> crate::error::Result<Option<String>> {
+    if is_default_credential_header(header) {
+        return Ok(None);
+    }
+    let name = header.unwrap_or("");
+    if !is_valid_http_header_name(name) {
+        return Err(crate::error::MppError::invalid_challenge_reason(
+            "Invalid HTTP header name",
+        ));
+    }
+    Ok(Some(name.to_string()))
 }
 
 /// Constant-time string comparison to prevent timing attacks.
@@ -525,6 +654,13 @@ pub struct ChallengeEcho {
     /// Server-defined correlation data (base64url-encoded JSON).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub opaque: Option<Base64UrlJson>,
+
+    /// HTTP field that must carry the Payment credential.
+    ///
+    /// Echoed from the challenge when present. Omitted when the challenge
+    /// used the default `Authorization` field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub header: Option<String>,
 }
 
 /// Payment payload in credential.
@@ -922,6 +1058,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 
@@ -1202,6 +1339,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert!(challenge.verify(secret));
@@ -1231,6 +1369,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert!(!challenge.verify("wrong-secret"));
@@ -1250,6 +1389,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert!(!challenge.verify("any-secret"));
@@ -1283,6 +1423,7 @@ mod tests {
             description: Some("test payment".to_string()),
             digest: digest.map(String::from),
             opaque: None,
+            header: None,
         };
 
         assert!(challenge.verify(secret));
@@ -1574,6 +1715,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         assert!(!challenge.verify(secret));
@@ -1619,6 +1761,7 @@ mod tests {
             Some("2026-01-01T00:00:00Z"),
             Some("sha-256=abc"),
             Some("test payment"),
+            None,
             None,
         );
         assert!(challenge.verify("my-secret"));
@@ -1671,6 +1814,7 @@ mod tests {
             None,
             None,
             Some(opaque),
+            None,
         );
         assert_eq!(challenge.opaque.as_ref().unwrap().raw(), opaque_raw);
         assert!(challenge.verify("my-secret"));
@@ -1691,6 +1835,7 @@ mod tests {
             None,
             None,
             Some(opaque),
+            None,
         );
         let tampered =
             Base64UrlJson::from_value(&serde_json::json!({"pi": "pi_TAMPERED"})).unwrap();
@@ -1714,6 +1859,7 @@ mod tests {
             None,
             None,
             Some(opaque),
+            None,
         );
         let echo = challenge.to_echo();
         assert_eq!(
@@ -1821,6 +1967,7 @@ mod tests {
             None,
             None,
             Some(opaque),
+            None,
         );
         assert!(challenge.verify("test-secret"));
 
@@ -2125,5 +2272,93 @@ mod tests {
 
         let encoded = URL_SAFE_NO_PAD.encode(b"not json");
         assert_eq!(extract_tx_hash(&encoded), None);
+    }
+
+    #[test]
+    fn test_authorization_header_does_not_change_challenge_id() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let implicit = PaymentChallenge::with_secret_key_full(
+            "test-secret-key-12345",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let explicit = PaymentChallenge::with_secret_key_full(
+            "test-secret-key-12345",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+            None,
+            None,
+            None,
+            None,
+            Some("Authorization"),
+        );
+
+        assert!(implicit.header.is_none());
+        assert!(explicit.header.is_none());
+        assert_eq!(implicit.id, explicit.id);
+        assert!(!implicit.to_header().unwrap().contains("header="));
+        assert_eq!(implicit.credential_header(), "Authorization");
+    }
+
+    #[test]
+    fn test_payment_authorization_header_is_bound_into_id() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000000"})).unwrap();
+        let implicit = PaymentChallenge::with_secret_key_full(
+            "test-secret-key-12345",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let advertised = PaymentChallenge::with_secret_key_full(
+            "test-secret-key-12345",
+            "api.example.com",
+            "tempo",
+            "charge",
+            request,
+            None,
+            None,
+            None,
+            None,
+            Some("Payment-Authorization"),
+        );
+
+        assert_ne!(implicit.id, advertised.id);
+        assert_eq!(advertised.header.as_deref(), Some("Payment-Authorization"));
+        assert!(advertised.verify("test-secret-key-12345"));
+        assert_eq!(advertised.credential_header(), "Payment-Authorization");
+        assert!(advertised
+            .to_header()
+            .unwrap()
+            .contains(r#"header="Payment-Authorization""#));
+        assert_eq!(
+            advertised.to_echo().header.as_deref(),
+            Some("Payment-Authorization")
+        );
+    }
+
+    #[test]
+    fn test_header_roundtrip_through_www_authenticate() {
+        let request = Base64UrlJson::from_value(&serde_json::json!({"amount": "1000"})).unwrap();
+        let challenge = PaymentChallenge::new("id", "api", "tempo", "charge", request)
+            .with_header("Payment-Authorization");
+        let header = challenge.to_header().unwrap();
+        let parsed = PaymentChallenge::from_header(&header).unwrap();
+        assert_eq!(parsed.header.as_deref(), Some("Payment-Authorization"));
+        assert_eq!(parsed.credential_header(), "Payment-Authorization");
     }
 }

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -90,6 +90,10 @@ pub const WWW_AUTHENTICATE_HEADER: &str = "www-authenticate";
 /// Header name for payment credentials (from client)
 pub const AUTHORIZATION_HEADER: &str = "authorization";
 
+/// Alternate header name for payment credentials when `Authorization` is
+/// reserved for ordinary application authentication.
+pub const PAYMENT_AUTHORIZATION_HEADER: &str = "Payment-Authorization";
+
 /// Header name for payment receipts (from server)
 pub const PAYMENT_RECEIPT_HEADER: &str = "payment-receipt";
 
@@ -298,6 +302,9 @@ pub fn parse_www_authenticate(header: &str) -> Result<PaymentChallenge> {
         description: params.get("description").cloned(),
         digest,
         opaque: params.get("opaque").map(Base64UrlJson::from_raw),
+        header: super::parse_advertised_credential_header(
+            params.get("header").map(String::as_str),
+        )?,
     })
 }
 
@@ -404,6 +411,7 @@ fn split_payment_challenges(header: &str) -> Vec<&str> {
 ///     description: None,
 ///     digest: None,
 ///     opaque: None,
+///     header: None,
 /// };
 /// let header = format_www_authenticate(&challenge).unwrap();
 /// assert!(header.starts_with("Payment id=\"abc123\""));
@@ -442,6 +450,12 @@ pub fn format_www_authenticate(challenge: &PaymentChallenge) -> Result<String> {
         parts.push(format!("digest=\"{}\"", escape_quoted_value(digest)?));
     }
 
+    if let Some(ref header) = challenge.header {
+        if !super::is_default_credential_header(Some(header)) {
+            parts.push(format!("header=\"{}\"", escape_quoted_value(header)?));
+        }
+    }
+
     if let Some(ref opaque) = challenge.opaque {
         parts.push(format!("opaque=\"{}\"", escape_quoted_value(opaque.raw())?));
     }
@@ -469,6 +483,7 @@ pub fn format_www_authenticate(challenge: &PaymentChallenge) -> Result<String> {
 ///     description: None,
 ///     digest: None,
 ///     opaque: None,
+///     header: None,
 /// };
 /// let headers = format_www_authenticate_many(&[challenge]).unwrap();
 /// assert_eq!(headers.len(), 1);
@@ -497,9 +512,12 @@ pub fn parse_authorization(header: &str) -> Result<PaymentCredential> {
     }
 
     let decoded = base64url_decode(token)?;
-    let credential: PaymentCredential = serde_json::from_slice(&decoded).map_err(|e| {
+    let mut credential: PaymentCredential = serde_json::from_slice(&decoded).map_err(|e| {
         MppError::invalid_challenge_reason(format!("Invalid credential JSON: {}", e))
     })?;
+
+    credential.challenge.header =
+        super::parse_advertised_credential_header(credential.challenge.header.as_deref())?;
 
     if let Some(ref d) = credential.challenge.digest {
         if !is_valid_digest_format(d) {
@@ -601,6 +619,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 
@@ -1178,5 +1197,54 @@ mod tests {
         let results = parse_www_authenticate_all(vec![mixed]);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].as_ref().unwrap().method.as_str(), "stripe");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_advertises_payment_authorization_header() {
+        let header = concat!(
+            r#"Payment id="abc", realm="api", method="tempo", intent="charge", "#,
+            r#"request="e30", header="Payment-Authorization""#,
+        );
+        let parsed = parse_www_authenticate(header).unwrap();
+        assert_eq!(parsed.header.as_deref(), Some("Payment-Authorization"));
+        assert_eq!(parsed.credential_header(), "Payment-Authorization");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_omits_default_authorization_header() {
+        let header = concat!(
+            r#"Payment id="abc", realm="api", method="tempo", intent="charge", "#,
+            r#"request="e30", header="Authorization""#,
+        );
+        let parsed = parse_www_authenticate(header).unwrap();
+        assert!(parsed.header.is_none());
+        assert_eq!(parsed.credential_header(), "Authorization");
+        assert!(!format_www_authenticate(&parsed)
+            .unwrap()
+            .contains("header="));
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_rejects_invalid_header_name() {
+        let header = concat!(
+            r#"Payment id="abc", realm="api", method="tempo", intent="charge", "#,
+            r#"request="e30", header="not a header""#,
+        );
+        let err = parse_www_authenticate(header).unwrap_err();
+        assert!(err.to_string().contains("Invalid HTTP header name"));
+    }
+
+    #[test]
+    fn test_credential_echo_roundtrip_includes_header() {
+        let mut challenge = test_challenge();
+        challenge.header = Some("Payment-Authorization".to_string());
+        let credential =
+            PaymentCredential::new(challenge.to_echo(), PaymentPayload::transaction("0xabc"));
+        let header = format_authorization(&credential).unwrap();
+        let parsed = parse_authorization(&header).unwrap();
+        assert_eq!(
+            parsed.challenge.header.as_deref(),
+            Some("Payment-Authorization")
+        );
     }
 }

--- a/src/protocol/core/mod.rs
+++ b/src/protocol/core/mod.rs
@@ -75,14 +75,15 @@ pub mod types;
 #[cfg(feature = "server")]
 pub(crate) use challenge::constant_time_eq;
 pub use challenge::{
-    compute_challenge_id, extract_tx_hash, ChallengeEcho, PaymentChallenge, PaymentCredential,
-    PaymentPayload, Receipt,
+    advertised_credential_header, compute_challenge_id, compute_challenge_id_with_header,
+    extract_tx_hash, is_default_credential_header, parse_advertised_credential_header,
+    ChallengeEcho, PaymentChallenge, PaymentCredential, PaymentPayload, Receipt,
 };
 pub use headers::{
     extract_payment_scheme, format_authorization, format_receipt, format_www_authenticate,
     format_www_authenticate_many, parse_authorization, parse_receipt, parse_www_authenticate,
     parse_www_authenticate_all, with_private_cache_control, AUTHORIZATION_HEADER,
-    PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
+    PAYMENT_AUTHORIZATION_HEADER, PAYMENT_RECEIPT_HEADER, PAYMENT_SCHEME, WWW_AUTHENTICATE_HEADER,
 };
 
 pub use types::{

--- a/src/protocol/intents/payment_request.rs
+++ b/src/protocol/intents/payment_request.rs
@@ -118,6 +118,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let request = from_challenge(&challenge).unwrap();
@@ -144,6 +145,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         };
 
         let decoded: ChargeRequest = from_challenge_typed(&challenge).unwrap();

--- a/src/protocol/methods/tempo/mod.rs
+++ b/src/protocol/methods/tempo/mod.rs
@@ -340,6 +340,7 @@ pub fn charge_challenge_with_options(
         description: description.map(|s| s.to_string()),
         digest: None,
         opaque: None,
+        header: None,
     })
 }
 

--- a/src/protocol/methods/tempo/relay.rs
+++ b/src/protocol/methods/tempo/relay.rs
@@ -392,6 +392,7 @@ mod tests {
                 expires: Some("2099-01-01T00:00:00Z".into()),
                 digest: None,
                 opaque: None,
+                header: None,
             },
             payload,
         )
@@ -425,6 +426,7 @@ mod tests {
                 expires: Some(expires.into()),
                 digest: None,
                 opaque: None,
+                header: None,
             },
             payload,
         )

--- a/src/protocol/traits/charge.rs
+++ b/src/protocol/traits/charge.rs
@@ -287,6 +287,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
         let request = ChargeRequest {
@@ -313,6 +314,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 
@@ -336,6 +338,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 
@@ -365,6 +368,7 @@ mod tests {
                 expires: None,
                 digest: None,
                 opaque: None,
+                header: None,
             },
             "did:example:payer",
             PaymentPayload::hash("0x123"),

--- a/src/protocol/traits/session.rs
+++ b/src/protocol/traits/session.rs
@@ -152,6 +152,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
         let request = SessionRequest {

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -346,6 +346,14 @@ pub trait ChargeChallenger: Send + Sync + 'static {
         }
         self.verify_payment_for_amount_with_body(credential_str, amount, body)
     }
+
+    /// HTTP field containing the Payment credential.
+    ///
+    /// Defaults to `Authorization`. Servers created with `requires_auth`
+    /// return `Payment-Authorization`.
+    fn credential_header(&self) -> &str {
+        "Authorization"
+    }
 }
 
 #[cfg(feature = "tempo")]
@@ -616,6 +624,10 @@ where
             .map_err(|e| e.to_string())
         })
     }
+
+    fn credential_header(&self) -> &str {
+        super::Mpp::credential_header(self)
+    }
 }
 
 #[cfg(feature = "stripe")]
@@ -885,6 +897,10 @@ where
             .map_err(|e| e.to_string())
         })
     }
+
+    fn credential_header(&self) -> &str {
+        super::Mpp::credential_header(self)
+    }
 }
 
 impl<S, C> FromRequestParts<S> for MppCharge<C>
@@ -903,7 +919,7 @@ where
         let mppx_scope = mppx_scope_from_parts(parts);
         let auth_header = parts
             .headers
-            .get(header::AUTHORIZATION)
+            .get(challenger.credential_header())
             .and_then(|v| v.to_str().ok())
             .and_then(extract_payment_scheme)
             .map(|s| s.to_string());
@@ -964,7 +980,7 @@ where
         let mppx_scope = mppx_scope_from_parts(&parts);
         let auth_header = parts
             .headers
-            .get(header::AUTHORIZATION)
+            .get(challenger.credential_header())
             .and_then(|v| v.to_str().ok())
             .and_then(extract_payment_scheme)
             .map(|s| s.to_string());

--- a/src/server/axum.rs
+++ b/src/server/axum.rs
@@ -352,7 +352,7 @@ pub trait ChargeChallenger: Send + Sync + 'static {
     /// Defaults to `Authorization`. Servers created with `requires_auth`
     /// return `Payment-Authorization`.
     fn credential_header(&self) -> &str {
-        "Authorization"
+        header::AUTHORIZATION.as_str()
     }
 }
 

--- a/src/server/compose.rs
+++ b/src/server/compose.rs
@@ -168,6 +168,7 @@ mod tests {
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }
     }
 
@@ -260,6 +261,7 @@ mod tests {
             expires: Some(expires),
             digest: None,
             opaque: None,
+            header: None,
         };
         PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
     }
@@ -328,6 +330,7 @@ mod tests {
             expires: Some(expires),
             digest: None,
             opaque: None,
+            header: None,
         };
         let cred = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -72,7 +72,7 @@ pub trait PaymentVerifier: Send + Sync + 'static {
     /// Defaults to `Authorization`. Servers created with `requires_auth`
     /// return `Payment-Authorization`.
     fn credential_header(&self) -> &str {
-        "Authorization"
+        header::AUTHORIZATION.as_str()
     }
 }
 

--- a/src/server/middleware.rs
+++ b/src/server/middleware.rs
@@ -50,7 +50,7 @@ pub trait PaymentVerifier: Send + Sync + 'static {
 
     /// Verify a credential string and return a `Payment-Receipt` header value.
     ///
-    /// The `credential` is the raw `Authorization` header value
+    /// The `credential` is the raw Payment credential header value
     /// (e.g., `"Payment eyJ..."` including the scheme prefix).
     fn verify(
         &self,
@@ -65,6 +65,14 @@ pub trait PaymentVerifier: Send + Sync + 'static {
     ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
         let _ = body;
         self.verify(credential)
+    }
+
+    /// HTTP field containing the Payment credential.
+    ///
+    /// Defaults to `Authorization`. Servers created with `requires_auth`
+    /// return `Payment-Authorization`.
+    fn credential_header(&self) -> &str {
+        "Authorization"
     }
 }
 
@@ -208,10 +216,10 @@ where
         let mut inner = std::mem::replace(&mut self.inner, clone);
 
         Box::pin(async move {
-            // Extract the Authorization header.
+            // Extract the Payment credential from the header selected by the challenge.
             let auth_header = req
                 .headers()
-                .get(header::AUTHORIZATION)
+                .get(verifier.credential_header())
                 .and_then(|v| v.to_str().ok())
                 .and_then(extract_payment_scheme)
                 .map(|s| s.to_string());
@@ -447,6 +455,8 @@ struct ChargeVerifier {
     challenge_fn: Box<dyn Fn() -> Result<String, String> + Send + Sync>,
     /// Builds a fresh body-bound `WWW-Authenticate` header value per request.
     challenge_with_body_fn: Box<dyn Fn(&[u8]) -> Result<String, String> + Send + Sync>,
+    /// HTTP field containing the Payment credential.
+    credential_header: String,
     /// Shared mpp instance for verification (type-erased).
     verify_fn: Box<
         dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>>
@@ -483,6 +493,10 @@ impl PaymentVerifier for ChargeVerifier {
         body: &[u8],
     ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send>> {
         (self.verify_with_body_fn)(credential.to_string(), body.to_vec())
+    }
+
+    fn credential_header(&self) -> &str {
+        &self.credential_header
     }
 }
 
@@ -581,6 +595,7 @@ impl PaymentLayer<ChargeVerifier> {
         Ok(Self::new(ChargeVerifier {
             challenge_fn,
             challenge_with_body_fn,
+            credential_header: mpp.credential_header().to_string(),
             verify_fn,
             verify_with_body_fn,
         }))

--- a/src/server/mpp.rs
+++ b/src/server/mpp.rs
@@ -44,6 +44,11 @@ const REALM_ENV_VARS: &[&str] = &[
 
 const DEFAULT_REALM: &str = "MPP Payment";
 
+#[cfg(any(feature = "tempo", feature = "stripe"))]
+fn advertised_builder_credential_header(requires_auth: bool) -> Option<String> {
+    requires_auth.then(|| crate::protocol::core::PAYMENT_AUTHORIZATION_HEADER.to_string())
+}
+
 /// Detect the server realm from environment variables.
 ///
 /// Checks platform-specific env vars in order (see [`REALM_ENV_VARS`]),
@@ -112,6 +117,7 @@ pub struct Mpp<M, S = ()> {
     machine_token_enabled: bool,
     chain_id: Option<u64>,
     opaque: Option<Base64UrlJson>,
+    credential_header: Option<String>,
     events: ServerEvents,
 }
 
@@ -135,6 +141,7 @@ where
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         }
     }
@@ -159,6 +166,7 @@ where
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         }
     }
@@ -182,6 +190,7 @@ where
             machine_token_enabled: self.machine_token_enabled,
             chain_id: self.chain_id,
             opaque: self.opaque,
+            credential_header: self.credential_header,
             events: self.events,
         }
     }
@@ -199,23 +208,51 @@ where
         self
     }
 
-    /// Stamp the configured `opaque` onto an issued challenge and recompute its
-    /// HMAC id. No-op when unconfigured.
+    /// Use `Payment-Authorization` for Payment credentials so `Authorization`
+    /// remains available for application authentication.
+    ///
+    /// Challenges advertise `header="Payment-Authorization"`, and clients send
+    /// the credential in that field instead of `Authorization`.
+    pub fn with_requires_auth(mut self, enabled: bool) -> Self {
+        self.credential_header =
+            enabled.then(|| crate::protocol::core::PAYMENT_AUTHORIZATION_HEADER.to_string());
+        self
+    }
+
+    /// Whether this handler requires ordinary application authentication.
+    ///
+    /// When true, Payment credentials use `Payment-Authorization`.
+    pub fn requires_auth(&self) -> bool {
+        self.credential_header.is_some()
+    }
+
+    /// HTTP field a client must use for Payment credentials issued by this handler.
+    pub fn credential_header(&self) -> &str {
+        self.credential_header.as_deref().unwrap_or("Authorization")
+    }
+
+    /// Stamp configured `opaque` and credential `header` onto an issued
+    /// challenge and recompute its HMAC id. No-op when neither is configured.
     #[cfg(any(feature = "tempo", feature = "stripe"))]
     fn apply_pinned_opaque(&self, mut challenge: PaymentChallenge) -> PaymentChallenge {
+        if self.opaque.is_none() && self.credential_header.is_none() {
+            return challenge;
+        }
         if let Some(opaque) = &self.opaque {
-            challenge.id = crate::protocol::core::compute_challenge_id(
-                &self.secret_key,
-                &challenge.realm,
-                challenge.method.as_str(),
-                challenge.intent.as_str(),
-                challenge.request.raw(),
-                challenge.expires.as_deref(),
-                challenge.digest.as_deref(),
-                Some(opaque.raw()),
-            );
             challenge.opaque = Some(opaque.clone());
         }
+        challenge.header = self.credential_header.clone();
+        challenge.id = crate::protocol::core::compute_challenge_id_with_header(
+            &self.secret_key,
+            &challenge.realm,
+            challenge.method.as_str(),
+            challenge.intent.as_str(),
+            challenge.request.raw(),
+            challenge.expires.as_deref(),
+            challenge.digest.as_deref(),
+            challenge.opaque.as_ref().map(|o| o.raw()),
+            challenge.header.as_deref(),
+        );
         challenge
     }
 
@@ -406,7 +443,7 @@ where
         &self,
         credential: &PaymentCredential,
     ) -> std::result::Result<(), VerificationError> {
-        let expected_id = crate::protocol::core::compute_challenge_id(
+        let expected_id = crate::protocol::core::compute_challenge_id_with_header(
             &self.secret_key,
             &self.realm,
             credential.challenge.method.as_str(),
@@ -415,6 +452,7 @@ where
             credential.challenge.expires.as_deref(),
             credential.challenge.digest.as_deref(),
             credential.challenge.opaque.as_ref().map(|o| o.raw()),
+            credential.challenge.header.as_deref(),
         );
 
         if !crate::protocol::core::constant_time_eq(&credential.challenge.id, &expected_id) {
@@ -905,7 +943,7 @@ where
     #[cfg(any(feature = "tempo", feature = "stripe"))]
     fn with_body_digest(&self, mut challenge: PaymentChallenge, body: &[u8]) -> PaymentChallenge {
         let digest = crate::body_digest::compute(body);
-        challenge.id = crate::protocol::core::compute_challenge_id(
+        challenge.id = crate::protocol::core::compute_challenge_id_with_header(
             &self.secret_key,
             &challenge.realm,
             challenge.method.as_str(),
@@ -914,6 +952,7 @@ where
             challenge.expires.as_deref(),
             Some(&digest),
             challenge.opaque.as_ref().map(|o| o.raw()),
+            challenge.header.as_deref(),
         );
         challenge.digest = Some(digest);
         challenge
@@ -977,6 +1016,7 @@ where
             description: None,
             digest: None,
             opaque: None,
+            header: None,
         }))
     }
 
@@ -1098,6 +1138,7 @@ where
             description: options.description.map(|s| s.to_string()),
             digest: None,
             opaque: None,
+            header: None,
         }))
     }
 
@@ -1253,6 +1294,7 @@ impl Mpp<super::TempoChargeMethod<super::TempoProvider>> {
             machine_token_enabled: builder.machine_token_enabled,
             chain_id: builder.chain_id,
             opaque: None,
+            credential_header: advertised_builder_credential_header(builder.requires_auth),
             events: ServerEvents::default(),
         })
     }
@@ -1348,6 +1390,7 @@ impl<S> Mpp<crate::protocol::methods::stripe::method::ChargeMethod, S> {
             description: options.description.map(|s| s.to_string()),
             digest: None,
             opaque: None,
+            header: None,
         }))
     }
 
@@ -1414,6 +1457,7 @@ impl Mpp<crate::protocol::methods::stripe::method::ChargeMethod> {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: advertised_builder_credential_header(builder.requires_auth),
             events: ServerEvents::default(),
         })
     }
@@ -1599,6 +1643,7 @@ mod tests {
             expires: Some(expires),
             digest: None,
             opaque: None,
+            header: None,
         };
         PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
     }
@@ -1643,6 +1688,7 @@ mod tests {
             expires: Some(expires),
             digest,
             opaque: None,
+            header: None,
         };
         PaymentCredential::new(echo, PaymentPayload::hash("0x123"))
     }
@@ -2167,6 +2213,7 @@ mod tests {
                 expires: Some(expires),
                 digest: None,
                 opaque: None,
+                header: None,
             },
             PaymentPayload::hash("0x123"),
         );
@@ -2572,6 +2619,7 @@ mod tests {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         }
     }
@@ -2588,6 +2636,31 @@ mod tests {
         let receipt = mpp.verify_credential(&credential).await.unwrap();
         assert!(receipt.is_success());
         assert_eq!(receipt.reference, "0xtxhash");
+    }
+
+    #[cfg(feature = "tempo")]
+    #[tokio::test]
+    async fn test_requires_auth_advertises_payment_authorization_header() {
+        let mpp = create_hmac_test_mpp().with_requires_auth(true);
+        let challenge = mpp.charge("0.10").unwrap();
+
+        assert!(mpp.requires_auth());
+        assert_eq!(mpp.credential_header(), "Payment-Authorization");
+        assert_eq!(challenge.header.as_deref(), Some("Payment-Authorization"));
+        assert!(challenge
+            .to_header()
+            .unwrap()
+            .contains(r#"header="Payment-Authorization""#));
+        assert!(challenge.verify("test-secret"));
+
+        let credential =
+            PaymentCredential::new(challenge.to_echo(), PaymentPayload::hash("0xdeadbeef"));
+        let receipt = mpp.verify_credential(&credential).await.unwrap();
+        assert!(receipt.is_success());
+
+        let implicit = create_hmac_test_mpp().charge("0.10").unwrap();
+        assert_ne!(implicit.id, challenge.id);
+        assert!(implicit.header.is_none());
     }
 
     #[cfg(feature = "tempo")]
@@ -3179,6 +3252,7 @@ mod tests {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         }
     }
@@ -3257,6 +3331,7 @@ mod tests {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         };
 
@@ -3302,6 +3377,7 @@ mod tests {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         };
 
@@ -3314,6 +3390,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0x123"));
 
@@ -3405,6 +3482,7 @@ mod tests {
             machine_token_enabled: false,
             chain_id: None,
             opaque: None,
+            credential_header: None,
             events: ServerEvents::default(),
         };
 
@@ -3552,6 +3630,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(echo, PaymentPayload::hash("0xdeadbeef"));
 
@@ -3840,6 +3919,7 @@ mod tests {
             expires: None,
             digest: None,
             opaque: None,
+            header: None,
         };
         let credential = PaymentCredential::new(
             echo,

--- a/src/server/stripe.rs
+++ b/src/server/stripe.rs
@@ -46,6 +46,7 @@ pub struct StripeBuilder {
     pub(crate) realm: String,
     pub(crate) hmac_secret_key: Option<String>,
     pub(crate) stripe_api_base: Option<String>,
+    pub(crate) requires_auth: bool,
 }
 
 impl StripeBuilder {
@@ -64,6 +65,13 @@ impl StripeBuilder {
     /// Override the Stripe API base URL (for testing with a mock server).
     pub fn stripe_api_base(mut self, url: &str) -> Self {
         self.stripe_api_base = Some(url.to_string());
+        self
+    }
+
+    /// Use `Payment-Authorization` for Payment credentials so `Authorization`
+    /// remains available for application authentication.
+    pub fn requires_auth(mut self, enabled: bool) -> Self {
+        self.requires_auth = enabled;
         self
     }
 }
@@ -102,5 +110,6 @@ pub fn stripe(config: StripeConfig<'_>) -> StripeBuilder {
         realm: detect_realm(),
         hmac_secret_key: None,
         stripe_api_base: None,
+        requires_auth: false,
     }
 }

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -40,6 +40,7 @@ pub struct TempoBuilder {
     pub(crate) fee_payer_allowed_fee_tokens: Option<Vec<Address>>,
     pub(crate) store: Option<std::sync::Arc<dyn crate::store::Store>>,
     pub(crate) relay: Option<TempoRelayConfig>,
+    pub(crate) requires_auth: bool,
 }
 
 impl TempoBuilder {
@@ -150,6 +151,13 @@ impl TempoBuilder {
         self.relay = Some(config);
         self
     }
+
+    /// Use `Payment-Authorization` for Payment credentials so `Authorization`
+    /// remains available for application authentication.
+    pub fn requires_auth(mut self, enabled: bool) -> Self {
+        self.requires_auth = enabled;
+        self
+    }
 }
 
 /// Create a Tempo payment method configuration with smart defaults.
@@ -208,6 +216,7 @@ pub fn tempo(config: TempoConfig<'_>) -> TempoBuilder {
         // Default in-memory store; replay protection on by default.
         store: Some(std::sync::Arc::new(crate::store::MemoryStore::new())),
         relay: None,
+        requires_auth: false,
     }
 }
 

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -115,7 +115,7 @@ impl HttpTransport {
         if self.requires_auth {
             crate::protocol::core::PAYMENT_AUTHORIZATION_HEADER
         } else {
-            "Authorization"
+            http_types::header::AUTHORIZATION.as_str()
         }
     }
 }

--- a/src/server/transport.rs
+++ b/src/server/transport.rs
@@ -85,16 +85,39 @@ pub trait Transport: Send + Sync {
 
 /// HTTP transport for server-side payment handling.
 ///
-/// - Reads credentials from the `Authorization` header
+/// - Reads credentials from `Authorization`, or from `Payment-Authorization`
+///   when constructed with [`HttpTransport::requires_auth`]
 /// - Issues challenges via `WWW-Authenticate` header with 402 status
 /// - Attaches receipts via `Payment-Receipt` header
 ///
 /// This is the default transport, matching mppx's `Transport.http()`.
-pub struct HttpTransport;
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HttpTransport {
+    requires_auth: bool,
+}
 
 /// Create an HTTP transport instance.
 pub fn http() -> HttpTransport {
-    HttpTransport
+    HttpTransport {
+        requires_auth: false,
+    }
+}
+
+impl HttpTransport {
+    /// Use `Payment-Authorization` for Payment credentials so `Authorization`
+    /// remains available for application authentication.
+    pub fn requires_auth(mut self, enabled: bool) -> Self {
+        self.requires_auth = enabled;
+        self
+    }
+
+    fn credential_header(&self) -> &'static str {
+        if self.requires_auth {
+            crate::protocol::core::PAYMENT_AUTHORIZATION_HEADER
+        } else {
+            "Authorization"
+        }
+    }
 }
 
 impl Transport for HttpTransport {
@@ -107,7 +130,7 @@ impl Transport for HttpTransport {
     }
 
     fn get_credential(&self, input: &Self::Input) -> Result<Option<PaymentCredential>, MppError> {
-        let Some(header) = input.headers().get(http_types::header::AUTHORIZATION) else {
+        let Some(header) = input.headers().get(self.credential_header()) else {
             return Ok(None);
         };
 
@@ -243,6 +266,43 @@ mod tests {
 
         let result = transport.get_credential(&req).unwrap();
         assert!(result.is_some(), "should parse valid Payment credential");
+        let parsed = result.unwrap();
+        assert_eq!(parsed.challenge.id, "test-id");
+    }
+
+    #[test]
+    fn test_http_get_credential_from_payment_authorization() {
+        let transport = http().requires_auth(true);
+
+        let mut challenge = PaymentChallenge::new(
+            "test-id",
+            "test.example.com",
+            "tempo",
+            "charge",
+            crate::protocol::core::Base64UrlJson::from_value(
+                &serde_json::json!({"amount": "1000"}),
+            )
+            .unwrap(),
+        );
+        challenge.header = Some("Payment-Authorization".to_string());
+        let credential = crate::protocol::core::PaymentCredential::new(
+            challenge.to_echo(),
+            crate::protocol::core::PaymentPayload::hash("0xdeadbeef"),
+        );
+        let auth_header = crate::protocol::core::format_authorization(&credential).unwrap();
+
+        let req = http_types::Request::builder()
+            .uri("/test")
+            .header("Authorization", "Bearer ordinary-authentication")
+            .header("Payment-Authorization", &auth_header)
+            .body(())
+            .unwrap();
+
+        let result = transport.get_credential(&req).unwrap();
+        assert!(
+            result.is_some(),
+            "should parse Payment-Authorization credential"
+        );
         let parsed = result.unwrap();
         assert_eq!(parsed.challenge.id, "test-id");
     }


### PR DESCRIPTION
When an endpoint already uses Authorization for application auth, challenges advertise header="Payment-Authorization" and clients send the credential there instead.

Mirrors mppx change: https://github.com/wevm/mppx/pull/821

Follows spec change here: https://github.com/tempoxyz/mpp-specs/pull/328