### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        uses: tempoxyz/gh-actions/vendor/rust-lang/crates-io-auth-action@487be2d19b0ba9ae1903143016444ab752c3e939
         id: auth
 
       - name: Changelogs


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/487be2d19b0ba9ae1903143016444ab752c3e939/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `rust-lang/crates-io-auth-action` | [`tempoxyz/gh-actions/vendor/rust-lang/crates-io-auth-action`](https://github.com/tempoxyz/gh-actions/tree/487be2d19b0ba9ae1903143016444ab752c3e939/vendor/rust-lang/crates-io-auth-action) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 2 -> 2).
