### PR TITLE
fix(headers): preserve non-ASCII in challenge quoted-strings

### DIFF
--- a/.changelog/unicode-escape-quoted-params.md
+++ b/.changelog/unicode-escape-quoted-params.md
@@ -1,0 +1,5 @@
+---
+mpp: patch
+---
+
+Fixed WWW-Authenticate quoted-string parsing to preserve non-ASCII text. Values were built one byte at a time as if each byte were a character, so `café` parsed as `cafÃ©`, and the `\uXXXX` escapes a challenge uses for characters above Latin-1 were decoded as the literal text `u2014` rather than `—`. Surrogate pairs are recombined, and an unpaired surrogate decodes to U+FFFD.

--- a/src/protocol/core/headers.rs
+++ b/src/protocol/core/headers.rs
@@ -161,28 +161,49 @@ fn parse_auth_params(params_str: &str) -> Result<HashMap<String, String>> {
         let value = if bytes[i] == b'"' {
             i += 1;
             let mut value = String::new();
-            while i < bytes.len() && bytes[i] != b'"' {
-                if key == "request" && value.len() >= MAX_TOKEN_LEN {
+            let mut segment_start = i;
+            let value_end = loop {
+                if i >= bytes.len() {
+                    return Err(MppError::invalid_challenge_reason(
+                        "Unterminated quoted-string",
+                    ));
+                }
+                if key == "request" && value.len() + (i - segment_start) >= MAX_TOKEN_LEN {
                     return Err(MppError::invalid_challenge_reason(format!(
                         "Request parameter exceeds maximum length of {} bytes",
                         MAX_TOKEN_LEN
                     )));
                 }
 
-                if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                    i += 1;
-                    value.push(bytes[i] as char);
-                } else {
-                    value.push(bytes[i] as char);
+                match bytes[i] {
+                    b'"' => break i,
+                    b'\\' => {
+                        value.push_str(&params_str[segment_start..i]);
+                        i += 1;
+                        if i >= bytes.len() {
+                            return Err(MppError::invalid_challenge_reason(
+                                "Unterminated quoted-string",
+                            ));
+                        }
+                        if let Some((decoded, next)) = read_unicode_escape(params_str, i) {
+                            value.push(decoded);
+                            i = next;
+                        } else {
+                            // RFC 9110 quoted-pair: the backslash escapes one character.
+                            let escaped = params_str[i..]
+                                .chars()
+                                .next()
+                                .expect("index sits on a character boundary");
+                            value.push(escaped);
+                            i += escaped.len_utf8();
+                        }
+                        segment_start = i;
+                    }
+                    _ => i += 1,
                 }
-                i += 1;
-            }
-            if i >= bytes.len() {
-                return Err(MppError::invalid_challenge_reason(
-                    "Unterminated quoted-string",
-                ));
-            }
-            i += 1;
+            };
+            value.push_str(&params_str[segment_start..value_end]);
+            i = value_end + 1;
             value
         } else {
             let value_start = i;
@@ -208,6 +229,48 @@ fn parse_auth_params(params_str: &str) -> Result<HashMap<String, String>> {
     }
 
     Ok(params)
+}
+
+/// Decodes the `uXXXX` body of a backslash escape at `at`.
+///
+/// A header value cannot carry characters above Latin-1, so a challenge escapes
+/// them this way. A surrogate is paired with the escape that follows it; an
+/// unpaired surrogate decodes to U+FFFD, the closest value a `str` can hold.
+/// Returns `None` when `at` does not start a unicode escape.
+fn read_unicode_escape(input: &str, at: usize) -> Option<(char, usize)> {
+    let (unit, next) = read_escaped_code_unit(input, at)?;
+
+    if !(0xD800..=0xDFFF).contains(&unit) {
+        return char::from_u32(u32::from(unit)).map(|decoded| (decoded, next));
+    }
+
+    if (0xD800..=0xDBFF).contains(&unit) && input.as_bytes().get(next) == Some(&b'\\') {
+        if let Some((low, after)) = read_escaped_code_unit(input, next + 1) {
+            if (0xDC00..=0xDFFF).contains(&low) {
+                let code =
+                    0x1_0000 + ((u32::from(unit) - 0xD800) << 10) + (u32::from(low) - 0xDC00);
+                if let Some(decoded) = char::from_u32(code) {
+                    return Some((decoded, after));
+                }
+            }
+        }
+    }
+
+    Some((char::REPLACEMENT_CHARACTER, next))
+}
+
+/// Reads `uXXXX` at `at` and returns the code unit it denotes with the index past it.
+fn read_escaped_code_unit(input: &str, at: usize) -> Option<(u16, usize)> {
+    if input.as_bytes().get(at) != Some(&b'u') {
+        return None;
+    }
+    let digits = input.get(at + 1..at + 5)?;
+    if !digits.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    u16::from_str_radix(digits, 16)
+        .ok()
+        .map(|unit| (unit, at + 5))
 }
 
 /// Validate ISO 8601 / RFC 3339 timestamp format.
@@ -1091,6 +1154,34 @@ mod tests {
             );
             let err = parse_www_authenticate(&header).unwrap_err();
             assert!(err.to_string().contains("Invalid method"));
+        }
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_decodes_unicode_escapes() {
+        // A header value cannot carry characters above Latin-1, so a challenge
+        // escapes them as `\uXXXX`; at or below Latin-1 they travel raw.
+        for (escaped, expected) in [
+            (
+                r"em dash \u2014 and coffee \u2615",
+                "em dash — and coffee ☕",
+            ),
+            (r"grinning \ud83d\ude00 face", "grinning 😀 face"),
+            ("café naïve", "café naïve"),
+            (r"lone \ud83d here", "lone \u{fffd} here"),
+            (r"lone \ude00 here", "lone \u{fffd} here"),
+            (r"not an escape \\u2014", r"not an escape \u2014"),
+            (r"short \u12 tail", "short u12 tail"),
+        ] {
+            let header = format!(
+                r#"Payment id="abc", realm="api", method="tempo", intent="charge", request="e30", description="{escaped}""#
+            );
+            let challenge = parse_www_authenticate(&header).unwrap();
+            assert_eq!(
+                challenge.description.as_deref(),
+                Some(expected),
+                "{escaped}"
+            );
         }
     }
 


### PR DESCRIPTION
### Problem

Two defects in the same loop in `parse_auth_params`, the second hidden by the first.

**1. Quoted values are built byte by byte as if each byte were a character.**

```rust
value.push(bytes[i] as char);
```

`bytes[i]` is a `u8` and `as char` reads it as a Unicode code point, so every multi-byte UTF-8 sequence is split into Latin-1 characters:

```
description="café naïve"   ->  "cafÃ© naÃ¯ve"
```

This needs no exotic input — an accented word in a description is enough.

**2. `\uXXXX` escapes are not decoded.**

A header value cannot carry characters above Latin-1 at all, so `mppx` escapes those when it serializes a challenge and decodes them again when it parses one. The backslash was treated as a plain RFC 9110 quoted-pair, so the escape survived as literal text:

```
mppx emits  : description="Payment — 50% off ☕"
mppx parses : "Payment — 50% off ☕"
mpp-rs parses: "Payment u2014 50% off u2615"
```

`pympp` and `mpp-go` share the second defect; companion PRs are open for both. The first is specific to mpp-rs.

`description` is excluded from the challenge binding, so a corrupted one is cosmetic. Both defects apply to every quoted parameter though, including `realm`, which is slot 0 of the challenge ID HMAC — a realm with non-ASCII text would come back altered and the binding check would then fail.

### Fix

Build the value from string slices rather than bytes, so UTF-8 passes through untouched, and decode the escape to match `readQuotedAuthParamValue` in `mppx`:

- `\uXXXX` becomes that code unit.
- Astral characters are serialized as a surrogate pair (`😀` → `😀`), so a high surrogate is combined with the escape that follows it.
- An unpaired surrogate becomes U+FFFD, the closest value a `str` can hold.
- A doubled backslash is still consumed first, so `\\u2014` stays the literal text `—`.

The `request` length guard keeps its incremental behavior; it now counts the pending slice alongside the built string so it still trips before the value is fully materialized.

Only the parse side changes.

### Tests

Seven cases in `test_parse_www_authenticate_decodes_unicode_escapes`: BMP escapes, an astral surrogate pair, raw non-ASCII, both unpaired surrogates, a doubled backslash, and a truncated escape.

`cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils` passes (1181 lib tests plus the integration suites), `cargo clippy --lib --all-features -- -D warnings` and `cargo fmt --check` are clean.

The expectations were taken from `mppx` rather than written by hand: the header shape in the tests is what `Challenge.serialize` produces, and each expected value is what `Challenge.deserialize` returns for it.