### PR TITLE
fix: charge multi-fetch session requests

### DIFF
--- a/.changelog/charge-session-multi-fetch-requests.md
+++ b/.changelog/charge-session-multi-fetch-requests.md
@@ -1,0 +1,6 @@
+---
+"mpp": patch
+---
+
+Export session channel deduction helpers and update the multi-fetch example to
+atomically charge each request before releasing paid content.

--- a/examples/session/multi-fetch/README.md
+++ b/examples/session/multi-fetch/README.md
@@ -9,8 +9,12 @@ This is the Rust port of the TypeScript `session/multi-fetch` example.
 1. **Server** exposes an `/api/scrape` endpoint that costs 0.01 pathUSD per request
 2. **Client** opens a payment channel on the first request (on-chain)
 3. Subsequent requests use off-chain vouchers — no gas, instant settlement
-4. Each voucher is cumulative: request N carries a voucher for `N × 0.01` pathUSD
-5. **Client** closes the channel, triggering on-chain settlement and refund of unused deposit
+4. The server atomically deducts 0.01 pathUSD from the channel before releasing each response
+5. Each voucher is cumulative: request N carries a voucher for `N × 0.01` pathUSD
+6. **Client** closes the channel, triggering on-chain settlement and refund of unused deposit
+
+Voucher verification only increases the channel's authorized balance. Applications must
+separately deduct their server-controlled request price before delivering paid content.
 
 ## Running
 

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -20,8 +20,8 @@ use axum::{
 };
 use mpp::client::channel_ops::default_escrow_contract;
 use mpp::server::{
-    tempo, Mpp, SessionChallengeOptions, SessionChannelStore, SessionMethodConfig,
-    TempoChargeMethod, TempoConfig, TempoSessionMethod,
+    deduct_from_channel, tempo, Mpp, SessionChallengeOptions, SessionChannelStore,
+    SessionMethodConfig, TempoChargeMethod, TempoConfig, TempoSessionMethod,
 };
 use mpp::{parse_authorization, PaymentCredential, PrivateKeySigner};
 use std::sync::Arc;
@@ -30,12 +30,17 @@ use tempo_alloy::TempoNetwork;
 const RPC_URL: &str = "https://rpc.moderato.tempo.xyz";
 const CHAIN_ID: u64 = 42431;
 /// 0.01 pathUSD in base units (6 decimals).
-const AMOUNT_PER_REQUEST: &str = "10000";
+const AMOUNT_PER_REQUEST: u128 = 10_000;
 
 type PaymentHandler = Mpp<
     TempoChargeMethod<mpp::server::TempoProvider>,
     TempoSessionMethod<mpp::server::TempoProvider>,
 >;
