### PR TITLE
ci: allow untagged Tempo lints SHA pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Pin pnpm for Tempo Lints
         run: corepack prepare pnpm@10.28.1 --activate
       - name: Run Tempo Lints
-        uses: tempoxyz/lints@f9268eb2b828dbacf9f4b5d4bf6ad4541826567f # main
+        uses: tempoxyz/lints@f9268eb2b828dbacf9f4b5d4bf6ad4541826567f # zizmor: ignore[ref-version-mismatch] pinned revision has no release tag
         with:
           language: rust
           path: "."


### PR DESCRIPTION
## Summary

- replace the moving `# main` annotation on the immutable `tempoxyz/lints` pin with a targeted `ref-version-mismatch` suppression
- keep the pinned action revision unchanged

## Context

The [scheduled workflow scan](https://github.com/tempoxyz/mpp-rs/actions/runs/33369112850) started failing after `tempoxyz/lints` main advanced to `0b90e872520e`. This repository remains intentionally pinned to `f9268eb2b828dbacf9f4b5d4bf6ad4541826567f`, so the `# main` annotation is now stale even though the immutable pin itself is valid.

Re-pinning to the current branch head would only postpone the same failure until the next upstream commit. The pinned revision does not have a matching release tag, so this uses the narrow inline exception pattern also used for untagged Tempo-owned actions in tempoxyz/zones#1034.

## Verification

- `zizmor 1.26.1 --persona regular .`: exit 13 before the change, exit 0 after it
- `actionlint 1.7.12`
- `git diff --check`
