### PR TITLE
fix(ci): update release and scanner pins for action policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: auth
 
       - name: Changelogs
-        uses: tempoxyz/changelogs@bd50cca508d81505924dfa3997b1696ac2b7b1aa # v0.9.0
+        uses: tempoxyz/changelogs@83e69646d7ef76c5f35364d3a06fce3a6fe62bf9 # main
         with:
           ecosystem: rust
           conventional-commit: true

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -18,7 +18,8 @@ permissions: {}
 jobs:
   scan:
     name: Scan GitHub Actions
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@698fc0aa8d7f86540fabd09f0f27efa3b9109214
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@891834ec16535af9d8b7f30ce157967243f8ac24
     permissions:
+      id-token: write
       actions: read
       contents: read


### PR DESCRIPTION
Update release and scanner pins to comply with the action policy; add the scanner’s required OIDC permission.

[Scanner CI passed](https://github.com/tempoxyz/mpp-rs/actions/runs/34199969542). Release execution needs verification after merge.

Prompted by: @grandizzy
