### PR TITLE
feat(stripe): mark machine payment intents

### DIFF
--- a/.changelog/brave-foxes-pay.md
+++ b/.changelog/brave-foxes-pay.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Added a machine-payment metadata field to every Stripe PaymentIntent created by mpp-rs.

--- a/src/protocol/methods/stripe/method.rs
+++ b/src/protocol/methods/stripe/method.rs
@@ -224,6 +224,7 @@ impl ChargeMethodTrait for ChargeMethod {
             if let Some(user_meta) = details.metadata {
                 metadata.extend(user_meta);
             }
+            metadata.insert("machine_payment".into(), "true".into());
 
             let idempotency_key = Self::idempotency_key(&challenge.id, &payload.spt);
 

--- a/tests/integration_stripe.rs
+++ b/tests/integration_stripe.rs
@@ -66,6 +66,11 @@ async fn mock_create_payment_intent(
         "confirm must be true"
     );
     assert_eq!(
+        params.get("metadata[machine_payment]").map(|s| s.as_str()),
+        Some("true"),
+        "machine_payment metadata must be true"
+    );
+    assert_eq!(
         params
             .get("automatic_payment_methods[enabled]")
             .map(|s| s.as_str()),


### PR DESCRIPTION
Add metadata.machine_payment=true to Stripe PaymentIntents created when verifying shared payment tokens.

This will help users identify machine payments.