### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           post-comment: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install ast-grep
-        uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
+        uses: tempoxyz/gh-actions/vendor/jaxxstorm/action-install-gh-release@b411ce7fe18d0775ae614ad5c4b873c768364979
         with:
           repo: ast-grep/ast-grep
           tag: "0.45.0"


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `jaxxstorm/action-install-gh-release` | [`tempoxyz/gh-actions/vendor/jaxxstorm/action-install-gh-release`](https://github.com/tempoxyz/gh-actions/tree/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor/jaxxstorm/action-install-gh-release) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 2 -> 2).