+
+struct AppState {
+    payment: PaymentHandler,
+    store: Arc<SessionChannelStore>,
+}
 
 #[derive(serde::Deserialize)]
 struct ScrapeQuery {
@@ -72,7 +77,7 @@ async fn main() {
     let store = Arc::new(SessionChannelStore::new());
     let session_method = TempoSessionMethod::new(
         rpc_provider,
-        store,
+        store.clone(),
         SessionMethodConfig {
             escrow_contract: default_escrow_contract(CHAIN_ID).unwrap(),
             chain_id: CHAIN_ID,
@@ -83,11 +88,12 @@ async fn main() {
 
     // Add session method to the payment handler.
     let payment = base_payment.with_session_method(session_method);
+    let state = Arc::new(AppState { payment, store });
 
     let app = Router::new()
         .route("/api/health", get(health))
         .route("/api/scrape", get(scrape).post(scrape))
-        .with_state(Arc::new(payment));
+        .with_state(state);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     println!("Listening on http://localhost:3000");
@@ -99,7 +105,7 @@ async fn health() -> impl IntoResponse {
 }
 
 async fn scrape(
-    State(payment): State<Arc<PaymentHandler>>,
+    State(state): State<Arc<AppState>>,
     headers: HeaderMap,
     Query(query): Query<ScrapeQuery>,
 ) -> impl IntoResponse {
@@ -107,7 +113,7 @@ async fn scrape(
 
     // Check for a payment credential in the Authorization header.
     if let Some(credential) = parse_credential(&headers) {
-        match payment.verify_session(&credential).await {
+        match state.payment.verify_session(&credential).await {
             Ok(result) => {
                 // If the session method returned a management response (open/close/topUp),
                 // return it directly instead of the scraped content.
@@ -122,7 +128,11 @@ async fn scrape(
                         .into_response();
                 }
 
-                // Payment verified — return the scraped content with a receipt.
+                if let Err(e) = charge_request(&state.store, &result.receipt.reference).await {
+                    eprintln!("Session charge failed: {e}");
+                    return payment_required(&state.payment);
+                }
+
                 let content = scrape_page(page_url);
                 let receipt_header = result.receipt.to_header().unwrap_or_default();
                 return (
@@ -142,11 +152,24 @@ async fn scrape(
     }
 
     // No valid credential — return 402 with a session challenge.
+    payment_required(&state.payment)
+}
+
+async fn charge_request(
+    store: &SessionChannelStore,
+    channel_id: &str,
+) -> Result<(), mpp::server::VerificationError> {
+    deduct_from_channel(store, channel_id, AMOUNT_PER_REQUEST)
+        .await
+        .map(|_| ())
+}
+
+fn payment_required(payment: &PaymentHandler) -> axum::response::Response {
     let currency = payment.currency().unwrap();
     let recipient = payment.recipient().unwrap();
     let challenge = payment
         .session_challenge_with_details(
-            AMOUNT_PER_REQUEST,
+            &AMOUNT_PER_REQUEST.to_string(),
             currency,
             recipient,
             SessionChallengeOptions {
@@ -174,4 +197,92 @@ fn parse_credential(headers: &HeaderMap) -> Option<PaymentCredential> {
 
 fn scrape_page(url: &str) -> String {
     format!("<h1>{url}</h1><p>Scraped content from {url}</p>")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::Address;
+    use mpp::tempo::ChannelState;
+
+    fn channel_state(channel_id: &str, authorized: u128, spent: u128) -> ChannelState {
+        ChannelState {
+            channel_id: channel_id.to_string(),
+            chain_id: CHAIN_ID,
+            escrow_contract: Address::ZERO,
+            payer: Address::ZERO,
+            payee: Address::ZERO,
+            token: Address::ZERO,
+            settlement_route: None,
+            authorized_signer: Address::ZERO,
+            deposit: authorized,
+            settled_on_chain: 0,
+            highest_voucher_amount: authorized,
+            highest_voucher_signature: None,
+            spent,
+            units: 0,
+            finalized: false,
+            closing: false,
+            close_requested_at: 0,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn request_charge_requires_full_price_and_preserves_failed_state() {
+        struct Case {
+            name: &'static str,
+            authorized: u128,
+            spent: u128,
+            succeeds: bool,
+            expected_spent: u128,
+        }
+
+        let cases = [
+            Case {
+                name: "one-unit voucher",
+                authorized: 10_001,
+                spent: 10_000,
+                succeeds: false,
+                expected_spent: 10_000,
+            },
+            Case {
+                name: "partial balance",
+                authorized: 19_999,
+                spent: 10_000,
+                succeeds: false,
+                expected_spent: 10_000,
+            },
+            Case {
+                name: "exact balance",
+                authorized: 20_000,
+                spent: 10_000,
+                succeeds: true,
+                expected_spent: 20_000,
+            },
+            Case {
+                name: "prepaid balance",
+                authorized: 30_000,
+                spent: 10_000,
+                succeeds: true,
+                expected_spent: 20_000,
+            },
+        ];
+
+        for (index, case) in cases.into_iter().enumerate() {
+            let channel_id = format!("channel-{index}");
+            let store = SessionChannelStore::new();
+            store.insert(
+                &channel_id,
+                channel_state(&channel_id, case.authorized, case.spent),
+            );
+
+            let result = charge_request(&store, &channel_id).await;
+            assert_eq!(result.is_ok(), case.succeeds, "{}", case.name);
+
+            let state = store.get_channel_sync(&channel_id).unwrap();
+            assert_eq!(state.spent, case.expected_spent, "{}", case.name);
+            assert_eq!(state.units, u64::from(case.succeeds), "{}", case.name);
+        }
+    }
 }

--- a/examples/session/multi-fetch/src/server.rs
+++ b/examples/session/multi-fetch/src/server.rs
@@ -23,7 +23,8 @@ use mpp::server::{
     deduct_from_channel, tempo, Mpp, SessionChallengeOptions, SessionChannelStore,
     SessionMethodConfig, TempoChargeMethod, TempoConfig, TempoSessionMethod,
 };
-use mpp::{parse_authorization, PaymentCredential, PrivateKeySigner};
+use mpp::tempo::SessionCredentialPayload;
+use mpp::{parse_authorization, PaymentCredential, PrivateKeySigner, Receipt};
 use std::sync::Arc;
 use tempo_alloy::TempoNetwork;
 
@@ -113,24 +114,37 @@ async fn scrape(
 
     // Check for a payment credential in the Authorization header.
     if let Some(credential) = parse_credential(&headers) {
+        let payload = credential.payload_as::<SessionCredentialPayload>().ok();
         match state.payment.verify_session(&credential).await {
             Ok(result) => {
                 // If the session method returned a management response (open/close/topUp),
                 // return it directly instead of the scraped content.
                 // Include the payment-receipt header so the client can read tx hashes.
-                if let Some(mgmt) = result.management_response {
-                    let receipt_header = result.receipt.to_header().unwrap_or_default();
-                    return (
-                        StatusCode::OK,
-                        [("payment-receipt", receipt_header)],
-                        axum::Json(mgmt),
-                    )
-                        .into_response();
+                if let Some(mgmt) = result.management_response.as_ref() {
+                    if !matches!(
+                        payload.as_ref(),
+                        Some(SessionCredentialPayload::Open { .. })
+                    ) {
+                        let receipt_header = result.receipt.to_header().unwrap_or_default();
+                        return (
+                            StatusCode::OK,
+                            [("payment-receipt", receipt_header)],
+                            axum::Json(mgmt.clone()),
+                        )
+                            .into_response();
+                    }
                 }
 
-                if let Err(e) = charge_request(&state.store, &result.receipt.reference).await {
+                let Some(channel_id) = payload
+                    .as_ref()
+                    .and_then(|payload| content_channel_id(payload, &result.receipt.reference))
+                else {
+                    return payment_required(&state.payment, Some(&result.receipt));
+                };
+
+                if let Err(e) = charge_request(&state.store, channel_id).await {
                     eprintln!("Session charge failed: {e}");
-                    return payment_required(&state.payment);
+                    return payment_required(&state.payment, Some(&result.receipt));
                 }
 
                 let content = scrape_page(page_url);
@@ -152,7 +166,18 @@ async fn scrape(
     }
 
     // No valid credential — return 402 with a session challenge.
-    payment_required(&state.payment)
+    payment_required(&state.payment, None)
+}
+
+fn content_channel_id<'a>(
+    payload: &'a SessionCredentialPayload,
+    receipt_reference: &'a str,
+) -> Option<&'a str> {
+    match payload {
+        SessionCredentialPayload::Open { channel_id, .. } => Some(channel_id),
+        SessionCredentialPayload::Voucher { .. } => Some(receipt_reference),
+        SessionCredentialPayload::TopUp { .. } | SessionCredentialPayload::Close { .. } => None,
+    }
 }
 
 async fn charge_request(
@@ -164,7 +189,10 @@ async fn charge_request(
         .map(|_| ())
 }
 
-fn payment_required(payment: &PaymentHandler) -> axum::response::Response {
+fn payment_required(
+    payment: &PaymentHandler,
+    receipt: Option<&Receipt>,
+) -> axum::response::Response {
     let currency = payment.currency().unwrap();
     let recipient = payment.recipient().unwrap();
     let challenge = payment
@@ -180,12 +208,26 @@ fn payment_required(payment: &PaymentHandler) -> axum::response::Response {
         )
         .expect("failed to create session challenge");
 
-    (
+    let mut response = (
         StatusCode::PAYMENT_REQUIRED,
         [(header::WWW_AUTHENTICATE, challenge.to_header().unwrap())],
         "Payment required",
     )
-        .into_response()
+        .into_response();
+    if let Some(receipt) = receipt {
+        insert_payment_receipt(&mut response, receipt);
+    }
+    response
+}
+
+fn insert_payment_receipt(response: &mut axum::response::Response, receipt: &Receipt) {
+    let receipt = receipt
+        .to_header()
+        .expect("failed to format payment receipt");
+    response.headers_mut().insert(
+        axum::http::HeaderName::from_static("payment-receipt"),
+        axum::http::HeaderValue::from_str(&receipt).expect("invalid payment receipt header"),
+    );
 }
 
 fn parse_credential(headers: &HeaderMap) -> Option<PaymentCredential> {
@@ -226,6 +268,68 @@ mod tests {
             close_requested_at: 0,
             created_at: "2026-01-01T00:00:00Z".to_string(),
         }
+    }
+
+    #[test]
+    fn opening_and_voucher_credentials_purchase_content() {
+        let cases = [
+            (
+                serde_json::json!({
+                    "action": "open",
+                    "type": "transaction",
+                    "channelId": "channel-open",
+                    "transaction": "0x01",
+                    "cumulativeAmount": "10000",
+                    "signature": "0x02"
+                }),
+                Some("channel-open"),
+            ),
+            (
+                serde_json::json!({
+                    "action": "voucher",
+                    "channelId": "channel-voucher",
+                    "cumulativeAmount": "20000",
+                    "signature": "0x03"
+                }),
+                Some("receipt-channel"),
+            ),
+            (
+                serde_json::json!({
+                    "action": "topUp",
+                    "type": "transaction",
+                    "channelId": "channel-top-up",
+                    "transaction": "0x04",
+                    "additionalDeposit": "10000"
+                }),
+                None,
+            ),
+            (
+                serde_json::json!({
+                    "action": "close",
+                    "channelId": "channel-close",
+                    "cumulativeAmount": "20000",
+                    "signature": "0x05"
+                }),
+                None,
+            ),
+        ];
+
+        for (payload, expected) in cases {
+            let payload: SessionCredentialPayload = serde_json::from_value(payload).unwrap();
+            assert_eq!(content_channel_id(&payload, "receipt-channel"), expected);
+        }
+    }
+
+    #[test]
+    fn payment_required_can_acknowledge_an_accepted_voucher() {
+        let receipt = Receipt::success("tempo", "channel-1");
+        let mut response = StatusCode::PAYMENT_REQUIRED.into_response();
+
+        insert_payment_receipt(&mut response, &receipt);
+
+        let encoded = response.headers().get("payment-receipt").unwrap();
+        let parsed = mpp::parse_receipt(encoded.to_str().unwrap()).unwrap();
+        assert_eq!(parsed.reference, "channel-1");
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -64,9 +64,10 @@ pub use mpp::{Mpp, SessionVerifyResult};
 // Re-export tempo types at server level for backward compatibility
 #[cfg(feature = "tempo")]
 pub use tempo::{
-    tempo, tempo_provider, SessionChannelStore, SessionMethodConfig, TempoBuilder, TempoChargeExt,
-    TempoChargeMethod, TempoConfig, TempoMethodDetails, TempoProvider, TempoRelayConfig,
-    TempoRelayErrorCode, TempoSessionMethod, CHAIN_ID, METHOD_NAME,
+    deduct_from_channel, tempo, tempo_provider, SessionChannelStore, SessionMethodConfig,
+    TempoBuilder, TempoChargeExt, TempoChargeMethod, TempoConfig, TempoMethodDetails,
+    TempoProvider, TempoRelayConfig, TempoRelayErrorCode, TempoSessionMethod, CHAIN_ID,
+    METHOD_NAME,
 };
 
 // Re-export stripe types at server level for backward compatibility

--- a/src/server/tempo.rs
+++ b/src/server/tempo.rs
@@ -5,8 +5,8 @@ use alloy::primitives::Address;
 use super::mpp::detect_realm;
 
 pub use crate::protocol::methods::tempo::session_method::{
-    InMemoryChannelStore as SessionChannelStore, SessionMethod as TempoSessionMethod,
-    SessionMethodConfig,
+    deduct_from_channel, InMemoryChannelStore as SessionChannelStore,
+    SessionMethod as TempoSessionMethod, SessionMethodConfig,
 };
 pub use crate::protocol::methods::tempo::ChargeMethod as TempoChargeMethod;
 pub use crate::protocol::methods::tempo::{

--- a/src/tempo/mod.rs
+++ b/src/tempo/mod.rs
@@ -45,6 +45,6 @@ pub use crate::protocol::methods::tempo::ChargeMethod as TempoChargeMethod;
 
 #[cfg(feature = "server")]
 pub use crate::protocol::methods::tempo::session_method::{
-    ChannelState, ChannelStore, InMemoryChannelStore as SessionChannelStore,
+    deduct_from_channel, ChannelState, ChannelStore, InMemoryChannelStore as SessionChannelStore,
     SessionMethod as TempoSessionMethod, SessionMethodConfig,
 };


### PR DESCRIPTION
## Motivation

The multi-fetch server verified cumulative vouchers but served content without deducting the advertised per-request price.

## Summary

- Atomically deduct the server-controlled request price before serving content
- Return a fresh payment challenge when available balance is insufficient
- Expose the channel deduction helper through public server APIs
- Document application-level session charging requirements

## Key design considerations

- Keep voucher authorization separate from request consumption
- Preserve channel state when the full request price is unavailable