### PR TITLE
Pin GitHub STS POST action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Fetch GitHub token via STS
         id: app-token
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
         with:
           policy: release-pr
 


### PR DESCRIPTION
## Summary

- pin all GitHub STS action uses to tempoxyz/gh-actions@c0292122e255def866c64c55e5844d1e7d5fe7ad
- use the action version that sends `POST /sts/exchange`
- preserve all existing scopes, policies, TTLs, and workflow behavior

This is part of the coordinated organization-wide rollout required before retiring legacy GET exchanges.

## Validation

- mechanical pin-only update; repository CI is the behavioral validation